### PR TITLE
docs: note the release gate wiring in ROADMAP and TODO

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,8 +15,9 @@
 - Baseline date: 2026-06-30
 
 ## Near-term (next release cycle)
+- [x] Release gate (2026-08-04): wired per Arissani's 2026-08-03 lock set. C3 is CONDITIONAL - the loan itself stays available, only its cost elaboration (the re-draw escalation, the Time Guard compounding, the Economy-dial pricing) locks until the experimentalSystems opt-in is on. `ReleaseGate.lua` + `incomeRelease` status command + `IncomeSetExperimental`. 44 assertions green.
 - [x] Emergency Loan (C3): the never-stuck recovery hatch. Forecast-crossing-zero trigger (alone), server-authoritative grant, Time Guard compounding monthly interest, auto-deduct repayment, one compounding debt line. C1 holds (difficulty scales cost, never availability). 27 assertions. PR to main pending. The base-game loan confirm was answered from the decompile (`Farm:getLoan()`, `loanMax`, 4% rate).
-- [x] SettingsHub: 9 settings registered (selfPersisted). ESC injection (SettingsUI.lua + UIHelper.lua, InGameMenuSettingsFrame hooks) retained as the standalone fallback; full removal is a later cleanup.
+- [x] SettingsHub: 10 settings registered (selfPersisted). ESC injection (SettingsUI.lua + UIHelper.lua, InGameMenuSettingsFrame hooks) retained as the standalone fallback; full removal is a later cleanup.
 - [x] StateLedger: `IncomeMod_Settings` + `IncomeMod_State` bridge live (delegate-when-present); own XML kept as the safety copy.
 - [x] 2026-07-26 bug sweep: IM-001 (setPayMode timer reset), IM-002 (mouseEvent isAux param), IM-003 (version strings) fixed and merged to main.
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,7 @@
 - [x] 2026-07-26 bug sweep: IncomeMod bugs fixed and merged to main. IM-001 (`setPayMode()` resets both mode timers to prevent catch-up exploit), IM-002 (added missing `isAux` parameter to `mouseEvent` signature), IM-003 (version strings consolidated to match modDesc.xml). All closed.
 
 ## Features / enhancements
+- [x] Release gate (2026-08-04): `ReleaseGate.lua` with the `c3_loan_elaboration` row (Arissani 2026-08-03, C3 CONDITIONAL per the never-stuck invariant). `experimentalSystems` setting (default false, orthogonal to difficulty) through SettingsManager load/save, the Settings predicate, the `IncomeSetExperimental` console command and the SettingsHub mirror. `incomeRelease` status command. `onInterestSettle` no-ops fail-open when locked, so the loan stays an interest-free bridge and the escape is never removed. 17 assertions in release_gate_test.lua.
 - [x] Emergency Loan (C3): the never-stuck recovery hatch. `EmergencyLoan.lua` owns the per-farm debt ledger; server-authoritative grant sized to the forecast shortfall + runway; Time Guard month-cadence compounding interest (debt*(1+rate)^N, LATE priority, farm-scoped id, escalation per re-draw); auto-deduct repayment (25% share) at the income payout; forecast-crossing-zero trigger alone (no other gate). C1 holds: difficulty scales the cost, never the availability. StateLedger sidecar (`IncomeEmergencyLoanBridge`), merge-never-replace. Economy dial (spine) not built; neutral default rates used. 27 assertions in emergency_loan_c3_test.lua. The base-game loan confirm was answered from the decompile: `Farm:getLoan()`, `Farm.loanMax`, 4% `LOAN_INTEREST_RATE`.
 - [ ] Companion read API: isActive, getCurrentPaymentAmount, getPayMode, getSeasonalMultiplier, getPaymentHistory (for FarmTablet IncomeApp).
 
@@ -19,7 +20,7 @@
 - [x] StateLedger: `IncomeMod_Settings` + `IncomeMod_State` bridge live (delegate-when-present; own XML kept as the safety copy).
 - [ ] NetworkSync: `IncomeMod_Sync` channel (settings broadcast + payment notification display). Not built yet.
 - [x] MasterHUD: `IncomeMod_HUD` registered (delegate-when-present).
-- [x] SettingsHub: 9 settings registered (selfPersisted). ESC injection retained as the standalone fallback.
+- [x] SettingsHub: 10 settings registered (selfPersisted). ESC injection retained as the standalone fallback.
 
 ## Docs / localization
 - [ ] Keep all 26 languages in step for any new setting.


### PR DESCRIPTION
## Follow-up to PR #35: ROADMAP/TODO note

PR #35 was merged before this commit landed on `development`. Carries commit `4e0d3fc`:

Documents the release gate wiring in ROADMAP.md and TODO.md, and bumps the SettingsHub setting count from 9 to 10. Docs only.
