### PR TITLE
feat: wire the release gate; C3 loan elaboration locked conditionally

### DIFF
--- a/src/EmergencyLoan.lua
+++ b/src/EmergencyLoan.lua
@@ -133,10 +133,20 @@ end
 --- debt * (1 + rate)^N, NOT N * rate (the brief's build specific). Server-only,
 --- idempotent (Time Guard persists the cursor). Time Guard never writes money;
 --- this body does, through the server-gated deduct.
+--- RELEASE GATE (Arissani 2026-08-03, C3 CONDITIONAL per the never-stuck
+--- invariant): the cost elaboration (the re-draw escalation + the Time Guard
+--- compounding interest + the Economy-dial pricing when it builds) is LOCKED
+--- until the player opts into experimental systems. The loan itself - the grant,
+--- the re-draw, the forecast and the repayment - stays fully available, so the
+--- never-stuck escape is never removed: a locked loan runs at the neutral
+--- interest-free cost character. Fail-open (see ReleaseGate.isSystemLive).
 ---@param farmId number
 ---@param ctx table
 function EmergencyLoan:onInterestSettle(farmId, ctx)
     if g_server == nil then return end
+    if ReleaseGate ~= nil and not ReleaseGate.isSystemLive("c3_loan_elaboration") then
+        return
+    end
     local debt = self.debts[farmId]
     if not debt or (debt.principal or 0) <= 0 then return end
 

--- a/src/ReleaseGate.lua
+++ b/src/ReleaseGate.lua
@@ -1,0 +1,116 @@
+-- =========================================================
+-- FS25 Income Mod - Release Gate
+-- =========================================================
+-- The release gate: which systems are released (STABLE) vs experimental (LOCKED).
+--
+-- Orthogonal to difficulty. The gate is its own explicit opt-in (experimental
+-- systems, on at your own risk), independent of difficulty, and the two locks
+-- STACK.
+--
+-- The lock set and the rule that generates it come from Arissani's certification
+-- (2026-08-03, ledger). The C3 emergency loan is CONDITIONAL per the never-stuck
+-- invariant (C1): a recovery hatch may never be locked away while its threat is
+-- live, and economic ruin is always live. So the loan itself stays available; the
+-- lock applies to its NEW elaboration only (the re-draw escalation, the Time Guard
+-- compounding interest, the Economy-dial pricing). A locked IncomeMod still lets a
+-- broke farm reach the base-game loan, at the neutral (interest-free) cost character.
+-- =========================================================
+
+ReleaseGate = {}
+
+-- The certified experimental (LOCKED) set. Each entry: [systemId] = { name, status }.
+-- `status` is a SHORT player-facing note on what is not working or implemented yet.
+-- A system that is NOT in this table is released (the proven baseline).
+ReleaseGate.EXPERIMENTAL = {
+    c3_loan_elaboration = {
+        name = "Emergency loan cost elaboration",
+        status = "the loan itself stays available; its escalation and compounding interest are locked",
+    },
+}
+
+-- Console command -> systemId, so command refusals route through the same registry.
+ReleaseGate.COMMAND_TO_SYSTEM = {}
+
+--- A system is released when it is NOT experimental, or the player has explicitly
+--- opted into experimental systems. `optIn` is the settings.experimentalSystems boolean.
+---@param systemId string
+---@param optIn boolean|nil
+---@return boolean
+function ReleaseGate.isReleased(systemId, optIn)
+    if not ReleaseGate.EXPERIMENTAL[systemId] then return true end
+    return optIn == true
+end
+
+--- The LIVE opt-in: reads the player's current settings.experimentalSystems value
+--- through the manager. Everything in the sim that gates a locked system calls this
+--- rather than re-deriving the flag, so the policy lives in one place.
+--- Returns nil when the manager/settings are not available yet (pre-init or the
+--- offline test bench); callers decide what nil means.
+---@return boolean|nil
+function ReleaseGate.liveOptIn()
+    local im = g_IncomeManager
+    if im and im.settings and im.settings.allowsExperimentalSystems then
+        return im.settings:allowsExperimentalSystems()
+    end
+    return nil
+end
+
+--- A system is LIVE right now: released, or the player has opted in. This is the
+--- single predicate the sim entry points check.
+--- FAIL-OPEN: when the live settings cannot be read (nil manager, nil settings, or
+--- a settings object without the predicate - e.g. the offline test bench), the
+--- system counts as live. The gate is an explicit opt-out of NEW systems; it must
+--- never silently disable a path just because the opt-in flag is not readable at
+--- that moment. For the emergency loan this is doubly important: the never-stuck
+--- escape must never be removed by a lock it cannot read.
+---@param systemId string
+---@return boolean
+function ReleaseGate.isSystemLive(systemId)
+    local optIn = ReleaseGate.liveOptIn()
+    if optIn == nil then return true end
+    return ReleaseGate.isReleased(systemId, optIn)
+end
+
+--- Refusal message when a system is locked; nil when released.
+---@param systemId string
+---@param optIn boolean|nil
+---@return string|nil
+function ReleaseGate.lockMessage(systemId, optIn)
+    local entry = ReleaseGate.EXPERIMENTAL[systemId]
+    if not entry or optIn == true then return nil end
+    return string.format(
+        "Locked: %s is not released yet. Enable Experimental Systems to use it at your own risk.",
+        entry.name)
+end
+
+--- Console command gate. Mirrors the SF bypass-lock pattern but on the release axis.
+---@param commandName string
+---@param optIn boolean|nil
+---@return string|nil
+function ReleaseGate.commandLockMessage(commandName, optIn)
+    return ReleaseGate.lockMessage(ReleaseGate.COMMAND_TO_SYSTEM[commandName], optIn)
+end
+
+--- Player-friendly gate status, for the status/help surfaces and tests.
+---@param optIn boolean|nil
+---@return string
+function ReleaseGate.status(optIn)
+    local lines = { "=== Release gate ===" }
+    lines[#lines + 1] = string.format("  Experimental systems: %s",
+        optIn == true and "ON (at your own risk)" or "OFF (stable only)")
+    local on = optIn == true
+    if on then
+        lines[#lines + 1] = "  All experimental systems: ON"
+        for id, entry in pairs(ReleaseGate.EXPERIMENTAL) do
+            lines[#lines + 1] = string.format("    [ON] %s", entry.name)
+        end
+    else
+        lines[#lines + 1] = "  Not yet released:"
+        for id, entry in pairs(ReleaseGate.EXPERIMENTAL) do
+            lines[#lines + 1] = string.format("    [LOCKED] %s - %s", entry.name, entry.status)
+        end
+    end
+    return table.concat(lines, "\n")
+end
+
+Logging.info("Income Mod: Release gate loaded")

--- a/src/main.lua
+++ b/src/main.lua
@@ -19,6 +19,7 @@ local modName      = g_currentModName
 source(modDirectory .. "src/settings/SettingsManager.lua")
 source(modDirectory .. "src/settings/Settings.lua")
 source(modDirectory .. "src/settings/SettingsGUI.lua")
+source(modDirectory .. "src/ReleaseGate.lua")
 source(modDirectory .. "src/utils/UIHelper.lua")
 source(modDirectory .. "src/settings/SettingsUI.lua")
 source(modDirectory .. "src/settings/SettingsHubBridge.lua")
@@ -145,6 +146,17 @@ end
 
 getfenv(0)["income"]        = income
 getfenv(0)["incomeStatus"]  = incomeStatus
+
+function incomeRelease()
+    local s = getSettings()
+    if s then
+        print(ReleaseGate and ReleaseGate.status(s:allowsExperimentalSystems()) or "Release gate not loaded")
+    else
+        print("Income Mod not initialized")
+    end
+end
+
+getfenv(0)["incomeRelease"] = incomeRelease
 
 getfenv(0)["incomeEnable"]  = function()
     local gui = getGUI()

--- a/src/settings/Settings.lua
+++ b/src/settings/Settings.lua
@@ -136,6 +136,17 @@ function Settings:getPaymentAmount()
 end
 
 -- =========================================================
+-- Release Gate
+-- =========================================================
+
+--- Release-gate opt-in. True when the player has explicitly enabled experimental
+--- (LOCKED) systems. Orthogonal to difficulty: the two locks stack, see ReleaseGate.lua.
+---@return boolean
+function Settings:allowsExperimentalSystems()
+    return self.experimentalSystems == true
+end
+
+-- =========================================================
 -- Load / Save / Validate
 -- =========================================================
 
@@ -173,6 +184,7 @@ function Settings:validateSettings()
     self.showNotifications  = not not self.showNotifications
     self.seasonalEffects    = not not self.seasonalEffects
     self.showHUD            = not not self.showHUD
+    self.experimentalSystems = not not self.experimentalSystems
 
     self.customAmount = tonumber(self.customAmount) or 0
     if self.customAmount < 0 then
@@ -203,6 +215,7 @@ function Settings:resetToDefaults(saveImmediately)
     self.seasonalEffects   = false
     self.incomeMultiplier  = 1
     self.showHUD           = true
+    self.experimentalSystems = false
 
     if saveImmediately then
         self:save()

--- a/src/settings/SettingsGUI.lua
+++ b/src/settings/SettingsGUI.lua
@@ -31,6 +31,7 @@ function SettingsGUI:registerConsoleCommands()
     addConsoleCommand("IncomeHistory",           "Show last 10 payment records",                        "consoleCommandHistory",          self)
     addConsoleCommand("IncomeNext",              "Show when the next payment fires",                    "consoleCommandNext",             self)
     addConsoleCommand("IncomeToggleHUD",         "Show/hide the income HUD overlay (true/false)",       "consoleCommandToggleHUD",        self)
+    addConsoleCommand("IncomeSetExperimental",   "Enable/disable experimental systems (true/false)",     "consoleCommandSetExperimental",  self)
     addConsoleCommand("income",                  "Show all income commands",                            "consoleCommandHelp",             self)
 
     Logging.info("Income Mod console commands registered")
@@ -210,9 +211,29 @@ function SettingsGUI:consoleCommandToggleHUD(value)
 end
 
 -- =========================================================
--- Test Payment
+-- Experimental Systems (release gate opt-in)
 -- =========================================================
 
+function SettingsGUI:consoleCommandSetExperimental(value)
+    if value == nil then
+        return "Usage: IncomeSetExperimental true|false"
+    end
+    local v = value:lower()
+    if v ~= "true" and v ~= "false" then
+        return "Invalid value. Use 'true' or 'false'"
+    end
+    if g_IncomeManager and g_IncomeManager.settings then
+        local on = (v == "true")
+        g_IncomeManager.settings.experimentalSystems = on
+        g_IncomeManager.settings:save()
+        return string.format("Experimental systems %s", on and "enabled (at your own risk)" or "disabled")
+    end
+    return "Error: Income Mod not initialized"
+end
+
+-- =========================================================
+-- Test Payment
+-- =========================================================
 function SettingsGUI:consoleCommandTestPayment()
     if g_IncomeManager and g_IncomeManager.incomeSystem then
         local success = g_IncomeManager.incomeSystem:giveMoney("test")

--- a/src/settings/SettingsHubBridge.lua
+++ b/src/settings/SettingsHubBridge.lua
@@ -68,6 +68,7 @@ function IncomeSettingsHubBridge.register(im)
         { id = "showNotifications", type = "bool", default = s.showNotifications, adminOnly = false, label = "Show Notifications" },
         { id = "showHUD",           type = "bool", default = s.showHUD,           adminOnly = false, label = "Show HUD" },
         { id = "debugMode",         type = "bool", default = s.debugMode,         adminOnly = false, label = "Debug Mode" },
+        { id = "experimentalSystems", type = "bool", default = s.experimentalSystems, adminOnly = true, label = "Experimental Systems" },
     }
 
     local ok, err = pcall(function()

--- a/src/settings/SettingsManager.lua
+++ b/src/settings/SettingsManager.lua
@@ -26,6 +26,8 @@ SettingsManager.defaultConfig = {
     seasonalEffects   = false,
     incomeMultiplier  = 1,
     showHUD           = true,
+    -- Release-gate opt-in (default false), orthogonal to difficulty. See ReleaseGate.lua.
+    experimentalSystems = false,
 }
 
 function SettingsManager.new()
@@ -75,6 +77,7 @@ function SettingsManager:loadSettings(settingsObject)
             settingsObject.seasonalEffects   = xml:getBool(t .. ".seasonalEffects",   self.defaultConfig.seasonalEffects)
             settingsObject.incomeMultiplier  = xml:getInt (t .. ".incomeMultiplier",  self.defaultConfig.incomeMultiplier)
             settingsObject.showHUD           = xml:getBool(t .. ".showHUD",           self.defaultConfig.showHUD)
+            settingsObject.experimentalSystems = xml:getBool(t .. ".experimentalSystems", self.defaultConfig.experimentalSystems)
             xml:delete()
             return
         end
@@ -90,6 +93,7 @@ function SettingsManager:loadSettings(settingsObject)
     settingsObject.seasonalEffects   = d.seasonalEffects
     settingsObject.incomeMultiplier  = d.incomeMultiplier
     settingsObject.showHUD           = d.showHUD
+    settingsObject.experimentalSystems = d.experimentalSystems
 end
 
 function SettingsManager:saveSettings(settingsObject)
@@ -108,6 +112,7 @@ function SettingsManager:saveSettings(settingsObject)
         xml:setBool(t .. ".seasonalEffects",   settingsObject.seasonalEffects)
         xml:setInt (t .. ".incomeMultiplier",  settingsObject.incomeMultiplier)
         xml:setBool(t .. ".showHUD",           settingsObject.showHUD)
+        xml:setBool(t .. ".experimentalSystems", settingsObject.experimentalSystems)
         xml:save()
         xml:delete()
     end

--- a/tools/test/lua/release_gate_test.lua
+++ b/tools/test/lua/release_gate_test.lua
@@ -1,0 +1,98 @@
+-- release_gate_test.lua - the release gate (STABLE vs experimental-LOCKED).
+--
+-- The gate is orthogonal to difficulty and mirrors the bypass lock, but on the
+-- release axis. Arissani's certification (2026-08-03): the C3 emergency loan is
+-- CONDITIONAL per the never-stuck invariant (C1). The loan itself stays
+-- available; only its cost elaboration (the re-draw escalation + the Time Guard
+-- compounding interest + the Economy-dial pricing when it builds) locks. A
+-- locked IncomeMod still lets a broke farm reach the base-game loan at the
+-- neutral interest-free cost character.
+--!load: src/ReleaseGate.lua, src/settings/Settings.lua, src/settings/SettingsManager.lua, src/EmergencyLoan.lua
+
+-- Sanity: the certified row exists.
+T.ok("c3_loan_elaboration registered", ReleaseGate.EXPERIMENTAL.c3_loan_elaboration ~= nil)
+
+-- isReleased: a non-experimental system is always released regardless of opt-in.
+T.ok("stable system released with no opt-in", ReleaseGate.isReleased("incomeSystem", nil) == true)
+T.ok("stable system released with opt-in off", ReleaseGate.isReleased("incomeSystem", false) == true)
+
+-- isReleased: the elaboration is LOCKED until the explicit opt-in.
+T.ok("elaboration LOCKED by default", ReleaseGate.isReleased("c3_loan_elaboration", nil) == false)
+T.ok("elaboration LOCKED with opt-in off", ReleaseGate.isReleased("c3_loan_elaboration", false) == false)
+T.ok("elaboration released when opt-in on", ReleaseGate.isReleased("c3_loan_elaboration", true) == true)
+
+-- lockMessage: nil when released, a refusal string when locked.
+T.eq("no lock message for a stable system", ReleaseGate.lockMessage("incomeSystem", nil), nil)
+T.eq("no lock message when opted in", ReleaseGate.lockMessage("c3_loan_elaboration", true), nil)
+local msg = ReleaseGate.lockMessage("c3_loan_elaboration", false)
+T.ok("lock message when locked", msg ~= nil)
+T.ok("message names the not-released state", string.find(msg, "not released", 1, true) ~= nil)
+
+-- status: player-friendly, short, one line per system.
+local st = ReleaseGate.status(false)
+T.ok("status says OFF when not opted in", string.find(st, "OFF", 1, true) ~= nil)
+T.ok("status lists LOCKED systems", string.find(st, "LOCKED", 1, true) ~= nil)
+local stOn = ReleaseGate.status(true)
+T.ok("status says ON when opted in", string.find(stOn, "ON", 1, true) ~= nil)
+
+-- ── SIM-WIRING GATE: the compounding interest settle respects the live opt-in ──
+local function newLoan()
+    local loan = EmergencyLoan.new()
+    loan.settings = setmetatable({ difficulty = Settings.DIFFICULTY_NORMAL }, {
+        __index = function() return Settings.DIFFICULTY_NORMAL end,
+    })
+    return loan
+end
+
+local function withOptIn(optIn, fn)
+    local prev = g_IncomeManager
+    g_IncomeManager = { settings = { experimentalSystems = optIn,
+        allowsExperimentalSystems = function(self) return self.experimentalSystems end } }
+    local ok, res = pcall(fn)
+    g_IncomeManager = prev
+    if not ok then error(res, 0) end
+    return res
+end
+
+g_server = {}
+
+-- Opt-in OFF: the compounding interest path is locked, so no interest accrues.
+T.ok("interest settle no-ops when opt-in off", withOptIn(false, function()
+    local loan = newLoan()
+    loan.debts[1] = { principal = 100000, accruedInterest = 0, drawCount = 1, lastInterestDay = 0 }
+    loan:onInterestSettle(1, { boundariesCrossed = 1, monotonicDay = 30 })
+    return loan.debts[1].accruedInterest == 0
+end))
+
+-- Opt-in ON: interest accrues exactly as before (8% on 100k = 8000).
+T.near("interest settles when opt-in on", withOptIn(true, function()
+    local loan = newLoan()
+    loan.debts[1] = { principal = 100000, accruedInterest = 0, drawCount = 1, lastInterestDay = 0 }
+    loan:onInterestSettle(1, { boundariesCrossed = 1, monotonicDay = 30 })
+    return loan.debts[1].accruedInterest
+end), 8000, 1)
+
+-- Fail-open: no manager means the gate cannot be read, so the settle behaves as
+-- before the gate (the never-stuck escape must never be removed by a lock it
+-- cannot read).
+local function settleWithNoManager()
+    local loan = newLoan()
+    loan.debts[1] = { principal = 100000, accruedInterest = 0, drawCount = 1, lastInterestDay = 0 }
+    loan:onInterestSettle(1, { boundariesCrossed = 1, monotonicDay = 30 })
+    return loan.debts[1].accruedInterest
+end
+T.near("interest settles with no manager (fail-open)", settleWithNoManager(), 8000, 1)
+
+-- The escape itself is never gated: the grant stays reachable regardless of the
+-- opt-in state.
+T.ok("grant reachable with opt-in off", withOptIn(false, function()
+    g_currentMission = { addMoney = function() end }
+    g_farmManager = { getFarmById = function() return { money = -20000 } end }
+    local loan = newLoan()
+    local ok = loan:grant(1)
+    g_currentMission = {}
+    g_farmManager = nil
+    return ok
+end))
+
+g_server = nil


### PR DESCRIPTION
## Release gate wiring (C3 emergency loan elaboration LOCKED, conditionally)

Wires Arissani's certified 2026-08-03 lock set into IncomeMod, mirroring the SoilFertilizer reference gate (PR #777).

### The ruling

C3 is CONDITIONAL per the never-stuck invariant (C1). A recovery hatch may never be locked away while its threat is live, and economic ruin is always live. So the lock applies to the loan's new ELABORATION only: the re-draw escalation, the Time Guard compounding interest, and the Economy-dial pricing when it builds. The floor escape stays available: a locked IncomeMod must still let a broke farm reach the base-game loan.

### What changed

- **`src/ReleaseGate.lua`** (new): the release gate mechanism with one registry row: `c3_loan_elaboration`. Same shape as SF's module: `isReleased`, `isSystemLive` (fail-open), `lockMessage`, `commandLockMessage`, `status`.
- **`experimentalSystems` setting**: default `false`, orthogonal to difficulty. Wired through `SettingsManager` load/save, `Settings` validate/reset, the `IncomeSetExperimental` console command, and the SettingsHub mirror.
- **`incomeRelease` status command**: prints the gate status.
- **`onInterestSettle` gate** (`src/EmergencyLoan.lua`): the compounding-interest path (and with it the `ESCALATION_PP_PER_DRAW` escalation, which is computed inside it) no-ops when the elaboration is locked. Fail-open per the SF pattern.
- **Test**: `release_gate_test.lua`, 17 assertions. Full suite 44 assertions / 0 failed, syntax + lint clean.

### Left available (deliberately)

The escape is never gated. These stay live with the lock on:

- The **grant** (`grant`), the **re-draw** (`redraw`), the **forecast** (`forecastBalance` / `isForecastRed`), and the **repayment** (`applyRepayment`, which only pays down principal when no interest accrues). Removing any of these would risk the escape.
- The **base rate tables** (`INTEREST_RATE_MONTHLY` / `MAX_RATE`). These are the neutral default cost character, the Economy dial is not built, and they are only ever read inside the gated settle, so they are effectively inert while locked. Not gated on their own.
- The **accrual registration** still happens on first draw; the settle body itself no-ops when locked, so registration is harmless and a later opt-in needs no re-wiring.

If a term belongs to the elaboration but I left it available, it is the repayment share (`REPAYMENT_SHARE`), which I read as the way the loan is retired (escape-adjacent) rather than a cost elaboration. Flagging it rather than risking the escape.

Verification: suite green, not yet loaded in a game session.
