### PR TITLE
Fix: notifications crash using correct FS25 addIngameNotification API

### DIFF
--- a/src/IncomeManager.lua
+++ b/src/IncomeManager.lua
@@ -69,11 +69,7 @@ function IncomeManager:onMissionLoaded()
     -- IncomeSystem:showNotification which guards getIsClient internally)
     if self.settings.enabled and self.settings.showNotifications then
         if g_currentMission and g_currentMission:getIsClient() then
-            if g_currentMission.hud and g_currentMission.hud.showBlinkingWarning then
-                g_currentMission.hud:showBlinkingWarning(
-                    "Income Mod Active - Type 'income' for commands", 4000
-                )
-            end
+            g_currentMission:addIngameNotification(FSBaseMission.INGAME_NOTIFICATION_OK, "Income Mod Active - Type 'income' for commands")
         end
     end
 end

--- a/src/IncomeSystem.lua
+++ b/src/IncomeSystem.lua
@@ -75,9 +75,7 @@ function IncomeSystem:showNotification(message)
     if not g_currentMission or not g_currentMission:getIsClient() then
         return
     end
-    if g_currentMission.hud and g_currentMission.hud.showBlinkingWarning then
-        g_currentMission.hud:showBlinkingWarning(message, 4000)
-    end
+    g_currentMission:addIngameNotification(FSBaseMission.INGAME_NOTIFICATION_OK, message)
 end
 
 -- =========================================================


### PR DESCRIPTION
## Summary

- Replaces broken `hud:showBlinkingWarning()` calls with `g_currentMission:addIngameNotification(FSBaseMission.INGAME_NOTIFICATION_OK, message)` in both `IncomeSystem.lua` and `IncomeManager.lua`
- Fixes the update-loop crash reported in issue #2 (`FSBaseMission.lua:2472: attempt to index nil with 'id'`)
- Notifications now display correctly on income payment and mod startup

## Root Cause

`hud:showBlinkingWarning()` internally accesses an `.id` field on a value that can be `nil` during the game's update loop. The correct FS25 API for in-game notifications is `addIngameNotification`.

Closes #2