### PR TITLE
Input Convention: clear default bindings

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,6 +17,7 @@
 ## Near-term (next release cycle)
 - [x] SettingsHub: 9 settings registered (selfPersisted). ESC injection (SettingsUI.lua + UIHelper.lua, InGameMenuSettingsFrame hooks) retained as the standalone fallback; full removal is a later cleanup.
 - [x] StateLedger: `IncomeMod_Settings` + `IncomeMod_State` bridge live (delegate-when-present); own XML kept as the safety copy.
+- [x] 2026-07-26 bug sweep: IM-001 (setPayMode timer reset), IM-002 (mouseEvent isAux param), IM-003 (version strings) fixed and merged to main.
 
 ## Mid-term (this season)
 - [ ] NetworkSync channel `IncomeMod_Sync` for settings broadcast and client-side payment notifications. Not built yet.

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@
 - [ ] Decide whether the console reset command should also push `SETTINGS_CHANGED` via NetworkSync.
 
 ## Bugs
-- [ ] None from the audit: payments are already server-gated (getIsServer in giveMoney), so no MP double-pay.
+- [x] 2026-07-26 bug sweep: IncomeMod bugs fixed and merged to main. IM-001 (`setPayMode()` resets both mode timers to prevent catch-up exploit), IM-002 (added missing `isAux` parameter to `mouseEvent` signature), IM-003 (version strings consolidated to match modDesc.xml). All closed.
 
 ## Features / enhancements
 - [ ] Companion read API: isActive, getCurrentPaymentAmount, getPayMode, getSeasonalMultiplier, getPaymentHistory (for FarmTablet IncomeApp).

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1588,11 +1588,7 @@
     </actions>
 
     <inputBinding>
-        <actionBinding action="IM_TOGGLE_HUD">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_I" />
-        </actionBinding>
-        <actionBinding action="IM_INCOME_REPORT">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_U" />
-        </actionBinding>
+        <actionBinding action="IM_TOGGLE_HUD" />
+        <actionBinding action="IM_INCOME_REPORT" />
     </inputBinding>
 </modDesc>


### PR DESCRIPTION
## Changes

### Input Convention (B2)
- Cleared default bindings: IM_TOGGLE_HUD (I), IM_INCOME_REPORT (U)
- Rule 1 compliant: no default key bindings shipped