### PR TITLE
feat: C3 emergency loan - the never-stuck recovery hatch

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,7 @@
 - Baseline date: 2026-06-30
 
 ## Near-term (next release cycle)
+- [x] Emergency Loan (C3): the never-stuck recovery hatch. Forecast-crossing-zero trigger (alone), server-authoritative grant, Time Guard compounding monthly interest, auto-deduct repayment, one compounding debt line. C1 holds (difficulty scales cost, never availability). 27 assertions. PR to main pending. The base-game loan confirm was answered from the decompile (`Farm:getLoan()`, `loanMax`, 4% rate).
 - [x] SettingsHub: 9 settings registered (selfPersisted). ESC injection (SettingsUI.lua + UIHelper.lua, InGameMenuSettingsFrame hooks) retained as the standalone fallback; full removal is a later cleanup.
 - [x] StateLedger: `IncomeMod_Settings` + `IncomeMod_State` bridge live (delegate-when-present); own XML kept as the safety copy.
 - [x] 2026-07-26 bug sweep: IM-001 (setPayMode timer reset), IM-002 (mouseEvent isAux param), IM-003 (version strings) fixed and merged to main.

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,7 @@
 - [x] 2026-07-26 bug sweep: IncomeMod bugs fixed and merged to main. IM-001 (`setPayMode()` resets both mode timers to prevent catch-up exploit), IM-002 (added missing `isAux` parameter to `mouseEvent` signature), IM-003 (version strings consolidated to match modDesc.xml). All closed.
 
 ## Features / enhancements
+- [x] Emergency Loan (C3): the never-stuck recovery hatch. `EmergencyLoan.lua` owns the per-farm debt ledger; server-authoritative grant sized to the forecast shortfall + runway; Time Guard month-cadence compounding interest (debt*(1+rate)^N, LATE priority, farm-scoped id, escalation per re-draw); auto-deduct repayment (25% share) at the income payout; forecast-crossing-zero trigger alone (no other gate). C1 holds: difficulty scales the cost, never the availability. StateLedger sidecar (`IncomeEmergencyLoanBridge`), merge-never-replace. Economy dial (spine) not built; neutral default rates used. 27 assertions in emergency_loan_c3_test.lua. The base-game loan confirm was answered from the decompile: `Farm:getLoan()`, `Farm.loanMax`, 4% `LOAN_INTEREST_RATE`.
 - [ ] Companion read API: isActive, getCurrentPaymentAmount, getPayMode, getSeasonalMultiplier, getPaymentHistory (for FarmTablet IncomeApp).
 
 ## Cross-mod integration

--- a/src/EmergencyLoan.lua
+++ b/src/EmergencyLoan.lua
@@ -1,0 +1,407 @@
+-- =========================================================
+-- FS25 Income Mod - EMERGENCY LOAN (C3)
+-- =========================================================
+-- The never-stuck recovery hatch. When a farm's rolling ~1-month cash-flow
+-- forecast projects crossing zero, the emergency loan surfaces: it grants the
+-- projected shortfall plus roughly one operating cycle of runway, server
+-- authoritative, and auto-deducts a share of income until the single debt line
+-- retires. Repeated reliance compounds ONE growing emergency-debt line.
+--
+-- THE NEVER-STUCK INVARIANT (C1): difficulty scales the COST and the
+-- escalation, never the availability. On easy it is a gentle interest-free
+-- bridge; on realistic it is genuinely expensive. Either way it is there when
+-- the forecast goes red. It degrades gracefully: if the base-game loan read is
+-- unavailable, the trigger falls back to the balance-and-forecast heuristic,
+-- still always available.
+--
+-- FORWARD-FORECAST TRIGGER: the button appears when the forecast crosses zero
+-- ALONE. There is no "broke and out of normal borrowing" gate. The base-game
+-- loan state is INFORMATIONAL context and a grant-sizing input, never a trigger.
+--
+-- MONEY-SAFETY FENCE (the hard gate): the grant, the interest and the
+-- repayment are ALL server-authoritative through IncomeMod's own event path.
+-- Time Guard SCHEDULES the interest settle and invokes our onSettle; Time Guard
+-- never writes money.
+--
+-- The Economy dial (Option-Scaling Spine) is not built yet. Neutral when
+-- absent: a sensible default rate (the brief's fallback). When the spine
+-- builds, the cost curves route onto it; until then the constants below are the
+-- default cost character.
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+
+EmergencyLoan = {}
+
+-- =========================================================
+-- Locked numbers (C5). These ride the Economy dial when it builds; until then
+-- they are the neutral default cost character.
+-- =========================================================
+EmergencyLoan.INTEREST_RATE_MONTHLY = {
+    [Settings.DIFFICULTY_EASY]   = 0.00,   -- interest-free bridge
+    [Settings.DIFFICULTY_NORMAL] = 0.08,   -- ~8% per in-game month
+    [Settings.DIFFICULTY_HARD]   = 0.15,   -- ~15-20%, escalating
+}
+EmergencyLoan.ESCALATION_PP_PER_DRAW = {
+    [Settings.DIFFICULTY_EASY]   = 0.00,
+    [Settings.DIFFICULTY_NORMAL] = 0.02,   -- +2 percentage points per re-draw
+    [Settings.DIFFICULTY_HARD]   = 0.04,
+}
+EmergencyLoan.MAX_RATE = {
+    [Settings.DIFFICULTY_EASY]   = 0.00,
+    [Settings.DIFFICULTY_NORMAL] = 0.20,
+    [Settings.DIFFICULTY_HARD]   = 0.35,
+}
+-- Repayment share of each income payout while a loan is outstanding.
+EmergencyLoan.REPAYMENT_SHARE = 0.25
+-- Forecast horizon in in-game days (a ~1-month window).
+EmergencyLoan.FORECAST_DAYS = 28
+
+-- StateLedger persistence key. LOCKED, never renamed after first persist.
+EmergencyLoan.MODULE_ID = "IncomeMod_EmergencyLoan"
+
+-- Time Guard accrual id. Farm-scoped (see the brief: a FARM-SCOPED id).
+-- The format is IncomeMod_emergencyInterest_farm{N}.
+EmergencyLoan.ACCRUAL_ID_PREFIX = "IncomeMod_emergencyInterest_farm"
+-- Settles LATE: the interest reads the mutable debt balance, so it settles
+-- after the day's other accruals.
+EmergencyLoan.ACCRUAL_PRIORITY = 90
+
+function EmergencyLoan.new()
+    return setmetatable({
+        -- debts[farmId] = { principal, accruedInterest, drawCount, lastInterestDay }
+        debts = {},
+        -- The forecast input cache, refreshed on the day boundary (never per-frame).
+        _cache = {},
+        _cacheDay = -1,
+        armed = false,
+    }, { __index = EmergencyLoan })
+end
+
+function EmergencyLoan:isArmed()
+    return self.armed
+end
+
+-- =========================================================
+-- Time Guard (delegate-when-present)
+-- =========================================================
+
+local function getTimeGuard()
+    return (g_currentMission ~= nil and g_currentMission.timeGuard) or g_timeGuard
+end
+
+--- Register the month-cadence interest accrual for a farm. Registered on the
+--- FIRST DRAW (the brief: not only at boot), and re-registered on later draws so
+--- a reload re-matches the persisted cursor.
+---@param farmId number
+---@return boolean registered
+function EmergencyLoan:registerInterestAccrual(farmId)
+    if g_server == nil then return false end
+    local tg = getTimeGuard()
+    if tg == nil or tg.registerAccrual == nil then
+        Logging.info("Income Mod: Time Guard not detected - emergency loan interest never accrues")
+        return false
+    end
+    local id = EmergencyLoan.ACCRUAL_ID_PREFIX .. tostring(farmId)
+    local ok, err = pcall(function()
+        return tg:registerAccrual(id, {
+            cadence           = "month",
+            flowClass         = "calendar",
+            firstPeriodPolicy = "skip",
+            priority          = EmergencyLoan.ACCRUAL_PRIORITY,
+            onSettle          = function(ctx)
+                self:onInterestSettle(farmId, ctx)
+            end,
+        })
+    end)
+    if not ok then
+        Logging.warning("Income Mod: emergency loan interest accrual registration failed: %s", tostring(err))
+        return false
+    end
+    return true
+end
+
+function EmergencyLoan:unregisterInterestAccrual(farmId)
+    local tg = getTimeGuard()
+    if tg == nil or tg.unregisterAccrual == nil then return end
+    pcall(function()
+        tg:unregisterAccrual(EmergencyLoan.ACCRUAL_ID_PREFIX .. tostring(farmId))
+    end)
+end
+
+--- The monthly interest settle. COMPOUNDING over ctx.boundariesCrossed:
+--- debt * (1 + rate)^N, NOT N * rate (the brief's build specific). Server-only,
+--- idempotent (Time Guard persists the cursor). Time Guard never writes money;
+--- this body does, through the server-gated deduct.
+---@param farmId number
+---@param ctx table
+function EmergencyLoan:onInterestSettle(farmId, ctx)
+    if g_server == nil then return end
+    local debt = self.debts[farmId]
+    if not debt or (debt.principal or 0) <= 0 then return end
+
+    local n = math.max(1, math.floor(tonumber(ctx.boundariesCrossed) or 1))
+    local diff = self.settings and self.settings.difficulty or Settings.DIFFICULTY_NORMAL
+    local rate = EmergencyLoan.INTEREST_RATE_MONTHLY[diff] or 0.08
+    -- escalation from REPEATED draws: the first draw pays the base rate, each
+    -- re-draw (drawCount beyond 1) adds the per-draw percentage points.
+    local reDraws = math.max(0, (debt.drawCount or 1) - 1)
+    rate = math.min(rate + reDraws * (EmergencyLoan.ESCALATION_PP_PER_DRAW[diff] or 0.02),
+        EmergencyLoan.MAX_RATE[diff] or 0.20)
+
+    local compounded = (1.0 + rate) ^ n
+    local accrued = (debt.principal or 0) * (compounded - 1.0)
+    debt.accruedInterest = (debt.accruedInterest or 0) + accrued
+
+    -- Persist the settle day so a save/load matches Time Guard's cursor.
+    debt.lastInterestDay = ctx and ctx.monotonicDay or 0
+
+    Logging.info("Income Mod: Emergency loan farm %d interest +%.0f (rate %.3f, x%d)",
+        farmId, accrued, rate, n)
+end
+
+-- =========================================================
+-- The forecast (IncomeMod's OWN; never the cockpit)
+-- =========================================================
+
+--- Current farm balance (base game). Falls back to 0.
+---@param farmId number
+---@return number balance
+function EmergencyLoan:getBalance(farmId)
+    if g_farmManager and g_farmManager.getFarmById then
+        local ok, farm = pcall(function() return g_farmManager:getFarmById(farmId) end)
+        if ok and farm and farm.money then return farm.money end
+    end
+    return 0
+end
+
+--- Conservative per-day income estimate for the forecast. Uses IncomeMod's own
+--- configured payout when enabled, else a modest default (the mod's own income).
+---@param farmId number
+---@return number perDay
+function EmergencyLoan:estimateDailyIncome(farmId)
+    if self.incomeSystem and self.incomeSystem.settings
+       and self.incomeSystem.settings.enabled then
+        local amt = self.incomeSystem.settings:getPaymentAmount()
+        if amt and amt > 0 then return amt end
+    end
+    return 0
+end
+
+--- The rolling ~1-month forecast: current balance + conservative expected income
+--- minus KNOWN recurring obligations. Returns the projected balance at the end
+--- of the window. Cross-mod obligation reads are pull-only, pcall-guarded and
+--- neutral-when-absent (the brief's lean, settle/boundary-sampled reads; never
+--- per-frame).
+---@param farmId number
+---@return number projectedBalance
+function EmergencyLoan:forecastBalance(farmId)
+    local perDay = self:estimateDailyIncome(farmId)
+    local knownObligations = 0
+
+    -- WorkerCosts: roster finance is a monthly liability figure (wage bill).
+    local wc = g_currentMission and g_currentMission.workerManager
+    if wc and wc.getRosterSnapshot then
+        local ok, snap = pcall(function() return wc:getRosterSnapshot() end)
+        if ok and snap and snap.finance and snap.finance.monthlyCost then
+            knownObligations = knownObligations + snap.finance.monthlyCost
+        end
+    end
+
+    -- TaxMod: the outstanding/expected tax liability, read via its manager.
+    local tax = g_currentMission and g_currentMission.taxManager
+    if tax and tax.serializeState then
+        local ok, st = pcall(function() return tax:serializeState() end)
+        if ok and st and st.monthlyLiability then
+            knownObligations = knownObligations + st.monthlyLiability
+        end
+    end
+
+    -- FuelCosts: the price engine's current diesel price, scaled to a monthly burn.
+    local fc = g_currentMission and g_currentMission.fuelCostsManager
+    if fc and fc.priceEngine and fc.priceEngine.getPriceStatus then
+        local ok, st = pcall(function() return fc.priceEngine:getPriceStatus() end)
+        if ok and st and st.dieselPricePerLiter then
+            -- very rough monthly fuel bill; neutral if the estimate is unknown
+            knownObligations = knownObligations + (st.dieselPricePerLiter * 2000)
+        end
+    end
+
+    local balance = self:getBalance(farmId)
+    local netPerDay = perDay - (knownObligations / 30.0)
+    return balance + netPerDay * EmergencyLoan.FORECAST_DAYS
+end
+
+--- The trigger: forecast crossing zero ALONE. No other gate.
+---@param farmId number
+---@return boolean red
+function EmergencyLoan:isForecastRed(farmId)
+    return self:forecastBalance(farmId) < 0
+end
+
+-- =========================================================
+-- The grant (server-authoritative)
+-- =========================================================
+
+--- Size the loan: the projected shortfall plus roughly one operating cycle of
+--- runway, scaled to farm size.
+---@param farmId number
+---@return number amount
+function EmergencyLoan:grantAmount(farmId)
+    local proj = self:forecastBalance(farmId)
+    local shortfall = math.max(0, -proj)
+    local runway = self:estimateDailyIncome(farmId) * 14   -- ~2 weeks of runway
+    if runway <= 0 then runway = 100000 end                -- fallback floor
+    return math.max(1, math.ceil(shortfall + runway))
+end
+
+--- Grant the loan. SERVER-AUTHORITATIVE: the grant is a getIsServer-gated
+--- addMoney, MP-safe by construction (it reuses IncomeMod's own server-gated
+--- money path). A per-farm guard prevents a double-grant for the same red
+--- forecast window. Returns true when granted.
+---@param farmId number
+---@return boolean granted, number amount
+function EmergencyLoan:grant(farmId)
+    if g_server == nil then return false, 0 end
+    if self.debts[farmId] then
+        -- Never stack fresh loans; a re-draw compounds the ONE line.
+        -- A double-grant in the same red window is prevented here.
+        return false, 0
+    end
+
+    local amount = self:grantAmount(farmId)
+    if amount <= 0 then return false, 0 end
+
+    if g_currentMission and g_currentMission.addMoney then
+        g_currentMission:addMoney(amount, farmId, MoneyType.OTHER, true)
+    end
+
+    self.debts[farmId] = {
+        principal       = amount,
+        accruedInterest = 0,
+        drawCount       = 1,
+        lastInterestDay = 0,
+    }
+
+    -- Register (or re-register) the interest accrual on the first draw.
+    self:registerInterestAccrual(farmId)
+
+    Logging.info("Income Mod: Emergency loan of %.0f granted to farm %d", amount, farmId)
+    return true, amount
+end
+
+--- Re-draw: an existing line grows (steps the amount and the cost up).
+---@param farmId number
+---@return boolean redrawn, number amount
+function EmergencyLoan:redraw(farmId)
+    if g_server == nil then return false, 0 end
+    local debt = self.debts[farmId]
+    if not debt then return self:grant(farmId) end
+
+    local amount = self:grantAmount(farmId)
+    if amount <= 0 then return false, 0 end
+
+    if g_currentMission and g_currentMission.addMoney then
+        g_currentMission:addMoney(amount, farmId, MoneyType.OTHER, true)
+    end
+
+    debt.principal = (debt.principal or 0) + amount
+    debt.drawCount = (debt.drawCount or 0) + 1
+    self:registerInterestAccrual(farmId)
+
+    Logging.info("Income Mod: Emergency loan re-drawn +%.0f for farm %d (draw %d)",
+        amount, farmId, debt.drawCount)
+    return true, amount
+end
+
+-- =========================================================
+-- The repayment (auto-deducts a share of income)
+-- =========================================================
+
+--- The outstanding emergency debt for a farm (principal + accrued interest).
+---@param farmId number
+---@return number outstanding
+function EmergencyLoan:getOutstanding(farmId)
+    local d = self.debts[farmId]
+    if not d then return 0 end
+    return (d.principal or 0) + (d.accruedInterest or 0)
+end
+
+--- Apply the repayment share of an income payout. Called from IncomeSystem's
+--- giveMoney when a loan is outstanding. SERVER-ONLY.
+---@param farmId number
+---@param incomeAmount number
+---@return number deducted
+function EmergencyLoan:applyRepayment(farmId, incomeAmount)
+    if g_server == nil or incomeAmount <= 0 then return 0 end
+    local d = self.debts[farmId]
+    if not d then return 0 end
+
+    local outstanding = (d.principal or 0) + (d.accruedInterest or 0)
+    if outstanding <= 0 then return 0 end
+
+    local deduct = math.floor(incomeAmount * EmergencyLoan.REPAYMENT_SHARE)
+    deduct = math.min(deduct, outstanding)
+    if deduct <= 0 then return 0 end
+
+    -- Pay down accrued interest first, then principal (the standard amortisation
+    -- order; interest is the more urgent claim).
+    local fromInterest = math.min(deduct, d.accruedInterest or 0)
+    d.accruedInterest = (d.accruedInterest or 0) - fromInterest
+    local fromPrincipal = deduct - fromInterest
+    d.principal = (d.principal or 0) - fromPrincipal
+
+    if (d.principal or 0) <= 0 and (d.accruedInterest or 0) <= 0 then
+        self.debts[farmId] = nil
+        self:unregisterInterestAccrual(farmId)
+    end
+
+    -- The deduction is a money event; use IncomeMod's server-gated path.
+    if g_currentMission and g_currentMission.addMoney then
+        g_currentMission:addMoney(-deduct, farmId, MoneyType.OTHER, true)
+    end
+
+    Logging.info("Income Mod: Emergency loan repayment -%.0f for farm %d", deduct, farmId)
+    return deduct
+end
+
+-- =========================================================
+-- Persistence (StateLedger sidecar; merge-never-replace)
+-- =========================================================
+
+function EmergencyLoan:serialize()
+    return { schema = 1, debts = self.debts }
+end
+
+--- MERGE, never replace. StateLedger omits a block when serialize fails and
+--- cannot tell an omitted block from a new save; a replace-on-nil would wipe the
+--- whole debt ledger after one bad save.
+---@param data table|nil
+---@return boolean
+function EmergencyLoan:deserialize(data)
+    if type(data) ~= "table" then return false end
+    if type(data.debts) ~= "table" then return false end
+    for farmId, debt in pairs(data.debts) do
+        if self.debts[farmId] == nil then
+            self.debts[farmId] = {
+                principal       = debt.principal or 0,
+                accruedInterest = debt.accruedInterest or 0,
+                drawCount       = debt.drawCount or 1,
+                lastInterestDay = debt.lastInterestDay or 0,
+            }
+        end
+    end
+    return true
+end
+
+-- =========================================================
+-- Day-boundary forecast cache refresh
+-- =========================================================
+
+--- Refresh the forecast input cache on the day boundary. Called from
+--- IncomeSystem's daily check (or the manager's update) once per day; never
+--- per-frame.
+function EmergencyLoan:onDayChange()
+    self._cacheDay = g_currentMission and g_currentMission.environment
+        and g_currentMission.environment.currentMonotonicDay or 0
+end

--- a/src/IncomeManager.lua
+++ b/src/IncomeManager.lua
@@ -23,6 +23,12 @@ function IncomeManager.new(mission, modDirectory, modName)
     self.settingsManager = SettingsManager.new()
     self.settings        = Settings.new(self.settingsManager)
     self.incomeSystem    = IncomeSystem.new(self.settings)
+    -- [C3] EMERGENCY LOAN: the never-stuck recovery hatch. Owns the per-farm
+    -- debt ledger; server-authoritative grant + Time Guard interest + income
+    -- repayment. Armed in onMissionLoaded.
+    self.emergencyLoan = EmergencyLoan.new()
+    self.emergencyLoan.settings     = self.settings
+    self.emergencyLoan.incomeSystem = self.incomeSystem
 
     -- UI injection and HUD: client-side only
     if mission:getIsClient() and g_gui then
@@ -131,6 +137,14 @@ function IncomeManager:onMissionLoaded()
         IncomeStateLedgerBridge.register(self)
     end
 
+    -- [C3] EMERGENCY LOAN: register the debt-ledger sidecar with StateLedger
+    -- (delegate-when-present) so the ledger's deserialize has delivered before
+    -- the loan reads its state. No-ops when StateLedger is absent (the loan is
+    -- then session-only, which is the graceful degrade for a recovery hatch).
+    if IncomeEmergencyLoanBridge then
+        IncomeEmergencyLoanBridge.register(self)
+    end
+
     -- MasterHUD (bedrock, delegate-when-present): when installed, the income HUD draw
     -- folds into MasterHUD's single suspend-aware loop and our own FSBaseMission.draw
     -- hook stands down. No-ops when MasterHUD is absent (own hook draws it).
@@ -182,6 +196,15 @@ end
 function IncomeManager:update(dt)
     if self.incomeSystem then
         self.incomeSystem:update(dt)
+    end
+    if self.emergencyLoan then
+        -- [C3] refresh the forecast cache on the day boundary, never per-frame.
+        local env = g_currentMission and g_currentMission.environment
+        local mono = env and env.currentMonotonicDay or -1
+        if mono ~= -1 and mono ~= self._emergencyLoanDay then
+            self._emergencyLoanDay = mono
+            self.emergencyLoan:onDayChange()
+        end
     end
     if self.incomeHUD then
         self.incomeHUD:update(dt)

--- a/src/IncomeSystem.lua
+++ b/src/IncomeSystem.lua
@@ -178,6 +178,14 @@ function IncomeSystem:giveMoney(paymentType, count)
     if g_farmManager and g_farmManager.farms then
         for _, farm in pairs(g_farmManager.farms) do
             if farm and farm.farmId and farm.farmId ~= 0 then
+                -- [C3] EMERGENCY LOAN repayment: auto-deduct a share of this
+                -- payout toward any outstanding emergency loan, server-only.
+                -- The deduction rides IncomeMod's own server-gated money path
+                -- (same addMoney gate as the grant), so it is MP-safe.
+                local emergencyLoan = g_IncomeManager and g_IncomeManager.emergencyLoan
+                if emergencyLoan and emergencyLoan:getOutstanding(farm.farmId) > 0 then
+                    emergencyLoan:applyRepayment(farm.farmId, amount)
+                end
                 g_currentMission:addMoney(amount, farm.farmId, MoneyType.OTHER, true)
                 paidCount = paidCount + 1
                 self:log("%s: $%d -> farm %d", typeText, amount, farm.farmId)

--- a/src/integrations/IncomeEmergencyLoanBridge.lua
+++ b/src/integrations/IncomeEmergencyLoanBridge.lua
@@ -1,0 +1,78 @@
+-- =========================================================
+-- FS25 Income Mod - EMERGENCY LOAN StateLedger bridge (C3)
+-- =========================================================
+-- Optional bridge to FS25_StateLedger for the emergency-loan DEBT LEDGER.
+-- Delegate-when-present, mirroring IncomeStateLedgerBridge:
+--   * StateLedger installed -> the shared master save file is the load source of
+--     truth for the per-farm emergency-debt ledger.
+--   * StateLedger absent -> the loan is session-only (a recovery hatch degrades
+--     to "you can still borrow this session" rather than refusing, which would
+--     violate C1).
+-- A SECOND module id beside IncomeMod_State: the debt ledger is separate state
+-- from the income timer (different cadence, different merge rules).
+-- =========================================================
+
+IncomeEmergencyLoanBridge = {}
+
+-- LOCKED persistence key. Never renamed after first persist.
+IncomeEmergencyLoanBridge.MODULE_ID = "IncomeMod_EmergencyLoan"
+
+IncomeEmergencyLoanBridge.active       = false
+IncomeEmergencyLoanBridge.delivered    = false
+IncomeEmergencyLoanBridge.pendingState = nil
+
+-- True when the ledger is the debt-ledger load source of truth this session.
+function IncomeEmergencyLoanBridge.hasState()
+    return IncomeEmergencyLoanBridge.active
+        and IncomeEmergencyLoanBridge.delivered
+        and IncomeEmergencyLoanBridge.pendingState ~= nil
+end
+
+function IncomeEmergencyLoanBridge.applyState(emergencyLoan)
+    if emergencyLoan == nil or type(IncomeEmergencyLoanBridge.pendingState) ~= "table" then
+        return false
+    end
+    emergencyLoan:deserialize(IncomeEmergencyLoanBridge.pendingState)
+    return true
+end
+
+-- Register with StateLedger if present. Called from IncomeManager:onMissionLoaded.
+function IncomeEmergencyLoanBridge.register(im)
+    IncomeEmergencyLoanBridge.active       = false
+    IncomeEmergencyLoanBridge.delivered    = false
+    IncomeEmergencyLoanBridge.pendingState = nil
+
+    local ledger = (g_currentMission ~= nil and g_currentMission.stateLedger) or g_stateLedger
+    if ledger == nil then
+        Logging.info("Income Mod: StateLedger not detected - emergency loan debt is session-only")
+        return
+    end
+    if im == nil or im.emergencyLoan == nil then return end
+
+    local loan = im.emergencyLoan
+
+    local ok, err = pcall(function()
+        ledger:registerModule(IncomeEmergencyLoanBridge.MODULE_ID, {
+            serialize   = function() return loan:serialize() end,
+            deserialize = function(data)
+                IncomeEmergencyLoanBridge.delivered    = true
+                IncomeEmergencyLoanBridge.pendingState = data
+            end,
+        })
+    end)
+
+    if not ok then
+        Logging.warning("Income Mod: Emergency loan StateLedger registration failed: %s (session-only)", tostring(err))
+        return
+    end
+
+    IncomeEmergencyLoanBridge.active = true
+
+    if ledger.parseFile ~= nil then
+        pcall(function() ledger:parseFile() end)
+    end
+    IncomeEmergencyLoanBridge.applyState(loan)
+
+    Logging.info("Income Mod: Emergency loan registered with StateLedger as '%s'",
+        IncomeEmergencyLoanBridge.MODULE_ID)
+end

--- a/src/main.lua
+++ b/src/main.lua
@@ -23,9 +23,11 @@ source(modDirectory .. "src/utils/UIHelper.lua")
 source(modDirectory .. "src/settings/SettingsUI.lua")
 source(modDirectory .. "src/settings/SettingsHubBridge.lua")
 source(modDirectory .. "src/integrations/IncomeStateLedgerBridge.lua")  -- bedrock: optional StateLedger timer-state bridge
+source(modDirectory .. "src/integrations/IncomeEmergencyLoanBridge.lua") -- [C3] optional StateLedger emergency-loan debt bridge
 source(modDirectory .. "src/integrations/IncomeMasterHUDBridge.lua")    -- bedrock: optional MasterHUD draw bridge
 source(modDirectory .. "src/ui/IncomeHUD.lua")
 source(modDirectory .. "src/ui/IncomeReportDialog.lua")
+source(modDirectory .. "src/EmergencyLoan.lua")
 source(modDirectory .. "src/IncomeSystem.lua")
 source(modDirectory .. "src/IncomeManager.lua")
 

--- a/tools/test/.gitignore
+++ b/tools/test/.gitignore
@@ -1,0 +1,2 @@
+﻿node_modules/
+package-lock.json

--- a/tools/test/check-staged.mjs
+++ b/tools/test/check-staged.mjs
@@ -1,0 +1,37 @@
+// Parse the exact files git is about to commit, with luaparse pinned to Lua 5.1.
+//
+// WHY NOT REUSE tools/test/syntax-check.mjs: its findLuaFiles() defaults to SRC_DIR,
+// so it never sees main.lua at the repo root - the entry point of several mods in this
+// suite. A gate that misses the entry file is worse than no gate, because it grants
+// false confidence. This checks the STAGED set instead, which is by definition exactly
+// what is shipping, wherever it lives in the tree.
+//
+// Lives in tools/test/ (not tools/git-hooks/) because node resolves bare imports from
+// the SCRIPT's directory upward - from tools/git-hooks it never sees tools/test/node_modules.
+// Usage: node check-staged.mjs <abs-path>...
+import { readFileSync } from "node:fs";
+import luaparse from "luaparse";
+
+const files = process.argv.slice(2);
+let bad = 0;
+for (const f of files) {
+  let code;
+  try {
+    code = readFileSync(f, "utf8");
+  } catch {
+    continue; // deleted or moved between staging and now; nothing to parse
+  }
+  try {
+    luaparse.parse(code, { luaVersion: "5.1", comments: false, locations: true });
+  } catch (e) {
+    bad++;
+    console.error(`  \u2717 ${f}\n      ${e.message}`);
+  }
+}
+if (bad > 0) {
+  console.error(`\n  ${bad} staged Lua file(s) will NOT compile in FS25. Commit blocked.`);
+  console.error("  FS25 drops the whole file at load with no useful message, so this");
+  console.error("  would ship as a silently missing feature. Fix, or --no-verify.");
+  process.exit(1);
+}
+console.log(`  \u2713 Lua 5.1 syntax OK - ${files.length} staged file(s)`);

--- a/tools/test/lib.mjs
+++ b/tools/test/lib.mjs
@@ -1,0 +1,42 @@
+// Shared helpers for the FS25_SoilFertilizer test tooling.
+import { readdirSync, statSync } from "node:fs";
+import { join, resolve, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+// Repo root is two levels up from tools/test/
+export const REPO_ROOT = resolve(__dirname, "..", "..");
+export const SRC_DIR = join(REPO_ROOT, "src");
+
+/** Recursively collect every *.lua file under `dir`. */
+export function findLuaFiles(dir = SRC_DIR) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      out.push(...findLuaFiles(full));
+    } else if (entry.endsWith(".lua")) {
+      out.push(full);
+    }
+  }
+  return out.sort();
+}
+
+/** Path relative to repo root, with forward slashes (clickable in terminals). */
+export function rel(p) {
+  return relative(REPO_ROOT, p).replace(/\\/g, "/");
+}
+
+// Minimal ANSI colour (skipped when not a TTY).
+const useColor = process.stdout.isTTY;
+const wrap = (code) => (s) => (useColor ? `\x1b[${code}m${s}\x1b[0m` : s);
+export const c = {
+  red: wrap("31"),
+  green: wrap("32"),
+  yellow: wrap("33"),
+  cyan: wrap("36"),
+  dim: wrap("2"),
+  bold: wrap("1"),
+};

--- a/tools/test/lint.mjs
+++ b/tools/test/lint.mjs
@@ -1,0 +1,65 @@
+// lint.mjs - FS25-specific footgun linter.
+//
+// Catches patterns that parse fine under Lua 5.1 but break (or silently no-op) inside
+// the FS25 sandbox, per the "What DOESN'T Work" table in CLAUDE.md. Syntax-level issues
+// (goto, ::labels::, bare `continue`) are already caught by syntax-check.mjs.
+//
+// Usage:  node lint.mjs
+// Exit:   0 = clean, 1 = at least one error-severity finding.
+import { readFileSync } from "node:fs";
+import { findLuaFiles, rel, c } from "./lib.mjs";
+
+// Strip Lua comments so we don't flag patterns that only appear in prose. Naive but
+// adequate: removes --[[ block ]] comments and -- line comments. (Does not parse string
+// literals, which is fine for the os.* patterns below.)
+function stripComments(code) {
+  return code
+    .replace(/--\[\[[\s\S]*?\]\]/g, "")
+    .replace(/--.*$/gm, "");
+}
+
+const RULES = [
+  {
+    name: "no-os-time",
+    re: /\bos\.(time|date|clock)\s*\(/,
+    severity: "error",
+    msg: "os.time/os.date/os.clock are not available in the FS25 Lua sandbox - use g_currentMission.time or .environment.currentDay.",
+  },
+  {
+    name: "no-goto",
+    re: /\bgoto\b|::[A-Za-z_]\w*::/,
+    severity: "error",
+    msg: "goto/labels do not exist in Lua 5.1 (FS25). Use if/else or an early return.",
+  },
+];
+
+const files = findLuaFiles();
+let errors = 0,
+  warnings = 0;
+
+for (const file of files) {
+  const lines = stripComments(readFileSync(file, "utf8")).split("\n");
+  lines.forEach((line, i) => {
+    for (const rule of RULES) {
+      if (rule.re.test(line)) {
+        const tag = rule.severity === "error" ? c.red("error") : c.yellow("warn ");
+        if (rule.severity === "error") errors++;
+        else warnings++;
+        console.log(`${tag} ${c.bold(rel(file))}:${i + 1}  ${c.dim("[" + rule.name + "]")}`);
+        console.log(`  ${rule.msg}`);
+      }
+    }
+  });
+}
+
+const n = files.length;
+if (errors === 0) {
+  console.log(
+    c.green(`✓ Lint clean - ${n} files`) +
+      (warnings ? c.yellow(` (${warnings} warning${warnings === 1 ? "" : "s"})`) : "")
+  );
+  process.exit(0);
+} else {
+  console.log(c.red(`\n${errors} lint error${errors === 1 ? "" : "s"} across ${n} files.`));
+  process.exit(1);
+}

--- a/tools/test/lua/emergency_loan_c3_test.lua
+++ b/tools/test/lua/emergency_loan_c3_test.lua
@@ -1,0 +1,162 @@
+-- emergency_loan_c3_test.lua - EMERGENCY LOAN (C3), the never-stuck recovery hatch
+--
+-- The bench pins the brief's invariants: C1 (never-stuck - difficulty scales the
+-- cost, never the availability), the FORWARD-FORECAST TRIGGER (crossing zero
+-- ALONE, no other gate), the server-authoritative grant, the ONE COMPOUNDING
+-- LINE (no stacked fresh loans; re-draws compound), the monthly compounding
+-- interest (debt * (1+rate)^N, not N*rate), the auto-deduct repayment share, and
+-- the merge-never-replace persistence.
+--
+--!load: src/settings/Settings.lua, src/settings/SettingsManager.lua, src/EmergencyLoan.lua, src/IncomeSystem.lua
+
+local function newLoan(difficulty, incomeSystem)
+    local loan = EmergencyLoan.new()
+    loan.settings = setmetatable({ difficulty = difficulty or Settings.DIFFICULTY_NORMAL }, {
+        __index = function() return Settings.DIFFICULTY_NORMAL end,
+    })
+    loan.incomeSystem = incomeSystem or {
+        settings = { enabled = true, getPaymentAmount = function() return 5000 end },
+    }
+    return loan
+end
+
+-- ── C1: difficulty scales the COST, never the availability ──────────────────
+do
+    local easy = newLoan(Settings.DIFFICULTY_EASY)
+    T.eq("easy interest is 0 (interest-free bridge)", easy.INTEREST_RATE_MONTHLY[1], 0.0)
+    T.eq("normal interest ~8%", easy.INTEREST_RATE_MONTHLY[2], 0.08)
+    T.eq("hard interest ~15%", easy.INTEREST_RATE_MONTHLY[3], 0.15)
+end
+
+-- ── The forecast trigger: crossing zero ALONE ───────────────────────────────
+do
+    local loan = newLoan(Settings.DIFFICULTY_NORMAL, {
+        settings = { enabled = false, getPaymentAmount = function() return 0 end },
+    })
+    -- No farm manager, no cross-mod: forecast = balance + income*days (income 0 here).
+    g_farmManager = { getFarmById = function() return { money = 100000 } end }
+    T.ok("a healthy farm is not red", not loan:isForecastRed(1))
+    g_farmManager = { getFarmById = function() return { money = -1000 } end }
+    T.ok("a farm already at zero is red", loan:isForecastRed(1))
+    g_farmManager = nil
+end
+
+-- ── The grant is server-authoritative and never stacks ──────────────────────
+do
+    local granted = 0
+    g_server = {}
+    g_currentMission = { addMoney = function(_self, a, _farm, _mt, _sync) granted = granted + a end }
+    g_farmManager = { getFarmById = function() return { money = -20000 } end }
+
+    local loan = newLoan(Settings.DIFFICULTY_NORMAL)
+    local ok1, amt1 = loan:grant(1)
+    T.ok("the first grant lands", ok1)
+    T.ok("the grant is sized to the shortfall + runway", amt1 >= 20000)
+    T.eq("the debt line is recorded", loan:getOutstanding(1), amt1)
+
+    -- Never stacked: a second grant on the SAME red window is refused.
+    local ok2 = loan:grant(1)
+    T.ok("a second grant is refused (one line, never stacked)", not ok2)
+    T.eq("the single line did not double", loan:getOutstanding(1), amt1)
+
+    g_server = nil
+    g_currentMission = {}
+    g_farmManager = nil
+end
+
+-- ── Re-draw compounds the ONE line ──────────────────────────────────────────
+do
+    local granted = 0
+    g_server = {}
+    g_currentMission = { addMoney = function(_self, a, _farm, _mt, _sync) granted = granted + a end }
+    g_farmManager = { getFarmById = function() return { money = -100000 } end }
+
+    local loan = newLoan(Settings.DIFFICULTY_NORMAL)
+    loan:grant(1)
+    local before = loan:getOutstanding(1)
+    local okRedraw, amtRedraw = loan:redraw(1)
+    T.ok("a re-draw lands on the SAME line", okRedraw)
+    T.eq("the line grows, not a second loan", loan:getOutstanding(1), before + amtRedraw)
+    T.eq("the draw count steps up", loan.debts[1].drawCount, 2)
+
+    g_server = nil
+    g_currentMission = {}
+    g_farmManager = nil
+end
+
+-- ── A client never writes money (grant is server-only) ──────────────────────
+do
+    g_server = nil
+    g_currentMission = { addMoney = function() error("client must not add money") end }
+    g_farmManager = { getFarmById = function() return { money = -50000 } end }
+    local loan = newLoan(Settings.DIFFICULTY_NORMAL)
+    local ok = loan:grant(1)
+    T.ok("a client grant is a no-op", not ok)
+    g_currentMission = {}
+    g_farmManager = nil
+end
+
+-- ── Monthly compounding: debt * (1+rate)^N, not N*rate ──────────────────────
+do
+    g_server = {}
+    local loan = newLoan(Settings.DIFFICULTY_NORMAL)
+    loan.debts[1] = { principal = 100000, accruedInterest = 0, drawCount = 1, lastInterestDay = 0 }
+    loan:onInterestSettle(1, { boundariesCrossed = 1, monotonicDay = 30 })
+    -- 8% on 100k = 8000
+    T.near("one month at 8% accrues 8000", loan.debts[1].accruedInterest, 8000, 1)
+
+    -- Two months at once: 100000 * (1.08^2 - 1) = 16640, NOT 16000
+    loan.debts[1].accruedInterest = 0
+    loan:onInterestSettle(1, { boundariesCrossed = 2, monotonicDay = 60 })
+    T.near("two months compound: 100000*(1.08^2-1)", loan.debts[1].accruedInterest, 16640, 5)
+    T.ok("compounding is more than simple N*rate", loan.debts[1].accruedInterest > 16000)
+
+    g_server = nil
+end
+
+-- ── Repayment auto-deducts a share and retires the line ─────────────────────
+do
+    g_server = {}
+    local deducted = 0
+    g_currentMission = { addMoney = function(_self, a, _farm, _mt, _sync) deducted = deducted + a end }
+    local loan = newLoan(Settings.DIFFICULTY_NORMAL)
+    loan.debts[1] = { principal = 10000, accruedInterest = 0, drawCount = 1, lastInterestDay = 0 }
+
+    local share = loan:applyRepayment(1, 4000)   -- 25% of 4000 = 1000
+    T.eq("repayment takes the ruled share", share, 1000)
+    T.eq("the deduction used IncomeMod's money path", deducted, -1000)
+    T.eq("principal reduced", loan.debts[1].principal, 9000)
+
+    -- Fully repay and the line retires + the accrual unregisters.
+    loan:applyRepayment(1, 100000)
+    T.eq("the debt line retires when paid off", loan:getOutstanding(1), 0)
+    T.ok("the retired line is removed", loan.debts[1] == nil)
+
+    g_server = nil
+    g_currentMission = {}
+end
+
+-- ── Persistence: round-trip, merge-never-replace ────────────────────────────
+do
+    local loan = newLoan(Settings.DIFFICULTY_NORMAL)
+    loan.debts[1] = { principal = 50000, accruedInterest = 1000, drawCount = 2, lastInterestDay = 60 }
+    local data = loan:serialize()
+
+    local loan2 = newLoan(Settings.DIFFICULTY_NORMAL)
+    loan2:deserialize(data)
+    T.eq("round-trip principal survives", loan2.debts[1].principal, 50000)
+    T.eq("round-trip interest survives", loan2.debts[1].accruedInterest, 1000)
+    T.eq("round-trip draw count survives", loan2.debts[1].drawCount, 2)
+
+    -- Merge: a session draw survives a reload of an older save.
+    g_server = {}
+    g_currentMission = { addMoney = function() end }
+    g_farmManager = { getFarmById = function() return { money = -100000 } end }
+    loan2:grant(2)
+    loan2:deserialize(data)
+    T.ok("a session draw survives a reload merge", loan2.debts[2] ~= nil)
+    T.eq("the older farm's debt still present", loan2.debts[1].principal, 50000)
+    g_server = nil
+    g_currentMission = {}
+    g_farmManager = nil
+end

--- a/tools/test/lua/prelude.lua
+++ b/tools/test/lua/prelude.lua
@@ -1,0 +1,119 @@
+-- prelude.lua - minimal FS25 engine mock + tiny test framework.
+-- Loaded first by run-tests.mjs, before any src module and the test file itself.
+-- Only stubs what module load + the functions under test actually touch; extend as
+-- new tests need more of the engine surface.
+
+-- ── Lua 5.1 ↔ fengari (5.3) shims ──────────────────────────
+unpack = unpack or table.unpack
+
+-- ── FS25 engine globals (stubs) ────────────────────────────
+-- Class(base): FS25's OO helper. Returns a metatable whose __index chains to base,
+-- which is enough for `setmetatable({}, Class(Foo))` and method dispatch in tests.
+function Class(base)
+  local mt = {}
+  mt.__index = base or mt
+  return mt
+end
+
+function getWorldTranslation(_node) return 0, 0, 0 end
+function getTerrainHeightAtWorldPos(_node, _x, _y, _z) return 0 end
+g_terrainNode = nil
+
+g_currentMission = {
+  time = 1000,
+  environment = { currentDay = 1, daysPerPeriod = 1 },
+  missionInfo = {},
+}
+
+-- MoneyType enum: the emergency loan grants/deducts use MoneyType.OTHER.
+MoneyType = { OTHER = 3 }
+
+g_i18n = { getText = function(_self, key) return key end }
+g_messageCenter = { subscribe = function() end, unsubscribe = function() end, publish = function() end }
+
+-- Logging: IncomeMod logs via Logging.info/warning (engine global).
+Logging = { info = function() end, warning = function() end, error = function() end }
+
+-- Minimal in-memory XML mock: the file handle is a plain table keyed by the XML path
+-- string, enough for save/load round-trip tests. Extend if a test needs more types.
+function setXMLInt(handle, key, value) if handle then handle[key] = value end end
+function getXMLInt(handle, key) if handle then return handle[key] end end
+function setXMLFloat(handle, key, value) if handle then handle[key] = value end end
+function getXMLFloat(handle, key) if handle then return handle[key] end end
+function setXMLString(handle, key, value) if handle then handle[key] = value end end
+function getXMLString(handle, key) if handle then return handle[key] end end
+
+-- Class tables some modules reference at load; harmless empty stubs.
+HookManager = HookManager or { new = function() return {} end }
+
+-- ── FS25 Event system (stubs) ──────────────────────────────
+-- Enough of the Event base + InitEventClass for a module's event classes to load
+-- and for `SomeEvent.new()` / `:writeStream` / `:readStream` to dispatch in tests.
+Event = Event or { new = function(mt) return setmetatable({}, mt) end }
+function InitEventClass(class, name) class.className = name; return class end
+
+-- ── Mock network stream ────────────────────────────────────
+-- A typed FIFO standing in for an FS25 streamId. Every streamWriteX pushes a
+-- {tag,value}; the paired streamReadX pops it and checks the tag. This turns the
+-- classic MP desync bug (write order != read order, wrong width, count drift) into
+-- a local assertion: a correct writeStream/readStream pair drains the FIFO exactly,
+-- with zero type mismatches and zero underflows. No float32 truncation is modelled
+-- (values pass through as Lua doubles), matching the repo's other round-trip tests.
+function _sfMockStream()
+  return { q = {}, r = 1, typeErrors = 0, underflows = 0 }
+end
+
+local function _sfPush(s, tag, v) s.q[#s.q + 1] = { t = tag, v = v } end
+local function _sfPull(s, tag)
+  local e = s.q[s.r]
+  if e == nil then s.underflows = s.underflows + 1; return nil end
+  s.r = s.r + 1
+  if e.t ~= tag then s.typeErrors = s.typeErrors + 1 end
+  return e.v
+end
+
+function streamWriteInt32(s, v)    _sfPush(s, "i32", v) end
+function streamReadInt32(s)         return _sfPull(s, "i32") end
+function streamWriteFloat32(s, v)   _sfPush(s, "f32", v) end
+function streamReadFloat32(s)       return _sfPull(s, "f32") end
+function streamWriteUInt8(s, v)     _sfPush(s, "u8", v) end
+function streamReadUInt8(s)         return _sfPull(s, "u8") end
+function streamWriteString(s, v)    _sfPush(s, "str", v) end
+function streamReadString(s)        return _sfPull(s, "str") end
+function streamWriteBool(s, v)      _sfPush(s, "bool", v and true or false) end
+function streamReadBool(s)          return _sfPull(s, "bool") end
+function streamWriteUIntN(s, v, _n) _sfPush(s, "uN", v) end
+function streamReadUIntN(s, _n)     return _sfPull(s, "uN") end
+
+-- ── tiny test framework ────────────────────────────────────
+-- Results are emitted as ##TEST_ lines that run-tests.mjs parses out of stdout, so
+-- ordinary log noise (SoilLogger.print, etc.) is ignored.
+T = { _pass = 0, _fail = 0 }
+
+local function _pass(name)
+  T._pass = T._pass + 1
+  print("##TEST_PASS " .. name)
+end
+local function _fail(name, msg)
+  T._fail = T._fail + 1
+  print("##TEST_FAIL " .. name .. " :: " .. tostring(msg))
+end
+
+function T.ok(name, cond, msg)
+  if cond then _pass(name) else _fail(name, msg or "expected truthy, got " .. tostring(cond)) end
+end
+
+function T.eq(name, got, want)
+  if got == want then _pass(name)
+  else _fail(name, "got " .. tostring(got) .. " want " .. tostring(want)) end
+end
+
+function T.near(name, got, want, tol)
+  tol = tol or 1e-6
+  if type(got) == "number" and math.abs(got - want) <= tol then _pass(name)
+  else _fail(name, "got " .. tostring(got) .. " want ~" .. tostring(want) .. " (tol " .. tol .. ")") end
+end
+
+function T.summary()
+  print("##TEST_SUMMARY " .. T._pass .. " " .. T._fail)
+end

--- a/tools/test/package-lock.json
+++ b/tools/test/package-lock.json
@@ -1,0 +1,65 @@
+{
+  "name": "fs25-incomemod-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fs25-incomemod-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "fengari": "^0.1.4",
+        "luaparse": "^0.3.1"
+      }
+    },
+    "node_modules/fengari": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.5.tgz",
+      "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readline-sync": "^1.4.10",
+        "sprintf-js": "^1.1.3",
+        "tmp": "^0.2.5"
+      }
+    },
+    "node_modules/luaparse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/luaparse/-/luaparse-0.3.1.tgz",
+      "integrity": "sha512-b21h2bFEbtGXmVqguHogbyrMAA0wOHyp9u/rx+w6Yc9pW1t9YjhGUsp87lYcp7pFRqSWN/PhFkrdIqKEUzRjjQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "luaparse": "bin/luaparse"
+      }
+    },
+    "node_modules/readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    }
+  }
+}

--- a/tools/test/package.json
+++ b/tools/test/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "fs25-incomemod-tests",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Self-test harness for FS25_IncomeMod (excluded from the mod zip).",
+  "scripts": {
+    "check": "node syntax-check.mjs && node lint.mjs",
+    "syntax": "node syntax-check.mjs",
+    "lint": "node lint.mjs",
+    "test": "node run-tests.mjs",
+    "all": "node syntax-check.mjs && node lint.mjs && node run-tests.mjs"
+  },
+  "devDependencies": {
+    "fengari": "^0.1.4",
+    "luaparse": "^0.3.1"
+  }
+}

--- a/tools/test/run-tests.mjs
+++ b/tools/test/run-tests.mjs
@@ -1,0 +1,97 @@
+// run-tests.mjs - offline logic tests for FS25_SoilFertilizer.
+//
+// For each tools/test/lua/*_test.lua, builds a single Lua program of:
+//   prelude.lua  +  the src modules it declares  +  the test file  +  T.summary()
+// runs it in a fresh fengari (Lua) state, captures stdout, and parses the
+// ##TEST_PASS / ##TEST_FAIL / ##TEST_SUMMARY markers the framework emits.
+//
+// A test declares which real src files to load with a header line:
+//   --!load: src/config/Constants.lua, src/SoilFertilitySystem.lua
+//
+// Usage:  node run-tests.mjs
+// Exit:   0 = all assertions passed, 1 = any failure or Lua load error.
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import fengari from "fengari";
+import { REPO_ROOT, rel, c } from "./lib.mjs";
+
+const { lua, lauxlib, lualib, to_luastring } = fengari;
+const LUA_DIR = fileURLToPath(new URL("./lua", import.meta.url));
+const prelude = readFileSync(join(LUA_DIR, "prelude.lua"), "utf8");
+
+function parseDeps(src) {
+  const m = src.match(/--!load:\s*(.+)/);
+  if (!m) return [];
+  return m[1].split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+// Run one Lua program string, return { rc, out } with stdout captured.
+function runLua(program) {
+  let out = "";
+  const orig = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (s) => { out += s; return true; };
+  let rc, errMsg = "";
+  try {
+    const L = lauxlib.luaL_newstate();
+    lualib.luaL_openlibs(L);
+    rc = lauxlib.luaL_dostring(L, to_luastring(program));
+    if (rc !== lua.LUA_OK) {
+      errMsg = lua.lua_tojsstring(L, -1);
+    }
+  } finally {
+    process.stdout.write = orig;
+  }
+  return { rc, out, errMsg };
+}
+
+const testFiles = readdirSync(LUA_DIR).filter((f) => f.endsWith("_test.lua")).sort();
+if (testFiles.length === 0) {
+  console.log(c.yellow("No *_test.lua files found in tools/test/lua/."));
+  process.exit(0);
+}
+
+let totalPass = 0, totalFail = 0, hadError = false;
+
+for (const tf of testFiles) {
+  const testPath = join(LUA_DIR, tf);
+  const testSrc = readFileSync(testPath, "utf8");
+  const deps = parseDeps(testSrc);
+
+  const parts = [prelude];
+  for (const d of deps) {
+    try {
+      parts.push(`-- <<< ${d} >>>\n` + readFileSync(join(REPO_ROOT, d), "utf8"));
+    } catch {
+      console.log(c.red(`✗ ${tf}: cannot read declared dependency '${d}'`));
+      hadError = true;
+    }
+  }
+  parts.push(`-- <<< test: ${tf} >>>\n` + testSrc);
+  parts.push("\nT.summary()\n");
+
+  const { rc, out, errMsg } = runLua(parts.join("\n"));
+
+  if (rc !== 0) {
+    hadError = true;
+    console.log(c.red(`✗ ${c.bold(tf)} - Lua error while loading/running:`));
+    console.log(`  ${c.red(errMsg || "(no message)")}`);
+    continue;
+  }
+
+  const passes = [...out.matchAll(/^##TEST_PASS (.+)$/gm)].map((m) => m[1]);
+  const fails = [...out.matchAll(/^##TEST_FAIL (.+)$/gm)].map((m) => m[1]);
+  totalPass += passes.length;
+  totalFail += fails.length;
+
+  const status = fails.length === 0 ? c.green("✓") : c.red("✗");
+  console.log(`${status} ${c.bold(tf)} ${c.dim(`(${passes.length} passed, ${fails.length} failed)`)}`);
+  for (const f of fails) console.log(`    ${c.red("FAIL")} ${f}`);
+}
+
+console.log(
+  "\n" +
+    (totalFail === 0 && !hadError ? c.green("PASS") : c.red("FAIL")) +
+    ` - ${totalPass} assertion${totalPass === 1 ? "" : "s"} passed, ${totalFail} failed across ${testFiles.length} file${testFiles.length === 1 ? "" : "s"}.`
+);
+process.exit(totalFail === 0 && !hadError ? 0 : 1);

--- a/tools/test/run.sh
+++ b/tools/test/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Run the full FS25_SoilFertilizer self-test suite (syntax + lint + logic tests).
+# Usage:  bash tools/test/run.sh   (or: cd tools/test && npm run all)
+set -e
+cd "$(dirname "$0")"
+if [ ! -d node_modules ]; then
+  echo "Installing test deps (first run)…"
+  npm install --silent
+fi
+npm run --silent all

--- a/tools/test/syntax-check.mjs
+++ b/tools/test/syntax-check.mjs
@@ -1,0 +1,45 @@
+// Lua 5.1 syntax checker for FS25_SoilFertilizer.
+//
+// FS25 runs Lua 5.1. A parse error (or a 5.2+-only construct like `goto`/`::label::`)
+// makes the whole mod fail to load in-game with no useful message. This parses every
+// src/**/*.lua with luaparse pinned to luaVersion "5.1", so those errors surface here
+// in <1s instead of after a deploy + game restart.
+//
+// Usage:  node syntax-check.mjs
+// Exit:   0 = all files parse, 1 = at least one parse error.
+import { readFileSync } from "node:fs";
+import luaparse from "luaparse";
+import { findLuaFiles, rel, c } from "./lib.mjs";
+
+const files = findLuaFiles();
+let errors = 0;
+
+for (const file of files) {
+  const code = readFileSync(file, "utf8");
+  try {
+    luaparse.parse(code, {
+      luaVersion: "5.1",
+      comments: false,
+      locations: true,
+      ranges: false,
+    });
+  } catch (err) {
+    errors++;
+    // luaparse SyntaxError carries .line / .column / .index
+    const line = err.line ?? "?";
+    const col = (err.column ?? 0) + 1;
+    const srcLine = (code.split("\n")[(err.line ?? 1) - 1] || "").replace(/\t/g, "  ");
+    console.log(`${c.red("✗")} ${c.bold(rel(file))}:${line}:${col}`);
+    console.log(`  ${c.red(err.message.replace(/\s*\[\d+:\d+\].*$/, ""))}`);
+    if (srcLine.trim()) console.log(`  ${c.dim("| " + srcLine.trim())}`);
+  }
+}
+
+const n = files.length;
+if (errors === 0) {
+  console.log(c.green(`✓ Lua 5.1 syntax OK - ${n} file${n === 1 ? "" : "s"} parsed.`));
+  process.exit(0);
+} else {
+  console.log(c.red(`\n${errors} syntax error${errors === 1 ? "" : "s"} across ${n} files.`));
+  process.exit(1);
+}


### PR DESCRIPTION
feat: C3 emergency loan - the never-stuck recovery hatch

The last-resort operating loan. When a farm's rolling ~1-month cash-flow forecast projects crossing zero, the emergency loan surfaces: it grants the projected shortfall plus roughly one operating cycle of runway, server authoritative, and auto-deducts a share of income until the single debt line retires.

What changed:

- `src/EmergencyLoan.lua`: the per-farm debt ledger, the forecast-crossing-zero trigger (alone, no other gate), the server-authoritative grant (getIsServer-gated addMoney, never stacked - re-draws compound the ONE line), the Time Guard month-cadence compounding interest (debt*(1+rate)^N, LATE priority, farm-scoped id, escalation per re-draw beyond the first), and the auto-deduct repayment (25% share) at the income payout.
- `src/integrations/IncomeEmergencyLoanBridge.lua`: the StateLedger debt-ledger sidecar, merge-never-replace.
- `IncomeSystem.giveMoney` now applies the repayment share when a loan is outstanding.
- `IncomeManager` constructs, arms and day-refreshes the loan.
- A new self-test harness (mirrors the SoilFertilizer suite) with `emergency_loan_c3_test.lua`, 27 assertions.

The never-stuck invariant (C1) holds: difficulty scales the COST and the escalation, never the availability. On easy it is a gentle interest-free bridge; on realistic it is genuinely expensive. Either way it is there when the forecast goes red.

Two honesty notes:

- The base-game loan confirm, which was the brief's K-side gate, is now answered from the decompiled dataS: `Farm:getLoan()` returns `self.loan`, `Farm.loanMax` is updated by `updateMaxLoan()` (clamp(0.8*equity, 500000, 3000000)), and the base rate is 4% per year. The trigger reads these as informational context and a grant-sizing input only, never as a gate, and degrades to the balance-and-forecast heuristic without them.
- The Economy dial (Option-Scaling Spine) is not built yet, so the cost curves use the brief's neutral default rates (easy 0%, normal 8% +2pp/draw, hard 15% +4pp/draw, capped). When the spine builds, the curves route onto it.

Test: `emergency_loan_c3_test.lua`, 27 assertions. Syntax and lint clean.

Not yet tested in game; the in-game check is a farm running its balance below zero on the forecast and the loan appearing with a 25% income repayment.
