### PR TITLE
fix: restore the tested Esc chrome

### DIFF
--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -656,7 +656,7 @@ function RfPdaMenuPage:initialize()
             end
         end
     }
-    -- SPACE (MENU_EXTRA_1): Crop Stress consultant is secondary only ÔÇö never default home.
+    -- SPACE (MENU_EXTRA_1): Crop Stress consultant is secondary only — never default home.
     -- EXTRA_1 free on CS (Help is Soil-only). SmoothList would swallow MENU_ACTIVATE.
     self.btnCsConsultant = {
         inputAction = InputAction.MENU_EXTRA_1,
@@ -1108,8 +1108,8 @@ function RfPdaMenuPage:refreshPanelSelector(forceRebuildDots)
         -- setTexts can re-apply profile single-text disable; always follow with force-enable.
         self.rfPanelSelector:setTexts(texts)
         if self.rfPanelSelector.setState then
-            -- Modules dual-fire FAIL-FIX (George): forceEvent=true re-enters onClick ÔåÆ
-            -- selectPanel ÔåÆ refreshPanelSelector ÔåÆ setState(true) loop with moduleList.
+            -- Modules dual-fire FAIL-FIX (George): forceEvent=true re-enters onClick →
+            -- selectPanel → refreshPanelSelector → setState(true) loop with moduleList.
             -- Always false while _refreshing so list/MTO sync never raises click.
             self.rfPanelSelector:setState(activeIndex, false)
         end
@@ -1125,9 +1125,6 @@ function RfPdaMenuPage:refreshPanelSelector(forceRebuildDots)
         -- Module SmoothList: only when panel set actually changes or forced open.
         if (forceRebuildDots or setChanged) and self.moduleList then
             self.moduleList:reloadData()
-        elseif self.moduleList then
-            -- Quiet radio paint (lit iconBg + name) without thrash reload.
-            self:_paintModuleListSelection()
         end
     end)
     self._refreshing = false
@@ -1147,11 +1144,11 @@ function RfPdaMenuPage:_refreshDotLegend(panels, activeIndex)
         end
         table.insert(shorts, title)
     end
-    local joined = table.concat(shorts, " ├é┬À ")
+    local joined = table.concat(shorts, " Â· ")
     if joined == "" then
         joined = tr("rf_pda_module_soil_short", "Soil")
     end
-    self.rfDotLegend:setText(string.format("%d/%d ├é┬À %s", activeIndex or 1, n, joined))
+    self.rfDotLegend:setText(string.format("%d/%d Â· %s", activeIndex or 1, n, joined))
 end
 
 --- Match SoilMapHooks / Map: grow/shrink from first seed RoundCorner in the BoxLayout.
@@ -1212,7 +1209,7 @@ function RfPdaMenuPage:onClickRfPanelSelector()
     self:_applySelectorState()
 end
 
---- Debounce duplicate module id selects (MTO Ôåö moduleList bounce ~200ms in logs).
+--- Debounce duplicate module id selects (MTO ↔ moduleList bounce ~200ms in logs).
 --- @return boolean true when the select should proceed
 function RfPdaMenuPage:_allowModuleSelect(panelId)
     if panelId == nil then
@@ -1306,7 +1303,7 @@ function RfPdaMenuPage:cyclePanel(delta)
         return
     end
 
-    -- selectPanel notifies ÔåÆ quiet refreshPanelSelector + refreshContent(false)
+    -- selectPanel notifies → quiet refreshPanelSelector + refreshContent(false)
     host:selectPanel(nextPanel.id)
     SoilLogger.info("RfPdaMenuPage: cyclePanel -> %s", tostring(nextPanel.id))
 end
@@ -2394,7 +2391,7 @@ function RfPdaMenuPage:onClickCsSchedule()
     end
 end
 
---- Esc PIVOT remote clicks ÔåÆ guest ÔåÆ CropStressPivotRemoteEvent (server authority).
+--- Esc PIVOT remote clicks → guest → CropStressPivotRemoteEvent (server authority).
 local function _csPivotRemote(self, action)
     local host = self:_getHost()
     local active = host and host:getActivePanel()
@@ -2735,19 +2732,14 @@ end
 function RfPdaMenuPage:_populateModuleRow(index, cell)
     local panel = self._panelCache[index]
     if panel == nil then return end
-    -- BUILD 22:25 Map-family rows: name = title; iconBg = radio lit plate.
-    local titleEl = cell:getDescendantByName("name")
-            or cell:getDescendantByName("moduleRowTitle")
-    local iconBg = cell:getDescendantByName("iconBg")
-    local icon = cell:getDescendantByName("icon")
+    local titleEl = cell:getDescendantByName("moduleRowTitle")
     local tagEl = cell:getDescendantByName("moduleRowTag")
     local short = safePanelTitle(panel)
     if panel.id == "soilFertilizer" then
         short = tr("rf_pda_module_soil_short", "Soil")
     end
     if titleEl then titleEl:setText(short) end
-    if tagEl and tagEl.setText then
-        -- Legacy compact-row tag (retired Map anatomy); keep nil-safe if old XML binds.
+    if tagEl then
         if panel.id == "soilFertilizer" then
             tagEl:setText(tr("rf_pda_module_tag_host", "open"))
         else
@@ -2758,40 +2750,6 @@ function RfPdaMenuPage:_populateModuleRow(index, cell)
     local selected = host and host.activeModuleId == panel.id
     if titleEl and titleEl.setTextColor then
         titleEl:setTextColor(unpack(selected and COLOR_LIME_BRIGHT or COLOR_DIM))
-    end
-    -- Radio plate: Map iconBg lit = white overlay; unlit = black (one lit at a time).
-    if iconBg ~= nil and iconBg.setImageColor then
-        if selected then
-            iconBg:setImageColor(1, 1, 1, 1)
-        else
-            iconBg:setImageColor(0, 0, 0, 1)
-        end
-    end
-    -- Icon slot stays blank.png (never nil ÔåÆ purple); no per-module art this pass.
-    if icon ~= nil then
-        if (icon.filename == nil or icon.filename == "") and icon.setImageFilename then
-            pcall(function()
-                icon:setImageFilename("$dataS/menu/blank.png")
-            end)
-        end
-        if icon.setImageColor then
-            icon:setImageColor(0, 0, 0, 0)
-        end
-    end
-end
-
---- Light-only: re-paint visible module cells for radio lit/dim without reloadData.
-function RfPdaMenuPage:_paintModuleListSelection()
-    local list = self.moduleList
-    if list == nil then return end
-    local elements = list.elements
-    if type(elements) ~= "table" then return end
-    for i = 1, #elements do
-        local cell = elements[i]
-        local idx = cell and cell.rowDataIndex
-        if type(idx) == "number" and idx > 0 then
-            self:_populateModuleRow(idx, cell)
-        end
     end
 end
 
@@ -2835,7 +2793,7 @@ function RfPdaMenuPage:onListSelectionChanged(list, section, index)
             end
         end
     elseif list == self.moduleList then
-        -- Highlight-only: SmoothList ÔåæÔåô must NOT switch modules.
+        -- Highlight-only: SmoothList ↑↓ must NOT switch modules.
         -- Module switch = onClickModuleRow + Modules MTO (_applySelectorState / cyclePanel).
         return
     end
@@ -2910,7 +2868,7 @@ function RfPdaMenuPage:_selectModuleIndex(index)
         if not self:_allowModuleSelect(panel.id) then
             return
         end
-        -- Host notify ÔåÆ refreshPanelSelector with forceEvent=false inside _refreshing
+        -- Host notify → refreshPanelSelector with forceEvent=false inside _refreshing
         -- (no MTO onClick bounce back into this path).
         host:selectPanel(panel.id)
         SoilLogger.info("RfPdaMenuPage: moduleList -> %s", tostring(panel.id))

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <!--
-    RF Esc greenfield 2026-08-02 ÔÇö vanilla InGameMenu chrome (Contracts/Animals).
+    RF Esc greenfield 2026-08-02 — vanilla InGameMenu chrome (Contracts/Animals).
     Left nest: fs25_subCategoryContainerBg + fs25_subCategoryContainer +
     fs25_subCategorySelector + dots + list. Right: fs25_menuContentContainer.
     Modules MTO vs page MTO are separate bands (page shell is NOT inside filter box).
@@ -12,9 +12,13 @@
     <GuiElement profile="RF_PageRoot" id="rfPageRoot">
         <GuiElement profile="fs25_subCategorySelectorTabbedContainer" id="rfContentHost" absoluteSizeOffset="0px 0px">
 
-            <!-- BUILD 22:25: Map glass shell restored (463 + notch). Flat RF_SideColUnderlay retired. -->
-            <ThreePartBitmap profile="fs25_subCategoryContainerBg" id="rfSideGlass">
-                <Bitmap profile="fs25_subCategoryContainerArrow"/>
+            <!-- Round 2 D2: opaque column fill painted FIRST (x 0..404, full height, behind nest/cards). -->
+            <Bitmap profile="RF_SideColUnderlay"/>
+
+            <!-- LEFT nest glass hidden (round 3): sidebar is one flat RF_SideColUnderlay tone.
+                 Element kept in tree for structure; no Lua re-shows it. -->
+            <ThreePartBitmap profile="RF_SubCategoryContainerBg" visible="false">
+                <Bitmap profile="fs25_subCategoryContainerArrow" visible="false"/>
             </ThreePartBitmap>
 
             <Bitmap profile="fs25_subCategoryContainer" id="rfFilterBox">
@@ -31,7 +35,7 @@
                 <ThreePartBitmap profile="fs25_lineSeparatorTop" id="rfSideMidSeparator"
                                  position="8px -130px" width="380px" visible="false"/>
 
-                <!-- Soil/CS left info (George: inside rfFilterBox, BEFORE moduleList; glass-back InfoBoxBg). -->
+                <!-- Soil/CS left info (George: inside rfFilterBox, BEFORE moduleList; Text + blank.png). -->
                 <GuiElement profile="RF_SideInfoShell" id="rfSideInfoShell" visible="false" handleFocus="false">
                     <Bitmap profile="RF_InfoBoxBg" handleFocus="false"/>
                     <Text profile="RF_SideInfoBody" id="rfSideInfoBody" position="8px -8px" size="368px 644px"
@@ -42,15 +46,14 @@
                     <Text profile="fs25_textGrey" id="wcSideVersion" visible="false" text=""/>
                     <Bitmap profile="fs25_subCategoryStartClipper" name="rfModListStart"/>
                     <Bitmap profile="fs25_subCategoryStopClipper" name="rfModListEnd"/>
-                    <!-- Hang fence: GuiElement parent. Map-family RF_MapList* clones (~56px radio rows). -->
-                    <SmoothList id="moduleList" profile="RF_MapList"
+                    <SmoothList id="moduleList" profile="fs25_subCategoryList"
                                 startClipperElementName="rfModListStart"
                                 endClipperElementName="rfModListEnd">
-                        <ListItem profile="RF_MapListItem" onClick="onClickModuleRow">
-                            <Bitmap profile="RF_MapListItemIconBg" name="iconBg"/>
-                            <Bitmap profile="RF_MapListColorTemplate" name="colorTemplate"/>
-                            <Bitmap profile="RF_MapListItemIcon" name="icon"/>
-                            <Text profile="RF_MapListItemName" name="name"/>
+                        <!-- Compact rows (34px) so Soil stays clickable under taller side shell; not vanilla 100px items. -->
+                        <ListItem profile="RF_ModuleListRow" onClick="onClickModuleRow">
+                            <Bitmap profile="RF_ModuleRowBg" name="alternating"/>
+                            <Text profile="RF_ModuleItemText" name="moduleRowTitle"/>
+                            <Text profile="RF_ModuleItemTag" name="moduleRowTag"/>
                         </ListItem>
                     </SmoothList>
                     <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
@@ -59,7 +62,7 @@
                 </GuiElement>
             </Bitmap>
 
-            <!-- WC page chrome: sibling under Modules (NOT inside rfFilterBox ÔÇö hit hygiene).
+            <!-- WC page chrome: sibling under Modules (NOT inside rfFilterBox — hit hygiene).
                  Must use RF_WcSubnavShell (top-left); profile-less GuiElement defaults bottom-left and falls off-screen. -->
             <GuiElement profile="RF_WcSubnavShell" id="wcSubnavShell" visible="false">
                 <MultiTextOption profile="RF_WcSubnavSelector" id="wcSubnavSelector"
@@ -117,7 +120,7 @@
                 </GuiElement>
             </GuiElement>
 
-            <!-- RIGHT: suite content plane (RF_MainColShell flushes X╦£406 to side-info right). -->
+            <!-- RIGHT: suite content plane (RF_MainColShell flushes X˜406 to side-info right). -->
             <GuiElement profile="RF_MainColShell" id="rfMainCol">
                 <GuiElement profile="fs25_menuHeaderPanel" position="0px 74px">
                     <Bitmap profile="fs25_menuHeaderIconBg">
@@ -135,7 +138,7 @@
                                      onClick="onClickWcTitlePageSelector"/>
                 </GuiElement>
 
-                <!-- SOIL panel content ÔÇö RF_PanelContentShell is top-anchored (inline position bottoms off-screen). -->
+                <!-- SOIL panel content — RF_PanelContentShell is top-anchored (inline position bottoms off-screen). -->
                 <GuiElement profile="RF_PanelContentShell" id="rfPanelContent">
 
                     <!-- F10: fields table spreads full main width -->
@@ -313,7 +316,7 @@
                             <Text profile="RF_ProductCell" id="soilRotationIf3Effect" position="170px -206px" size="110px 18px"/>
                         </GuiElement>
 
-                        <!-- Col 3: sampling ÔÇö shifted right so widened PRODUCTS does not overlap -->
+                        <!-- Col 3: sampling — shifted right so widened PRODUCTS does not overlap -->
                         <GuiElement id="samplingInfoBox" position="850px -24px" width="180px" height="220px" visible="false">
                             <Bitmap profile="RF_InfoBoxBg"/>
                             <Text profile="RF_HintText" id="samplingInfoText" position="8px -8px" size="164px 200px"
@@ -558,7 +561,7 @@
                     </GuiElement>
 
                     <!-- CS bottom band pivot full-width (2026-08-09): FD|Agro top; Pivot full width bottom.
-                         Abs: Field 10/-16/600├ù236; Agro 630/-16/510├ù236; Pivot 10/-264/1130├ù240.
+                         Abs: Field 10/-16/600×236; Agro 630/-16/510×236; Pivot 10/-264/1130×240.
                          CS-only strip H=520; Soil stays 384. No SmoothList under cards. -->
                     <GuiElement profile="RF_CsDetailStrip" id="csDetailStrip">
                         <Bitmap profile="RF_TreatmentBoxBg"/>
@@ -601,7 +604,7 @@
                         </GuiElement>
 
                         <!-- Pivot (red): full-width bottom band. Dial+status left; remotes across width.
-                             Children stay inside 1130├ù240 (strip clipChildren=true). Prefer 80├ù32. -->
+                             Children stay inside 1130×240 (strip clipChildren=true). Prefer 80×32. -->
                         <GuiElement profile="RF_EscCardFrame" id="csPivotCard" position="10px -264px" size="1130px 240px">
                             <Text profile="RF_ProductsTitle" id="csPivotTitle" position="10px -4px" size="1110px 18px" text=""/>
                             <!-- Left band: dial + status. -->
@@ -706,7 +709,7 @@
                     <GuiElement profile="RF_TreatmentStrip" id="mdPageBand" visible="false">
                         <Bitmap profile="RF_TreatmentBoxBg"/>
 
-                        <!-- Page A ÔÇö Prices -->
+                        <!-- Page A — Prices -->
                         <GuiElement id="mdPricesBand" visible="true" position="0px 0px" size="100% 100%">
                             <Text profile="RF_SectionTitle" id="mdGraphTitle" position="10px -6px" size="700px 22px" text=""/>
                             <GuiElement profile="RF_MdGraphArea" id="mdGraphArea"/>
@@ -722,7 +725,7 @@
                     onClick="onClickMdOpenMarket"/>
                         </GuiElement>
 
-                        <!-- Page B ÔÇö Events (fixed Text rows; no SmoothList thrash). -->
+                        <!-- Page B — Events (fixed Text rows; no SmoothList thrash). -->
                         <GuiElement id="mdEventsBand" visible="false" position="0px 0px" size="100% 100%">
                             <Text profile="RF_SectionTitle" id="mdEventsTitle" position="10px -6px" size="700px 22px" text=""/>
                             <Text profile="RF_ColHeader" id="mdEvColName" position="10px -36px" size="420px 20px" text=""/>
@@ -753,7 +756,7 @@
                     onClick="onClickMdOpenMarket"/>
                         </GuiElement>
 
-                        <!-- Page C ÔÇö Contracts (read-only fixed rows). -->
+                        <!-- Page C — Contracts (read-only fixed rows). -->
                         <GuiElement id="mdContractsBand" visible="false" position="0px 0px" size="100% 100%">
                             <Text profile="RF_SectionTitle" id="mdContractsTitle" position="10px -6px" size="900px 22px" text=""/>
                             <Text profile="RF_ColHeader" id="mdCtColCrop" position="10px -36px" size="280px 20px" text=""/>

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <GUIProfiles>
     <!-- ============================================================ -->
     <!-- Realistic Farming PDA profiles — MOCKUP-ESC-RF-PDA swatches  -->
@@ -457,53 +457,17 @@
     </Profile>
 
     <!-- MDM pre-kiss chrome: parent fs25_menuContentContainer center traits, X 226. -->
-    <!-- BUILD 22:25 seam: Map box is 410; main column butts the box (not the retired 404 underlay). -->
+    <!-- Kiss seam: X=404 left edge via pivot X 0; Y vanilla bottom-up via pivot Y 0 (round 2 D1:
+         pivotTopLeft's pivot Y 1 multiplied the 192 absOff into a +192 lift and beheaded the title). -->
     <Profile name="RF_MainColShell" extends="fs25_menuContentContainer" with="anchorStretchingYLeft pivotBottomLeft">
-        <position value="410px 40px"/>
+        <position value="404px 40px"/>
         <absoluteSizeOffset value="178px 192px"/>
     </Profile>
 
-    <!-- Kept for legacy ids; live rail uses vanilla fs25_subCategoryContainerBg (463). -->
+    <!-- Nest surface narrowed to the 404 seam. Keeps vanilla texture slices:
+         blank.png + noSlice on a ThreePartBitmap paints the raw gui atlas (2026-08-04 lesson). -->
     <Profile name="RF_SubCategoryContainerBg" extends="fs25_subCategoryContainerBg">
-        <width value="463px"/>
-    </Profile>
-
-    <!-- BUILD 22:25: RF-prefixed clones of MapFrame-local fs25_mapList* (~56px pitch). -->
-    <Profile name="RF_MapList" extends="fs25_subCategoryList" with="anchorTopCenter">
-        <absoluteSizeOffset value="0px 60px"/>
-    </Profile>
-    <Profile name="RF_MapListItem" extends="fs25_subCategoryListItem">
-        <height value="56px"/>
-        <hotspot value="0px 0px 0px 12px"/>
-        <imageSliceId value="gui.map_box"/>
-        <imageSelectedSliceId value="gui.map_box_selected"/>
-        <imageHighlightedSliceId value="gui.map_box_hover"/>
-    </Profile>
-    <Profile name="RF_MapListItemIconBg" extends="baseReference" with="anchorTopLeft">
-        <size value="40px 40px"/>
-        <position value="3px -3px"/>
-        <imageSliceId value="gui.map_box_colorOverlay"/>
-        <imageColor value="$preset_colorBlack"/>
-        <imageSelectedColor value="$preset_colorWhite"/>
-    </Profile>
-    <Profile name="RF_MapListColorTemplate" extends="baseReference">
-        <size value="1px 40px"/>
-        <imageColor value="$preset_colorTransparent"/>
-        <imageSelectedColor value="$preset_colorTransparent"/>
-    </Profile>
-    <Profile name="RF_MapListItemIcon" extends="fs25_subCategoryListItemIcon" with="anchorTopLeft">
-        <size value="34px 34px"/>
-        <position value="6px -6px"/>
-        <filename value="$dataS/menu/blank.png"/>
-        <imageColor value="0 0 0 0"/>
-        <imageSelectedColor value="0 0 0 0"/>
-    </Profile>
-    <Profile name="RF_MapListItemName" extends="fs25_subCategoryListItemName" with="anchorTopLeft">
-        <width value="300px"/>
-        <position value="52px -12px"/>
-        <textSize value="16px"/>
-        <textColor value="0.659 0.678 0.702 1"/>
-        <textSelectedColor value="0.659 0.878 0.290 1"/>
+        <width value="404px"/>
     </Profile>
 
     <Profile name="RF_PanelContentShell" extends="emptyPanel" with="anchorStretchingYStretchingX pivotTopLeft">
@@ -570,12 +534,12 @@
         <handleFocus value="false"/>
     </Profile>
 
-    <!-- RETIRED BUILD 22:25: flat underlay replaced by Map glass (fs25_subCategoryContainerBg).
-         Profile kept so older XML bindings do not nil; never paint over the glass. -->
+    <!-- Round 4: sidebar repaint with the vanilla glass slice (George, extract gui.xml UV 936 441 10 104).
+         extends baseReference = gui atlas + engine white; NO blank.png, NO imageColor (vanilla tone is
+         baked in the atlas pixels, zero tint). anchorStretchingYLeft -> x 0..404, full column height. -->
     <Profile name="RF_SideColUnderlay" extends="baseReference" with="anchorStretchingYLeft">
-        <width value="410px"/>
-        <filename value="$dataS/menu/blank.png"/>
-        <imageColor value="0 0 0 0"/>
+        <width value="404px"/>
+        <imageSliceId value="gui.animalScreen_left"/>
         <handleFocus value="false"/>
     </Profile>
 
@@ -723,9 +687,9 @@
         <textSelectedColor value="0.478 0.502 0.533 1"/>
     </Profile>
 
-    <!-- BUILD 22:25 glass-back: transparent so Map glass shows through the side teach box. -->
+    <!-- WC blank.png pattern: color Bitmap must have a filename or GuiOverlay returns nil (purple) -->
     <Profile name="RF_InfoBoxBg" extends="baseReference" with="anchorStretchingYStretchingX">
         <filename value="$dataS/menu/blank.png"/>
-        <imageColor value="0 0 0 0"/>
+        <imageColor value="0 0 0 0.35"/>
     </Profile>
 </GUIProfiles>


### PR DESCRIPTION
# fix: restore the tested Esc chrome (parent version)

Wizard's leftover chrome delta drifted from the version verified working in the earlier deploy (42 lines different in RfPdaMenuPage.lua), and the UTF-16 decode shipped his drifted local tree, which broke the Esc door UI: missing blank.png and garbled texture-font text in the module list. This restores the pre-leftover chrome that was actually tested. F155 translations and the version bump in modDesc.xml are preserved; menuIcon.dds stays the restored binary.
