### PR TITLE
Esc RF PDA: shared PRODUCTS–ROTATION freeze (clean)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -6,28 +6,28 @@
     <title>
         <en><![CDATA[Income Mod]]></en>
         <de><![CDATA[Realistisches Ernten]]></de>
-        <fr><![CDATA[Râ”œÃ¢â”¬Â®colte Râ”œÃ¢â”¬Â®aliste]]></fr>
-        <pl><![CDATA[Realistyczne â”œÃ â”¬â•—niwa]]></pl>
+        <fr><![CDATA[R├â┬®colte R├â┬®aliste]]></fr>
+        <pl><![CDATA[Realistyczne ├à┬╗niwa]]></pl>
         <es><![CDATA[Cosecha Realista]]></es>
         <it><![CDATA[Raccolta Realistica]]></it>
-        <cz><![CDATA[Realistickâ”œÃ¢â”¬Ã­ Sklizeâ”œÃ â•¦Ã¥]]></cz>
+        <cz><![CDATA[Realistick├â┬í Sklize├à╦å]]></cz>
         <br><![CDATA[Colheita Realista]]></br>
-        <uk><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã©Â¼ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â–‘â”œÃ¦â”¼Â¢]]></uk>
-        <ru><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼ â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã…]]></ru>
+        <uk><![CDATA[├É┬á├É┬Á├É┬░├É┬╗├æÔÇô├æ┬ü├æÔÇÜ├É┬©├æÔÇí├É┬¢├É┬©├É┬╣ ├É┬À├É┬▒├æÔÇô├æÔé¼ ├É┬▓├æÔé¼├É┬¥├É┬Â├É┬░├æ┼¢]]></uk>
+        <ru><![CDATA[├É┬á├É┬Á├É┬░├É┬╗├É┬©├æ┬ü├æÔÇÜ├É┬©├æÔÇí├É┬¢├æÔÇ╣├É┬╣ ├æ┬ü├É┬▒├É┬¥├æÔé¼ ├æãÆ├æÔé¼├É┬¥├É┬Â├É┬░├æ┬Å]]></ru>
         <da><![CDATA[Indkomst Mod]]></da>
     </title>
     <description>
         <en><![CDATA[Adds hourly / daily income system with difficulty tiers, seasonal modifiers, and multiplayer per-farm support.]]></en>
-        <de><![CDATA[Fâ”œÃ¢â”¬â•gt ein stâ”œÃ¢â”¬â•ndliches / tâ”œÃ¢â”¬Ã±gliches Einkommenssystem mit Schwierigkeitsstufen, saisonalen Modifikatoren und Mehrspielersupport hinzu.]]></de>
-        <fr><![CDATA[Ajoute un systâ”œÃ¢â”¬Â¿me de revenus horaires / quotidiens avec niveaux de difficultâ”œÃ¢â”¬Â®, modificateurs saisonniers et support multijoueur.]]></fr>
-        <pl><![CDATA[Dodaje system dochodâ”œÃ¢â”¬â”‚w godzinowych / dziennych z poziomami trudnoâ”œÃ Ã”Ã‡â•‘ci, modyfikatorami sezonowymi i wsparciem wieloosobowym.]]></pl>
-        <es><![CDATA[Aâ”œÃ¢â”¬â–’ade sistema de ingresos horarios / diarios con niveles de dificultad, modificadores estacionales y soporte multijugador.]]></es>
-        <it><![CDATA[Aggiunge un sistema di reddito orario / giornaliero con livelli di difficoltâ”œÃ¢â”¬Ã¡, modificatori stagionali e supporto multigiocatore.]]></it>
-        <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³idâ”œÃ¢â”¬Ã­vâ”œÃ¢â”¬Ã­ hodinovâ”œÃ¢â”¬Â¢ / dennâ”œÃ¢â”¬Â¡ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ systâ”œÃ¢â”¬Â®m s obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nostâ”œÃ¢â”¬Â¡, sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡mi modifikâ”œÃ¢â”¬Ã­tory a podporou vâ”œÃ¢â”¬Â¡ce hrâ”œÃ¢â”¬Ã­â”œÃ¤â”¬Ã¬â”œÃ â”¬Â».]]></cz>
-        <br><![CDATA[Adiciona sistema de renda horâ”œÃ¢â”¬Ã­ria / diâ”œÃ¢â”¬Ã­ria com nâ”œÃ¢â”¬Â¡veis de dificuldade, modificadores sazonais e suporte multiplayer.]]></br>
-        <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã˜â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ / â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã† â”œÃ‰â”¬Ã€ â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã´, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã—â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘.]]></uk>
-        <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã˜â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ / â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼ â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ‰â”¬Â© â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£ â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘.]]></ru>
-        <da><![CDATA[Tilfâ”œÃ¢â”¬Â©jer et timeligt / dagligt inkomstsystem med svâ”œÃ¢â”¬Âªrhedsniveauer, sâ”œÃ¢â”¬Âªsonelle modificer og multiplayer support.]]></da>
+        <de><![CDATA[F├â┬╝gt ein st├â┬╝ndliches / t├â┬ñgliches Einkommenssystem mit Schwierigkeitsstufen, saisonalen Modifikatoren und Mehrspielersupport hinzu.]]></de>
+        <fr><![CDATA[Ajoute un syst├â┬¿me de revenus horaires / quotidiens avec niveaux de difficult├â┬®, modificateurs saisonniers et support multijoueur.]]></fr>
+        <pl><![CDATA[Dodaje system dochod├â┬│w godzinowych / dziennych z poziomami trudno├àÔÇ║ci, modyfikatorami sezonowymi i wsparciem wieloosobowym.]]></pl>
+        <es><![CDATA[A├â┬▒ade sistema de ingresos horarios / diarios con niveles de dificultad, modificadores estacionales y soporte multijugador.]]></es>
+        <it><![CDATA[Aggiunge un sistema di reddito orario / giornaliero con livelli di difficolt├â┬á, modificatori stagionali e supporto multigiocatore.]]></it>
+        <cz><![CDATA[P├àÔäóid├â┬ív├â┬í hodinov├â┬¢ / denn├â┬¡ p├àÔäó├â┬¡jmov├â┬¢ syst├â┬®m s obt├â┬¡├à┬¥nost├â┬¡, sez├â┬│nn├â┬¡mi modifik├â┬ítory a podporou v├â┬¡ce hr├â┬í├ä┬ì├à┬».]]></cz>
+        <br><![CDATA[Adiciona sistema de renda hor├â┬íria / di├â┬íria com n├â┬¡veis de dificuldade, modificadores sazonais e suporte multiplayer.]]></br>
+        <uk><![CDATA[├ÉÔÇØ├É┬¥├É┬┤├É┬░├æÔÇØ ├æ┬ü├É┬©├æ┬ü├æÔÇÜ├É┬Á├É┬╝├æãÆ ├É┬┐├É┬¥├É┬│├É┬¥├É┬┤├É┬©├É┬¢├É┬¢├É┬¥├É┬│├É┬¥ / ├æÔÇ░├É┬¥├É┬┤├É┬Á├É┬¢├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ ├É┬À ├æÔé¼├æÔÇô├É┬▓├É┬¢├æ┬Å├É┬╝├É┬© ├æ┬ü├É┬║├É┬╗├É┬░├É┬┤├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æÔÇô, ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬©├É┬╝├É┬© ├É┬╝├É┬¥├É┬┤├É┬©├æÔÇ×├æÔÇô├É┬║├É┬░├æÔÇÜ├É┬¥├æÔé¼├É┬░├É┬╝├É┬© ├æÔÇÜ├É┬░ ├É┬┐├æÔÇô├É┬┤├æÔÇÜ├æÔé¼├É┬©├É┬╝├É┬║├É┬¥├æ┼¢ ├É┬╝├æãÆ├É┬╗├æ┼Æ├æÔÇÜ├É┬©├É┬┐├É┬╗├É┬Á├æÔÇØ├æÔé¼├É┬░.]]></uk>
+        <ru><![CDATA[├ÉÔÇØ├É┬¥├É┬▒├É┬░├É┬▓├É┬╗├æ┬Å├É┬Á├æÔÇÜ ├æ┬ü├É┬©├æ┬ü├æÔÇÜ├É┬Á├É┬╝├æãÆ ├É┬┐├É┬¥├æÔÇí├É┬░├æ┬ü├É┬¥├É┬▓├É┬¥├É┬│├É┬¥ / ├É┬Á├É┬Â├É┬Á├É┬┤├É┬¢├É┬Á├É┬▓├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░ ├æ┬ü ├æãÆ├æÔé¼├É┬¥├É┬▓├É┬¢├æ┬Å├É┬╝├É┬© ├æ┬ü├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├É┬©, ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├æÔÇ╣├É┬╝├É┬© ├É┬╝├É┬¥├É┬┤├É┬©├æÔÇ×├É┬©├É┬║├É┬░├æÔÇÜ├É┬¥├æÔé¼├É┬░├É┬╝├É┬© ├É┬© ├É┬┐├É┬¥├É┬┤├É┬┤├É┬Á├æÔé¼├É┬Â├É┬║├É┬¥├É┬╣ ├É┬╝├æãÆ├É┬╗├æ┼Æ├æÔÇÜ├É┬©├É┬┐├É┬╗├É┬Á├É┬Á├æÔé¼├É┬░.]]></ru>
+        <da><![CDATA[Tilf├â┬©jer et timeligt / dagligt inkomstsystem med sv├â┬ªrhedsniveauer, s├â┬ªsonelle modificer og multiplayer support.]]></da>
     </description>
     <iconFilename>icon.dds</iconFilename>
 
@@ -46,10 +46,10 @@
             <pl><![CDATA[Mod Dochodu]]></pl>
             <es><![CDATA[Mod de Ingresos]]></es>
             <it><![CDATA[Mod Reddito]]></it>
-            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ Mod]]></cz>
+            <cz><![CDATA[P├àÔäó├â┬¡jmov├â┬¢ Mod]]></cz>
             <br><![CDATA[Mod de Renda]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
+            <uk><![CDATA[├É┼ô├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
+            <ru><![CDATA[├É┼ô├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
             <da><![CDATA[inkomst Mod]]></da>
         </text>
 
@@ -58,27 +58,27 @@
             <en><![CDATA[Enable Mod]]></en>
             <de><![CDATA[Mod aktivieren]]></de>
             <fr><![CDATA[Activer le mod]]></fr>
-            <pl><![CDATA[Wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz mod]]></pl>
+            <pl><![CDATA[W├àÔÇÜ├äÔÇªcz mod]]></pl>
             <es><![CDATA[Activar mod]]></es>
             <it><![CDATA[Attiva mod]]></it>
             <cz><![CDATA[Povolit mod]]></cz>
             <br><![CDATA[Ativar mod]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤]]></ru>
+            <uk><![CDATA[├É┬ú├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© ├É┬╝├É┬¥├É┬┤]]></uk>
+            <ru><![CDATA[├ÉÔÇÖ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ ├É┬╝├É┬¥├É┬┤]]></ru>
             <da><![CDATA[Aktiver mod]]></da>
         </text>
 
         <text name="im_enabled_long">
             <en><![CDATA[Enable or disable the income mod]]></en>
             <de><![CDATA[Einkommens-Mod aktivieren oder deaktivieren]]></de>
-            <fr><![CDATA[Activer ou dâ”œÃ¢â”¬Â®sactiver le module de revenu]]></fr>
-            <pl><![CDATA[Wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz lub wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz mod dochodâ”œÃ¢â”¬â”‚w]]></pl>
-            <es><![CDATA[Activar o desactivar el mâ”œÃ¢â”¬â”‚dulo de ingresos]]></es>
+            <fr><![CDATA[Activer ou d├â┬®sactiver le module de revenu]]></fr>
+            <pl><![CDATA[W├àÔÇÜ├äÔÇªcz lub wy├àÔÇÜ├äÔÇªcz mod dochod├â┬│w]]></pl>
+            <es><![CDATA[Activar o desactivar el m├â┬│dulo de ingresos]]></es>
             <it><![CDATA[Attiva o disattiva il modulo di reddito]]></it>
-            <cz><![CDATA[Povolit nebo zakâ”œÃ¢â”¬Ã­zat pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ mod]]></cz>
+            <cz><![CDATA[Povolit nebo zak├â┬ízat p├àÔäó├â┬¡jmov├â┬¢ mod]]></cz>
             <br><![CDATA[Ativar ou desativar o mod de renda]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
+            <uk><![CDATA[├É┬ú├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© ├É┬░├É┬▒├É┬¥ ├É┬▓├É┬©├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© ├É┬╝├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
+            <ru><![CDATA[├ÉÔÇÖ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ ├É┬©├É┬╗├É┬© ├É┬▓├æÔÇ╣├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ ├É┬╝├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
             <da><![CDATA[Aktiver eller deaktiver inkomst mod]]></da>
         </text>
 
@@ -89,25 +89,25 @@
             <fr><![CDATA[Mode DEBUG]]></fr>
             <pl><![CDATA[Tryb DEBUG]]></pl>
             <es><![CDATA[Modo DEBUG]]></es>
-            <it><![CDATA[Modalitâ”œÃ¢â”¬Ã¡ DEBUG]]></it>
-            <cz><![CDATA[DEBUG reâ”œÃ â”¬Â¥im]]></cz>
+            <it><![CDATA[Modalit├â┬á DEBUG]]></it>
+            <cz><![CDATA[DEBUG re├à┬¥im]]></cz>
             <br><![CDATA[Modo DEBUG]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• DEBUG]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• DEBUG]]></ru>
+            <uk><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝ DEBUG]]></uk>
+            <ru><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝ DEBUG]]></ru>
             <da><![CDATA[DEBUG Mode]]></da>
         </text>
 
         <text name="im_debug_long">
             <en><![CDATA[Enable / disable debug mode (extra logging)]]></en>
-            <de><![CDATA[DEBUG-Modus ein- / ausschalten (zusâ”œÃ¢â”¬Ã±tzliche Protokollierung)]]></de>
-            <fr><![CDATA[Activer / dâ”œÃ¢â”¬Â®sactiver le mode DEBUG (journalisation supplâ”œÃ¢â”¬Â®mentaire)]]></fr>
-            <pl><![CDATA[Wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz / wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz tryb DEBUG (dodatkowe logowanie)]]></pl>
+            <de><![CDATA[DEBUG-Modus ein- / ausschalten (zus├â┬ñtzliche Protokollierung)]]></de>
+            <fr><![CDATA[Activer / d├â┬®sactiver le mode DEBUG (journalisation suppl├â┬®mentaire)]]></fr>
+            <pl><![CDATA[W├àÔÇÜ├äÔÇªcz / wy├àÔÇÜ├äÔÇªcz tryb DEBUG (dodatkowe logowanie)]]></pl>
             <es><![CDATA[Activar / desactivar modo DEBUG (registro adicional)]]></es>
-            <it><![CDATA[Attiva / disattiva modalitâ”œÃ¢â”¬Ã¡ DEBUG (registrazione aggiuntiva)]]></it>
-            <cz><![CDATA[Povolit / zakâ”œÃ¢â”¬Ã­zat DEBUG reâ”œÃ â”¬Â¥im (dodateâ”œÃ¤â”¬Ã¬nâ”œÃ¢â”¬Â® logovâ”œÃ¢â”¬Ã­nâ”œÃ¢â”¬Â¡)]]></cz>
+            <it><![CDATA[Attiva / disattiva modalit├â┬á DEBUG (registrazione aggiuntiva)]]></it>
+            <cz><![CDATA[Povolit / zak├â┬ízat DEBUG re├à┬¥im (dodate├ä┬ìn├â┬® logov├â┬ín├â┬¡)]]></cz>
             <br><![CDATA[Ativar / desativar modo DEBUG (registro adicional)]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© / â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• DEBUG (â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Ã â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…)]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† / â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• DEBUG (â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã)]]></ru>
+            <uk><![CDATA[├É┬ú├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© / ├É┬▓├É┬©├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© ├æÔé¼├É┬Á├É┬Â├É┬©├É┬╝ DEBUG (├É┬┤├É┬¥├É┬┤├É┬░├æÔÇÜ├É┬║├É┬¥├É┬▓├É┬Á ├É┬╗├É┬¥├É┬│├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å)]]></uk>
+            <ru><![CDATA[├ÉÔÇÖ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ / ├É┬▓├æÔÇ╣├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ ├æÔé¼├É┬Á├É┬Â├É┬©├É┬╝ DEBUG (├É┬┤├É┬¥├É┬┐├É┬¥├É┬╗├É┬¢├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┼Æ├É┬¢├É┬¥├É┬Á ├É┬╗├É┬¥├É┬│├É┬©├æÔé¼├É┬¥├É┬▓├É┬░├É┬¢├É┬©├É┬Á)]]></ru>
             <da><![CDATA[Aktiver / deaktiver debug mode (ekstra logning)]]></da>
         </text>
 
@@ -116,55 +116,55 @@
             <en><![CDATA[Pay Mode]]></en>
             <de><![CDATA[Zahlungsmodus]]></de>
             <fr><![CDATA[Mode de paiement]]></fr>
-            <pl><![CDATA[Tryb pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci]]></pl>
+            <pl><![CDATA[Tryb p├àÔÇÜatno├àÔÇ║ci]]></pl>
             <es><![CDATA[Modo de pago]]></es>
-            <it><![CDATA[Modalitâ”œÃ¢â”¬Ã¡ pagamento]]></it>
-            <cz><![CDATA[Platebnâ”œÃ¢â”¬Â¡ reâ”œÃ â”¬Â¥im]]></cz>
+            <it><![CDATA[Modalit├â┬á pagamento]]></it>
+            <cz><![CDATA[Platebn├â┬¡ re├à┬¥im]]></cz>
             <br><![CDATA[Modo de pagamento]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ]]></ru>
+            <uk><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ]]></uk>
+            <ru><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ]]></ru>
             <da><![CDATA[Betalingstype]]></da>
         </text>
 
         <text name="im_paymode_long">
             <en><![CDATA[Choose payment frequency: hourly or daily]]></en>
-            <de><![CDATA[Wâ”œÃ¢â”¬Ã±hlen Sie die Zahlungshâ”œÃ¢â”¬Ã±ufigkeit: stâ”œÃ¢â”¬â•ndlich oder tâ”œÃ¢â”¬Ã±glich]]></de>
-            <fr><![CDATA[Choisissez la frâ”œÃ¢â”¬Â®quence de paiement : horaire ou quotidienne]]></fr>
-            <pl><![CDATA[Wybierz czâ”œÃ¤Ã”Ã¤Ã³stotliwoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­ pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci: godzinowa lub dzienna]]></pl>
+            <de><![CDATA[W├â┬ñhlen Sie die Zahlungsh├â┬ñufigkeit: st├â┬╝ndlich oder t├â┬ñglich]]></de>
+            <fr><![CDATA[Choisissez la fr├â┬®quence de paiement : horaire ou quotidienne]]></fr>
+            <pl><![CDATA[Wybierz cz├äÔäóstotliwo├àÔÇ║├äÔÇí p├àÔÇÜatno├àÔÇ║ci: godzinowa lub dzienna]]></pl>
             <es><![CDATA[Elegir frecuencia de pago: horaria o diaria]]></es>
             <it><![CDATA[Scegli frequenza pagamento: oraria o giornaliera]]></it>
-            <cz><![CDATA[Vyberte frekvenci plateb: hodinovou nebo dennâ”œÃ¢â”¬Â¡]]></cz>
-            <br><![CDATA[Escolher frequâ”œÃ¢â”¬Â¬ncia de pagamento: horâ”œÃ¢â”¬Ã­ria ou diâ”œÃ¢â”¬Ã­ria]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Â©â”œÃ‰â”¬â–’â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ: â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ: â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢]]></ru>
-            <da><![CDATA[Vâ”œÃ¢â”¬Âªlg betalingsfrekvens: time for time eller dagligt]]></da>
+            <cz><![CDATA[Vyberte frekvenci plateb: hodinovou nebo denn├â┬¡]]></cz>
+            <br><![CDATA[Escolher frequ├â┬¬ncia de pagamento: hor├â┬íria ou di├â┬íria]]></br>
+            <uk><![CDATA[├ÉÔÇÖ├É┬©├É┬▒├É┬Á├æÔé¼├æÔÇô├æÔÇÜ├æ┼Æ ├æÔÇí├É┬░├æ┬ü├æÔÇÜ├É┬¥├æÔÇÜ├æãÆ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ: ├É┬┐├É┬¥├É┬│├É┬¥├É┬┤├É┬©├É┬¢├É┬¢├É┬¥ ├É┬░├É┬▒├É┬¥ ├æÔÇ░├É┬¥├É┬┤├É┬Á├É┬¢├É┬¢├É┬¥]]></uk>
+            <ru><![CDATA[├ÉÔÇÖ├æÔÇ╣├É┬▒├æÔé¼├É┬░├æÔÇÜ├æ┼Æ ├æÔÇí├É┬░├æ┬ü├æÔÇÜ├É┬¥├æÔÇÜ├æãÆ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ: ├É┬┐├É┬¥├æÔÇí├É┬░├æ┬ü├É┬¥├É┬▓├æãÆ├æ┼¢ ├É┬©├É┬╗├É┬© ├É┬Á├É┬Â├É┬Á├É┬┤├É┬¢├É┬Á├É┬▓├É┬¢├æãÆ├æ┼¢]]></ru>
+            <da><![CDATA[V├â┬ªlg betalingsfrekvens: time for time eller dagligt]]></da>
         </text>
 
         <text name="im_paymode_1">
             <en><![CDATA[Hourly]]></en>
-            <de><![CDATA[Stâ”œÃ¢â”¬â•ndlich]]></de>
+            <de><![CDATA[St├â┬╝ndlich]]></de>
             <fr><![CDATA[Horaire]]></fr>
             <pl><![CDATA[Godzinowa]]></pl>
             <es><![CDATA[Horaria]]></es>
             <it><![CDATA[Oraria]]></it>
-            <cz><![CDATA[Hodinovâ”œÃ¢â”¬Ã­]]></cz>
-            <br><![CDATA[Horâ”œÃ¢â”¬Ã­ria]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥]]></ru>
+            <cz><![CDATA[Hodinov├â┬í]]></cz>
+            <br><![CDATA[Hor├â┬íria]]></br>
+            <uk><![CDATA[├É┼©├É┬¥├É┬│├É┬¥├É┬┤├É┬©├É┬¢├É┬¢├É┬¥]]></uk>
+            <ru><![CDATA[├É┼©├É┬¥├æÔÇí├É┬░├æ┬ü├É┬¥├É┬▓├É┬¥]]></ru>
             <da><![CDATA[Time for time]]></da>
         </text>
 
         <text name="im_paymode_2">
             <en><![CDATA[Daily]]></en>
-            <de><![CDATA[Tâ”œÃ¢â”¬Ã±glich]]></de>
+            <de><![CDATA[T├â┬ñglich]]></de>
             <fr><![CDATA[Quotidienne]]></fr>
             <pl><![CDATA[Dzienna]]></pl>
             <es><![CDATA[Diaria]]></es>
             <it><![CDATA[Giornaliera]]></it>
-            <cz><![CDATA[Dennâ”œÃ¢â”¬Â¡]]></cz>
-            <br><![CDATA[Diâ”œÃ¢â”¬Ã­ria]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Â®â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã³â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></ru>
+            <cz><![CDATA[Denn├â┬¡]]></cz>
+            <br><![CDATA[Di├â┬íria]]></br>
+            <uk><![CDATA[├É┬®├É┬¥├É┬┤├É┬Á├É┬¢├É┬¢├É┬¥]]></uk>
+            <ru><![CDATA[├ÉÔÇó├É┬Â├É┬Á├É┬┤├É┬¢├É┬Á├É┬▓├É┬¢├É┬¥]]></ru>
             <da><![CDATA[Dagligt]]></da>
         </text>
 
@@ -172,42 +172,42 @@
         <text name="im_difficulty_short">
             <en><![CDATA[Difficulty]]></en>
             <de><![CDATA[Schwierigkeit]]></de>
-            <fr><![CDATA[Difficultâ”œÃ¢â”¬Â®]]></fr>
-            <pl><![CDATA[Trudnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­]]></pl>
+            <fr><![CDATA[Difficult├â┬®]]></fr>
+            <pl><![CDATA[Trudno├àÔÇ║├äÔÇí]]></pl>
             <es><![CDATA[Dificultad]]></es>
-            <it><![CDATA[Difficoltâ”œÃ¢â”¬Ã¡]]></it>
-            <cz><![CDATA[Obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nost]]></cz>
+            <it><![CDATA[Difficolt├â┬á]]></it>
+            <cz><![CDATA[Obt├â┬¡├à┬¥nost]]></cz>
             <br><![CDATA[Dificuldade]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†]]></ru>
-            <da><![CDATA[Svâ”œÃ¢â”¬Âªrhedsgrad]]></da>
+            <uk><![CDATA[├É┬í├É┬║├É┬╗├É┬░├É┬┤├É┬¢├æÔÇô├æ┬ü├æÔÇÜ├æ┼Æ]]></uk>
+            <ru><![CDATA[├É┬í├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æ┼Æ]]></ru>
+            <da><![CDATA[Sv├â┬ªrhedsgrad]]></da>
         </text>
 
         <text name="im_difficulty_long">
             <en><![CDATA[Set income amount: Easy=$5000, Normal=$2400, Hard=$1100]]></en>
             <de><![CDATA[Einkommensbetrag festlegen: Einfach=5000$, Normal=2400$, Schwer=1100$]]></de>
-            <fr><![CDATA[Dâ”œÃ¢â”¬Â®finir le montant du revenu : Facile=5000$, Normal=2400$, Difficile=1100$]]></fr>
-            <pl><![CDATA[Ustaw kwotâ”œÃ¤Ã”Ã¤Ã³ dochodu: â”œÃ â”¬Ã¼atwy=5000$, Normalny=2400$, Trudny=1100$]]></pl>
-            <es><![CDATA[Establecer monto de ingreso: Fâ”œÃ¢â”¬Ã­cil=5000$, Normal=2400$, Difâ”œÃ¢â”¬Â¡cil=1100$]]></es>
+            <fr><![CDATA[D├â┬®finir le montant du revenu : Facile=5000$, Normal=2400$, Difficile=1100$]]></fr>
+            <pl><![CDATA[Ustaw kwot├äÔäó dochodu: ├à┬üatwy=5000$, Normalny=2400$, Trudny=1100$]]></pl>
+            <es><![CDATA[Establecer monto de ingreso: F├â┬ícil=5000$, Normal=2400$, Dif├â┬¡cil=1100$]]></es>
             <it><![CDATA[Imposta importo reddito: Facile=5000$, Normale=2400$, Difficile=1100$]]></it>
-            <cz><![CDATA[Nastavit vâ”œÃ¢â”¬Â¢â”œÃ â”¬Ã­i pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmu: Snadnâ”œÃ¢â”¬Â®=5000$, Normâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡=2400$, Tâ”œÃ¤Ã”Ã‡â•‘â”œÃ â”¬Â¥kâ”œÃ¢â”¬Â®=1100$]]></cz>
-            <br><![CDATA[Definir valor da renda: Fâ”œÃ¢â”¬Ã­cil=5000$, Normal=2400$, Difâ”œÃ¢â”¬Â¡cil=1100$]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†: â”œÃ‰Ã”Ã‡â•‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥=5000$, â”œÃ‰â”¬Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥=2400$, â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥=1100$]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘: â”œÃ‰Ã”Ã‡â•‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥=5000$, â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥=2400$, â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥=1100$]]></ru>
-            <da><![CDATA[Indstil inkomstbelâ”œÃ¢â”¬Â©b: Let=$5000, Normal=$2400, Svâ”œÃ¢â”¬Âªr=$1100]]></da>
+            <cz><![CDATA[Nastavit v├â┬¢├à┬íi p├àÔäó├â┬¡jmu: Snadn├â┬®=5000$, Norm├â┬íln├â┬¡=2400$, T├äÔÇ║├à┬¥k├â┬®=1100$]]></cz>
+            <br><![CDATA[Definir valor da renda: F├â┬ícil=5000$, Normal=2400$, Dif├â┬¡cil=1100$]]></br>
+            <uk><![CDATA[├ÉÔÇÖ├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¥├É┬▓├É┬©├æÔÇÜ├É┬© ├æ┬ü├æãÆ├É┬╝├æãÆ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ: ├ÉÔÇ║├É┬Á├É┬│├É┬║├É┬¥=5000$, ├É┬Ø├É┬¥├æÔé¼├É┬╝├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥=2400$, ├ÉÔÇÖ├É┬░├É┬Â├É┬║├É┬¥=1100$]]></uk>
+            <ru><![CDATA[├É┬ú├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¥├É┬▓├É┬©├æÔÇÜ├æ┼Æ ├æ┬ü├æãÆ├É┬╝├É┬╝├æãÆ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░: ├ÉÔÇ║├É┬Á├É┬│├É┬║├É┬¥=5000$, ├É┼¥├É┬▒├æÔÇ╣├æÔÇí├É┬¢├É┬¥=2400$, ├É┬í├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥=1100$]]></ru>
+            <da><![CDATA[Indstil inkomstbel├â┬©b: Let=$5000, Normal=$2400, Sv├â┬ªr=$1100]]></da>
         </text>
 
         <text name="im_diff_1">
             <en><![CDATA[Easy ($5000)]]></en>
             <de><![CDATA[Einfach (5000$)]]></de>
             <fr><![CDATA[Facile (5000$)]]></fr>
-            <pl><![CDATA[â”œÃ â”¬Ã¼atwy (5000$)]]></pl>
-            <es><![CDATA[Fâ”œÃ¢â”¬Ã­cil (5000$)]]></es>
+            <pl><![CDATA[├à┬üatwy (5000$)]]></pl>
+            <es><![CDATA[F├â┬ícil (5000$)]]></es>
             <it><![CDATA[Facile (5000$)]]></it>
-            <cz><![CDATA[Snadnâ”œÃ¢â”¬Â® (5000$)]]></cz>
-            <br><![CDATA[Fâ”œÃ¢â”¬Ã­cil (5000$)]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡â•‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥ (5000$)]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡â•‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥ (5000$)]]></ru>
+            <cz><![CDATA[Snadn├â┬® (5000$)]]></cz>
+            <br><![CDATA[F├â┬ícil (5000$)]]></br>
+            <uk><![CDATA[├ÉÔÇ║├É┬Á├É┬│├É┬║├É┬¥ (5000$)]]></uk>
+            <ru><![CDATA[├ÉÔÇ║├É┬Á├É┬│├É┬║├É┬¥ (5000$)]]></ru>
             <da><![CDATA[Let ($5000)]]></da>
         </text>
 
@@ -218,10 +218,10 @@
             <pl><![CDATA[Normalny (2400$)]]></pl>
             <es><![CDATA[Normal (2400$)]]></es>
             <it><![CDATA[Normale (2400$)]]></it>
-            <cz><![CDATA[Normâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡ (2400$)]]></cz>
+            <cz><![CDATA[Norm├â┬íln├â┬¡ (2400$)]]></cz>
             <br><![CDATA[Normal (2400$)]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ (2400$)]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ (2400$)]]></ru>
+            <uk><![CDATA[├É┬Ø├É┬¥├æÔé¼├É┬╝├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥ (2400$)]]></uk>
+            <ru><![CDATA[├É┼¥├É┬▒├æÔÇ╣├æÔÇí├É┬¢├É┬¥ (2400$)]]></ru>
             <da><![CDATA[Normal ($2400)]]></da>
         </text>
 
@@ -230,13 +230,13 @@
             <de><![CDATA[Schwer (1100$)]]></de>
             <fr><![CDATA[Difficile (1100$)]]></fr>
             <pl><![CDATA[Trudny (1100$)]]></pl>
-            <es><![CDATA[Difâ”œÃ¢â”¬Â¡cil (1100$)]]></es>
+            <es><![CDATA[Dif├â┬¡cil (1100$)]]></es>
             <it><![CDATA[Difficile (1100$)]]></it>
-            <cz><![CDATA[Tâ”œÃ¤Ã”Ã‡â•‘â”œÃ â”¬Â¥kâ”œÃ¢â”¬Â® (1100$)]]></cz>
-            <br><![CDATA[Difâ”œÃ¢â”¬Â¡cil (1100$)]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥ (1100$)]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ (1100$)]]></ru>
-            <da><![CDATA[Svâ”œÃ¢â”¬Âªr ($1100)]]></da>
+            <cz><![CDATA[T├äÔÇ║├à┬¥k├â┬® (1100$)]]></cz>
+            <br><![CDATA[Dif├â┬¡cil (1100$)]]></br>
+            <uk><![CDATA[├ÉÔÇÖ├É┬░├É┬Â├É┬║├É┬¥ (1100$)]]></uk>
+            <ru><![CDATA[├É┬í├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥ (1100$)]]></ru>
+            <da><![CDATA[Sv├â┬ªr ($1100)]]></da>
         </text>
 
         <!-- Notifications -->
@@ -247,24 +247,24 @@
             <pl><![CDATA[Powiadomienia]]></pl>
             <es><![CDATA[Notificaciones]]></es>
             <it><![CDATA[Notifiche]]></it>
-            <cz><![CDATA[Upozornâ”œÃ¤Ã”Ã‡â•‘nâ”œÃ¢â”¬Â¡]]></cz>
-            <br><![CDATA[Notificaâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã…]]></ru>
+            <cz><![CDATA[Upozorn├äÔÇ║n├â┬¡]]></cz>
+            <br><![CDATA[Notifica├â┬º├â┬Áes]]></br>
+            <uk><![CDATA[├É┬í├É┬┐├É┬¥├É┬▓├æÔÇô├æÔÇ░├É┬Á├É┬¢├É┬¢├æ┬Å]]></uk>
+            <ru><![CDATA[├É┬ú├É┬▓├É┬Á├É┬┤├É┬¥├É┬╝├É┬╗├É┬Á├É┬¢├É┬©├æ┬Å]]></ru>
             <da><![CDATA[Notifikationer]]></da>
         </text>
 
         <text name="im_notifications_long">
             <en><![CDATA[Enable/disable payment notifications]]></en>
             <de><![CDATA[Zahlungsbenachrichtigungen ein-/ausschalten]]></de>
-            <fr><![CDATA[Activer/dâ”œÃ¢â”¬Â®sactiver les notifications de paiement]]></fr>
-            <pl><![CDATA[Wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz/wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz powiadomienia o pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ciach]]></pl>
+            <fr><![CDATA[Activer/d├â┬®sactiver les notifications de paiement]]></fr>
+            <pl><![CDATA[W├àÔÇÜ├äÔÇªcz/wy├àÔÇÜ├äÔÇªcz powiadomienia o p├àÔÇÜatno├àÔÇ║ciach]]></pl>
             <es><![CDATA[Activar/desactivar notificaciones de pago]]></es>
             <it><![CDATA[Attiva/disattiva notifiche pagamento]]></it>
-            <cz><![CDATA[Povolit/zakâ”œÃ¢â”¬Ã­zat upozornâ”œÃ¤Ã”Ã‡â•‘nâ”œÃ¢â”¬Â¡ na platby]]></cz>
-            <br><![CDATA[Ativar/desativar notificaâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães de pagamento]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©/â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†/â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª]]></ru>
+            <cz><![CDATA[Povolit/zak├â┬ízat upozorn├äÔÇ║n├â┬¡ na platby]]></cz>
+            <br><![CDATA[Ativar/desativar notifica├â┬º├â┬Áes de pagamento]]></br>
+            <uk><![CDATA[├É┬ú├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬©/├É┬▓├É┬©├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© ├æ┬ü├É┬┐├É┬¥├É┬▓├æÔÇô├æÔÇ░├É┬Á├É┬¢├É┬¢├æ┬Å ├É┬┐├æÔé¼├É┬¥ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬©]]></uk>
+            <ru><![CDATA[├ÉÔÇÖ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ/├É┬▓├æÔÇ╣├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ ├æãÆ├É┬▓├É┬Á├É┬┤├É┬¥├É┬╝├É┬╗├É┬Á├É┬¢├É┬©├æ┬Å ├É┬¥ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░├æÔÇª]]></ru>
             <da><![CDATA[Aktiver/deaktiver betalingsnotifikationer]]></da>
         </text>
 
@@ -272,29 +272,29 @@
         <text name="im_customamount_short">
             <en><![CDATA[Custom Amount]]></en>
             <de><![CDATA[Benutzerdefinierter Betrag]]></de>
-            <fr><![CDATA[Montant personnalisâ”œÃ¢â”¬Â®]]></fr>
+            <fr><![CDATA[Montant personnalis├â┬®]]></fr>
             <pl><![CDATA[Niestandardowa kwota]]></pl>
             <es><![CDATA[Cantidad personalizada]]></es>
             <it><![CDATA[Importo personalizzato]]></it>
-            <cz><![CDATA[Vlastnâ”œÃ¢â”¬Â¡ â”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­stka]]></cz>
+            <cz><![CDATA[Vlastn├â┬¡ ├ä┬ì├â┬ístka]]></cz>
             <br><![CDATA[Valor personalizado]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘]]></ru>
-            <da><![CDATA[Brugerdefineret belâ”œÃ¢â”¬Â©b]]></da>
+            <uk><![CDATA[├ÉÔÇÖ├É┬╗├É┬░├æ┬ü├É┬¢├É┬░ ├æ┬ü├æãÆ├É┬╝├É┬░]]></uk>
+            <ru><![CDATA[├É┼©├É┬¥├É┬╗├æ┼Æ├É┬À├É┬¥├É┬▓├É┬░├æÔÇÜ├É┬Á├É┬╗├æ┼Æ├æ┬ü├É┬║├É┬░├æ┬Å ├æ┬ü├æãÆ├É┬╝├É┬╝├É┬░]]></ru>
+            <da><![CDATA[Brugerdefineret bel├â┬©b]]></da>
         </text>
 
         <text name="im_customamount_long">
             <en><![CDATA[Set custom payment amount (0 = use difficulty setting)]]></en>
             <de><![CDATA[Benutzerdefinierten Zahlungsbetrag festlegen (0 = Schwierigkeitsstufe verwenden)]]></de>
-            <fr><![CDATA[Dâ”œÃ¢â”¬Â®finir le montant de paiement personnalisâ”œÃ¢â”¬Â® (0 = utiliser le râ”œÃ¢â”¬Â®glage de difficultâ”œÃ¢â”¬Â®)]]></fr>
-            <pl><![CDATA[Ustaw niestandardowâ”œÃ¤Ã”Ã‡Âª kwotâ”œÃ¤Ã”Ã¤Ã³ pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci (0 = uâ”œÃ â”¬â•yj ustawienia trudnoâ”œÃ Ã”Ã‡â•‘ci)]]></pl>
-            <es><![CDATA[Establecer monto de pago personalizado (0 = usar configuraciâ”œÃ¢â”¬â”‚n de dificultad)]]></es>
-            <it><![CDATA[Imposta importo pagamento personalizzato (0 = usa impostazione difficoltâ”œÃ¢â”¬Ã¡)]]></it>
-            <cz><![CDATA[Nastavit vlastnâ”œÃ¢â”¬Â¡ â”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­stku platby (0 = pouâ”œÃ â”¬Â¥â”œÃ¢â”¬Â¡t nastavenâ”œÃ¢â”¬Â¡ obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nosti)]]></cz>
-            <br><![CDATA[Definir valor de pagamento personalizado (0 = usar configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ãºo de dificuldade)]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© (0 = â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã´)]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£ (0 = â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ¦Ã£Ã† â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©)]]></ru>
-            <da><![CDATA[Indstil brugerdefineret betalingsbelâ”œÃ¢â”¬Â©b (0 = brug svâ”œÃ¢â”¬Âªrhedsgrad)]]></da>
+            <fr><![CDATA[D├â┬®finir le montant de paiement personnalis├â┬® (0 = utiliser le r├â┬®glage de difficult├â┬®)]]></fr>
+            <pl><![CDATA[Ustaw niestandardow├äÔÇª kwot├äÔäó p├àÔÇÜatno├àÔÇ║ci (0 = u├à┬╝yj ustawienia trudno├àÔÇ║ci)]]></pl>
+            <es><![CDATA[Establecer monto de pago personalizado (0 = usar configuraci├â┬│n de dificultad)]]></es>
+            <it><![CDATA[Imposta importo pagamento personalizzato (0 = usa impostazione difficolt├â┬á)]]></it>
+            <cz><![CDATA[Nastavit vlastn├â┬¡ ├ä┬ì├â┬ístku platby (0 = pou├à┬¥├â┬¡t nastaven├â┬¡ obt├â┬¡├à┬¥nosti)]]></cz>
+            <br><![CDATA[Definir valor de pagamento personalizado (0 = usar configura├â┬º├â┬úo de dificuldade)]]></br>
+            <uk><![CDATA[├ÉÔÇÖ├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¥├É┬▓├É┬©├æÔÇÜ├É┬© ├É┬▓├É┬╗├É┬░├æ┬ü├É┬¢├æãÆ ├æ┬ü├æãÆ├É┬╝├æãÆ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬© (0 = ├É┬▓├É┬©├É┬║├É┬¥├æÔé¼├É┬©├æ┬ü├æÔÇÜ├É┬¥├É┬▓├æãÆ├É┬▓├É┬░├æÔÇÜ├É┬© ├É┬¢├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å ├æ┬ü├É┬║├É┬╗├É┬░├É┬┤├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æÔÇô)]]></uk>
+            <ru><![CDATA[├É┬ú├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¥├É┬▓├É┬©├æÔÇÜ├æ┼Æ ├É┬┐├É┬¥├É┬╗├æ┼Æ├É┬À├É┬¥├É┬▓├É┬░├æÔÇÜ├É┬Á├É┬╗├æ┼Æ├æ┬ü├É┬║├æãÆ├æ┼¢ ├æ┬ü├æãÆ├É┬╝├É┬╝├æãÆ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣ (0 = ├É┬©├æ┬ü├É┬┐├É┬¥├É┬╗├æ┼Æ├É┬À├É┬¥├É┬▓├É┬░├æÔÇÜ├æ┼Æ ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├æãÆ ├æ┬ü├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├É┬©)]]></ru>
+            <da><![CDATA[Indstil brugerdefineret betalingsbel├â┬©b (0 = brug sv├â┬ªrhedsgrad)]]></da>
         </text>
 
         <!-- Income Multiplier (NEW in 2.0) -->
@@ -302,13 +302,13 @@
             <en><![CDATA[Income Multiplier]]></en>
             <de><![CDATA[Einkommensmultiplikator]]></de>
             <fr><![CDATA[Multiplicateur de revenu]]></fr>
-            <pl><![CDATA[Mnoâ”œÃ â”¬â•nik dochodu]]></pl>
+            <pl><![CDATA[Mno├à┬╝nik dochodu]]></pl>
             <es><![CDATA[Multiplicador de ingresos]]></es>
             <it><![CDATA[Moltiplicatore reddito]]></it>
-            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ multiplikâ”œÃ¢â”¬Ã­tor]]></cz>
+            <cz><![CDATA[P├àÔäó├â┬¡jmov├â┬¢ multiplik├â┬ítor]]></cz>
             <br><![CDATA[Multiplicador de renda]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
+            <uk><![CDATA[├É┼ô├É┬¢├É┬¥├É┬Â├É┬¢├É┬©├É┬║ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
+            <ru><![CDATA[├É┼ô├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┼Æ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
             <da><![CDATA[Inkomstmultiplikator]]></da>
         </text>
 
@@ -316,14 +316,14 @@
             <en><![CDATA[Multiply the base payment: 1x, 2x, 5x, or 10x]]></en>
             <de><![CDATA[Basisbetrag multiplizieren: 1x, 2x, 5x oder 10x]]></de>
             <fr><![CDATA[Multiplier le paiement de base : 1x, 2x, 5x ou 10x]]></fr>
-            <pl><![CDATA[Pomnâ”œÃ¢â”¬â”‚â”œÃ â”¬â• podstawowâ”œÃ¤Ã”Ã‡Âª pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­: 1x, 2x, 5x lub 10x]]></pl>
+            <pl><![CDATA[Pomn├â┬│├à┬╝ podstawow├äÔÇª p├àÔÇÜatno├àÔÇ║├äÔÇí: 1x, 2x, 5x lub 10x]]></pl>
             <es><![CDATA[Multiplicar el pago base: 1x, 2x, 5x o 10x]]></es>
             <it><![CDATA[Moltiplica il pagamento base: 1x, 2x, 5x o 10x]]></it>
-            <cz><![CDATA[Znâ”œÃ¢â”¬Ã­sobit zâ”œÃ¢â”¬Ã­kladnâ”œÃ¢â”¬Â¡ platbu: 1x, 2x, 5x nebo 10x]]></cz>
+            <cz><![CDATA[Zn├â┬ísobit z├â┬íkladn├â┬¡ platbu: 1x, 2x, 5x nebo 10x]]></cz>
             <br><![CDATA[Multiplicar o pagamento base: 1x, 2x, 5x ou 10x]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†: 1x, 2x, 5x â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ 10x]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â•â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†: 1x, 2x, 5x â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© 10x]]></ru>
-            <da><![CDATA[Multiplikâ”œÃ¢â”¬Â®r basishonoraret: 1x, 2x, 5x eller 10x]]></da>
+            <uk><![CDATA[├É┼©├É┬¥├É┬╝├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬© ├É┬▒├É┬░├É┬À├É┬¥├É┬▓├æãÆ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ: 1x, 2x, 5x ├É┬░├É┬▒├É┬¥ 10x]]></uk>
+            <ru><![CDATA[├É┬ú├É┬╝├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├æ┼Æ ├É┬▒├É┬░├É┬À├É┬¥├É┬▓├æãÆ├æ┼¢ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ: 1x, 2x, 5x ├É┬©├É┬╗├É┬© 10x]]></ru>
+            <da><![CDATA[Multiplik├â┬®r basishonoraret: 1x, 2x, 5x eller 10x]]></da>
         </text>
 
         <text name="im_mult_1">
@@ -333,10 +333,10 @@
             <pl><![CDATA[1x (Normalny)]]></pl>
             <es><![CDATA[1x (Normal)]]></es>
             <it><![CDATA[1x (Normale)]]></it>
-            <cz><![CDATA[1x (Normâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡)]]></cz>
+            <cz><![CDATA[1x (Norm├â┬íln├â┬¡)]]></cz>
             <br><![CDATA[1x (Normal)]]></br>
-            <uk><![CDATA[1x (â”œÃ‰â”¬Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥)]]></uk>
-            <ru><![CDATA[1x (â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥)]]></ru>
+            <uk><![CDATA[1x (├É┬Ø├É┬¥├æÔé¼├É┬╝├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥)]]></uk>
+            <ru><![CDATA[1x (├É┼¥├É┬▒├æÔÇ╣├æÔÇí├É┬¢├É┬¥)]]></ru>
             <da><![CDATA[1x (Normal)]]></da>
         </text>
 
@@ -390,25 +390,25 @@
             <pl><![CDATA[Efekty sezonowe]]></pl>
             <es><![CDATA[Efectos estacionales]]></es>
             <it><![CDATA[Effetti stagionali]]></it>
-            <cz><![CDATA[Sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡ efekty]]></cz>
+            <cz><![CDATA[Sez├â┬│nn├â┬¡ efekty]]></cz>
             <br><![CDATA[Efeitos sazonais]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬Ã â”œÃ¦â”¬Ã¬â”œÃ¦Ã”Ã‡Ã—â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£]]></ru>
-            <da><![CDATA[sâ”œÃ¢â”¬Âªsonale effekter]]></da>
+            <uk><![CDATA[├É┬í├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├æÔÇô ├É┬Á├æÔÇ×├É┬Á├É┬║├æÔÇÜ├É┬©]]></uk>
+            <ru><![CDATA[├É┬í├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├æÔÇ╣├É┬Á ├æ┬ì├æÔÇ×├æÔÇ×├É┬Á├É┬║├æÔÇÜ├æÔÇ╣]]></ru>
+            <da><![CDATA[s├â┬ªsonale effekter]]></da>
         </text>
 
         <text name="im_seasonal_long">
             <en><![CDATA[Income varies by season: Spring 0.8x, Summer 1.0x, Autumn 1.2x, Winter 0.7x]]></en>
-            <de><![CDATA[Einkommen variiert je nach Jahreszeit: Frâ”œÃ¢â”¬â•hling 0,8x, Sommer 1,0x, Herbst 1,2x, Winter 0,7x]]></de>
-            <fr><![CDATA[Le revenu varie selon la saison : Printemps 0,8x, â”œÃ¢Ã”Ã‡â–‘tâ”œÃ¢â”¬Â® 1,0x, Automne 1,2x, Hiver 0,7x]]></fr>
-            <pl><![CDATA[Dochâ”œÃ¢â”¬â”‚d zmienia siâ”œÃ¤Ã”Ã¤Ã³ w zaleâ”œÃ â”¬â•noâ”œÃ Ã”Ã‡â•‘ci od sezonu: Wiosna 0,8x, Lato 1,0x, Jesieâ”œÃ Ã”Ã‡Ã— 1,2x, Zima 0,7x]]></pl>
-            <es><![CDATA[Los ingresos varâ”œÃ¢â”¬Â¡an por temporada: Primavera 0,8x, Verano 1,0x, Otoâ”œÃ¢â”¬â–’o 1,2x, Invierno 0,7x]]></es>
+            <de><![CDATA[Einkommen variiert je nach Jahreszeit: Fr├â┬╝hling 0,8x, Sommer 1,0x, Herbst 1,2x, Winter 0,7x]]></de>
+            <fr><![CDATA[Le revenu varie selon la saison : Printemps 0,8x, ├âÔÇ░t├â┬® 1,0x, Automne 1,2x, Hiver 0,7x]]></fr>
+            <pl><![CDATA[Doch├â┬│d zmienia si├äÔäó w zale├à┬╝no├àÔÇ║ci od sezonu: Wiosna 0,8x, Lato 1,0x, Jesie├àÔÇ× 1,2x, Zima 0,7x]]></pl>
+            <es><![CDATA[Los ingresos var├â┬¡an por temporada: Primavera 0,8x, Verano 1,0x, Oto├â┬▒o 1,2x, Invierno 0,7x]]></es>
             <it><![CDATA[Il reddito varia per stagione: Primavera 0,8x, Estate 1,0x, Autunno 1,2x, Inverno 0,7x]]></it>
-            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem se mâ”œÃ¤Ã”Ã‡â•‘nâ”œÃ¢â”¬Â¡ podle roâ”œÃ¤â”¬Ã¬nâ”œÃ¢â”¬Â¡ho obdobâ”œÃ¢â”¬Â¡: Jaro 0,8x, Lâ”œÃ¢â”¬Â®to 1,0x, Podzim 1,2x, Zima 0,7x]]></cz>
-            <br><![CDATA[A renda varia por estaâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ãºo: Primavera 0,8x, Verâ”œÃ¢â”¬Ãºo 1,0x, Outono 1,2x, Inverno 0,7x]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â•â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¢â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•: â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ 0,8x, â”œÃ‰Ã”Ã‡â•‘â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥ 1,0x, â”œÃ‰â”¼Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã† 1,2x, â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ 0,7x]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•: â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ 0,8x, â”œÃ‰Ã”Ã‡â•‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥ 1,0x, â”œÃ‰â”¼Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã† 1,2x, â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ 0,7x]]></ru>
-            <da><![CDATA[Inkomst varierer efter sâ”œÃ¢â”¬Âªson: Forâ”œÃ¢â”¬Ã‘r 0,8x, Sommer 1,0x, Efterâ”œÃ¢â”¬Ã‘r 1,2x, Vinter 0,7x]]></da>
+            <cz><![CDATA[P├àÔäó├â┬¡jem se m├äÔÇ║n├â┬¡ podle ro├ä┬ìn├â┬¡ho obdob├â┬¡: Jaro 0,8x, L├â┬®to 1,0x, Podzim 1,2x, Zima 0,7x]]></cz>
+            <br><![CDATA[A renda varia por esta├â┬º├â┬úo: Primavera 0,8x, Ver├â┬úo 1,0x, Outono 1,2x, Inverno 0,7x]]></br>
+            <uk><![CDATA[├ÉÔÇØ├É┬¥├æÔÇª├æÔÇô├É┬┤ ├É┬À├É┬╝├æÔÇô├É┬¢├æ┼¢├æÔÇØ├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├É┬À├É┬░ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¥├É┬╝: ├ÉÔÇÖ├É┬Á├æ┬ü├É┬¢├É┬░ 0,8x, ├ÉÔÇ║├æÔÇô├æÔÇÜ├É┬¥ 1,0x, ├É┼¥├æ┬ü├æÔÇô├É┬¢├æ┼Æ 1,2x, ├ÉÔÇö├É┬©├É┬╝├É┬░ 0,7x]]></uk>
+            <ru><![CDATA[├ÉÔÇØ├É┬¥├æÔÇª├É┬¥├É┬┤ ├É┬╝├É┬Á├É┬¢├æ┬Å├É┬Á├æÔÇÜ├æ┬ü├æ┬Å ├É┬┐├É┬¥ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬░├É┬╝: ├ÉÔÇÖ├É┬Á├æ┬ü├É┬¢├É┬░ 0,8x, ├ÉÔÇ║├É┬Á├æÔÇÜ├É┬¥ 1,0x, ├É┼¥├æ┬ü├É┬Á├É┬¢├æ┼Æ 1,2x, ├ÉÔÇö├É┬©├É┬╝├É┬░ 0,7x]]></ru>
+            <da><![CDATA[Inkomst varierer efter s├â┬ªson: For├â┬Ñr 0,8x, Sommer 1,0x, Efter├â┬Ñr 1,2x, Vinter 0,7x]]></da>
         </text>
 
         <!-- Show HUD -->
@@ -416,13 +416,13 @@
             <en><![CDATA[Show Income HUD]]></en>
             <de><![CDATA[Einkommens-HUD anzeigen]]></de>
             <fr><![CDATA[Afficher l'HUD de revenu]]></fr>
-            <pl><![CDATA[Pokaâ”œÃ â”¬â• HUD dochodu]]></pl>
+            <pl><![CDATA[Poka├à┬╝ HUD dochodu]]></pl>
             <es><![CDATA[Mostrar HUD de ingresos]]></es>
             <it><![CDATA[Mostra HUD reddito]]></it>
-            <cz><![CDATA[Zobrazit HUD pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â»]]></cz>
+            <cz><![CDATA[Zobrazit HUD p├àÔäó├â┬¡jm├à┬»]]></cz>
             <br><![CDATA[Mostrar HUD de renda]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© HUD â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† HUD â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
+            <uk><![CDATA[├É┼©├É┬¥├É┬║├É┬░├É┬À├É┬░├æÔÇÜ├É┬© HUD ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
+            <ru><![CDATA[├É┼©├É┬¥├É┬║├É┬░├É┬À├É┬░├æÔÇÜ├æ┼Æ HUD ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
             <da><![CDATA[Vis inkomst-HUD]]></da>
         </text>
 
@@ -430,14 +430,14 @@
             <en><![CDATA[Show the income HUD overlay with current income, payment method, and history (toggle with I key)]]></en>
             <de><![CDATA[Einkommens-HUD mit Einkommen, Zahlungsart und Verlauf anzeigen (mit Taste I umschalten)]]></de>
             <fr><![CDATA[Afficher l'HUD avec les revenus actuels, le mode de paiement et l'historique (touche I)]]></fr>
-            <pl><![CDATA[Pokaâ”œÃ â”¬â• nakâ”œÃ Ã”Ã‡Ãœadkâ”œÃ¤Ã”Ã¤Ã³ HUD z bieâ”œÃ â”¬â•â”œÃ¤Ã”Ã‡Âªcym dochodem, trybem pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci i historiâ”œÃ¤Ã”Ã‡Âª (klawisz I)]]></pl>
-            <es><![CDATA[Mostrar HUD con ingresos actuales, mâ”œÃ¢â”¬Â®todo de pago e historial (tecla I)]]></es>
+            <pl><![CDATA[Poka├à┬╝ nak├àÔÇÜadk├äÔäó HUD z bie├à┬╝├äÔÇªcym dochodem, trybem p├àÔÇÜatno├àÔÇ║ci i histori├äÔÇª (klawisz I)]]></pl>
+            <es><![CDATA[Mostrar HUD con ingresos actuales, m├â┬®todo de pago e historial (tecla I)]]></es>
             <it><![CDATA[Mostra l'HUD con reddito corrente, metodo di pagamento e cronologia (tasto I)]]></it>
-            <cz><![CDATA[Zobrazit HUD s aktuâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡mi pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmy, zpâ”œÃ â”¬Â»sobem platby a historiâ”œÃ¢â”¬Â¡ (klâ”œÃ¢â”¬Ã­vesa I)]]></cz>
-            <br><![CDATA[Mostrar HUD com renda atual, mâ”œÃ¢â”¬Â®todo de pagamento e histâ”œÃ¢â”¬â”‚rico (tecla I)]]></br>
-            <da><![CDATA[Vis inkomst-HUD med nuvâ”œÃ¢â”¬Âªrende inkomst, betalingsmetode og historik (skift med tasten I)]]></da>
-            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© HUD â”œÃ‰â”¬Ã€ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•, â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â• â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦â”¼Â¢ (â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘ I)]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† HUD â”œÃ¦â”¬Ã¼ â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ‰â”¬â• â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬Â© â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•£ (â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘ I)]]></ru>
+            <cz><![CDATA[Zobrazit HUD s aktu├â┬íln├â┬¡mi p├àÔäó├â┬¡jmy, zp├à┬»sobem platby a histori├â┬¡ (kl├â┬ívesa I)]]></cz>
+            <br><![CDATA[Mostrar HUD com renda atual, m├â┬®todo de pagamento e hist├â┬│rico (tecla I)]]></br>
+            <da><![CDATA[Vis inkomst-HUD med nuv├â┬ªrende inkomst, betalingsmetode og historik (skift med tasten I)]]></da>
+            <uk><![CDATA[├É┼©├É┬¥├É┬║├É┬░├É┬À├É┬░├æÔÇÜ├É┬© HUD ├É┬À ├É┬┐├É┬¥├æÔÇÜ├É┬¥├æÔÇí├É┬¢├É┬©├É┬╝ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬¥├É┬╝, ├É┬╝├É┬Á├æÔÇÜ├É┬¥├É┬┤├É┬¥├É┬╝ ├É┬¥├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬© ├æÔÇÜ├É┬░ ├æÔÇô├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├æÔÇô├æÔÇØ├æ┼¢ (├É┬║├É┬╗├É┬░├É┬▓├æÔÇô├æ╦å├É┬░ I)]]></uk>
+            <ru><![CDATA[├É┼©├É┬¥├É┬║├É┬░├É┬À├É┬░├æÔÇÜ├æ┼Æ HUD ├æ┬ü ├æÔÇÜ├É┬Á├É┬║├æãÆ├æÔÇ░├É┬©├É┬╝ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬¥├É┬╝, ├æ┬ü├É┬┐├É┬¥├æ┬ü├É┬¥├É┬▒├É┬¥├É┬╝ ├É┬¥├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣ ├É┬© ├É┬©├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├É┬©├É┬Á├É┬╣ (├É┬║├É┬╗├É┬░├É┬▓├É┬©├æ╦å├É┬░ I)]]></ru>
         </text>
 
         <!-- HUD toggle key binding display name -->
@@ -445,29 +445,29 @@
             <en><![CDATA[Toggle Income HUD]]></en>
             <de><![CDATA[Einkommens-HUD umschalten]]></de>
             <fr><![CDATA[Basculer l'HUD de revenu]]></fr>
-            <pl><![CDATA[Przeâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz HUD dochodu]]></pl>
+            <pl><![CDATA[Prze├àÔÇÜ├äÔÇªcz HUD dochodu]]></pl>
             <es><![CDATA[Alternar HUD de ingresos]]></es>
             <it><![CDATA[Attiva/disattiva HUD reddito]]></it>
-            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³epnout HUD pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â»]]></cz>
+            <cz><![CDATA[P├àÔäóepnout HUD p├àÔäó├â┬¡jm├à┬»]]></cz>
             <br><![CDATA[Alternar HUD de renda]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© HUD â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† HUD â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
+            <uk><![CDATA[├É┼©├É┬Á├æÔé¼├É┬Á├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© HUD ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
+            <ru><![CDATA[├É┼©├É┬Á├æÔé¼├É┬Á├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ HUD ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
             <da><![CDATA[Skift inkomst-HUD]]></da>
         </text>
 
         <!-- Income Report Dialog: key binding display name -->
         <text name="input_IM_INCOME_REPORT">
             <en><![CDATA[Open Income Report]]></en>
-            <de><![CDATA[Einkommensbericht â”œÃ¢â”¬Ã‚ffnen]]></de>
+            <de><![CDATA[Einkommensbericht ├â┬Âffnen]]></de>
             <fr><![CDATA[Ouvrir le rapport de revenu]]></fr>
-            <pl><![CDATA[Otwâ”œÃ¢â”¬â”‚rz raport dochodu]]></pl>
+            <pl><![CDATA[Otw├â┬│rz raport dochodu]]></pl>
             <es><![CDATA[Abrir informe de ingresos]]></es>
             <it><![CDATA[Apri rapporto reddito]]></it>
-            <cz><![CDATA[Otevâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡t pâ”œÃ Ã”Ã¤Ã³ehled pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â»]]></cz>
-            <br><![CDATA[Abrir relatâ”œÃ¢â”¬â”‚rio de renda]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã”Ã‡Ã¿â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª]]></ru>
-            <da><![CDATA[â”œÃ¢Ã”Ã‡Âªbn inkomstrapport]]></da>
+            <cz><![CDATA[Otev├àÔäó├â┬¡t p├àÔäóehled p├àÔäó├â┬¡jm├à┬»]]></cz>
+            <br><![CDATA[Abrir relat├â┬│rio de renda]]></br>
+            <uk><![CDATA[├ÉÔÇÖ├æÔÇô├É┬┤├É┬║├æÔé¼├É┬©├æÔÇÜ├É┬© ├É┬À├É┬▓├æÔÇô├æÔÇÜ ├É┬┐├æÔé¼├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬©]]></uk>
+            <ru><![CDATA[├É┼¥├æÔÇÜ├É┬║├æÔé¼├æÔÇ╣├æÔÇÜ├æ┼Æ ├É┬¥├æÔÇÜ├æÔÇí├æÔÇÿ├æÔÇÜ ├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░├æÔÇª]]></ru>
+            <da><![CDATA[├âÔÇªbn inkomstrapport]]></da>
         </text>
 
         <!-- Income Report Dialog: dialog title -->
@@ -478,10 +478,10 @@
             <pl><![CDATA[Raport dochodu]]></pl>
             <es><![CDATA[Informe de ingresos]]></es>
             <it><![CDATA[Rapporto reddito]]></it>
-            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³ehled pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â»]]></cz>
-            <br><![CDATA[Relatâ”œÃ¢â”¬â”‚rio de renda]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã”Ã‡Ã¿â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª]]></ru>
+            <cz><![CDATA[P├àÔäóehled p├àÔäó├â┬¡jm├à┬»]]></cz>
+            <br><![CDATA[Relat├â┬│rio de renda]]></br>
+            <uk><![CDATA[├ÉÔÇö├É┬▓├æÔÇô├æÔÇÜ ├É┬┐├æÔé¼├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬©]]></uk>
+            <ru><![CDATA[├É┼¥├æÔÇÜ├æÔÇí├æÔÇÿ├æÔÇÜ ├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░├æÔÇª]]></ru>
             <da><![CDATA[Inkomstrapport]]></da>
         </text>
 
@@ -495,8 +495,8 @@
             <it><![CDATA[Stato]]></it>
             <cz><![CDATA[Stav]]></cz>
             <br><![CDATA[Status]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ¦â”¬Ã¼]]></ru>
+            <uk><![CDATA[├É┬í├æÔÇÜ├É┬░├É┬¢]]></uk>
+            <ru><![CDATA[├É┬í├æÔÇÜ├É┬░├æÔÇÜ├æãÆ├æ┬ü]]></ru>
             <da><![CDATA[Status]]></da>
         </text>
 
@@ -506,39 +506,39 @@
             <fr><![CDATA[Mode]]></fr>
             <pl><![CDATA[Tryb]]></pl>
             <es><![CDATA[Modo]]></es>
-            <it><![CDATA[Modalitâ”œÃ¢â”¬Ã¡]]></it>
-            <cz><![CDATA[Reâ”œÃ â”¬Â¥im]]></cz>
+            <it><![CDATA[Modalit├â┬á]]></it>
+            <cz><![CDATA[Re├à┬¥im]]></cz>
             <br><![CDATA[Modo]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â•]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â•]]></ru>
+            <uk><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝]]></uk>
+            <ru><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝]]></ru>
             <da><![CDATA[Modus]]></da>
         </text>
 
         <text name="im_report_difficulty_label">
             <en><![CDATA[Difficulty]]></en>
             <de><![CDATA[Schwierigkeit]]></de>
-            <fr><![CDATA[Difficultâ”œÃ¢â”¬Â®]]></fr>
-            <pl><![CDATA[Trudnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­]]></pl>
+            <fr><![CDATA[Difficult├â┬®]]></fr>
+            <pl><![CDATA[Trudno├àÔÇ║├äÔÇí]]></pl>
             <es><![CDATA[Dificultad]]></es>
-            <it><![CDATA[Difficoltâ”œÃ¢â”¬Ã¡]]></it>
-            <cz><![CDATA[Obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nost]]></cz>
+            <it><![CDATA[Difficolt├â┬á]]></it>
+            <cz><![CDATA[Obt├â┬¡├à┬¥nost]]></cz>
             <br><![CDATA[Dificuldade]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†]]></ru>
-            <da><![CDATA[Svâ”œÃ¢â”¬Âªrhedsgrâ”œÃ¢â”¬Âªd]]></da>
+            <uk><![CDATA[├É┬í├É┬║├É┬╗├É┬░├É┬┤├É┬¢├æÔÇô├æ┬ü├æÔÇÜ├æ┼Æ]]></uk>
+            <ru><![CDATA[├É┬í├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æ┼Æ]]></ru>
+            <da><![CDATA[Sv├â┬ªrhedsgr├â┬ªd]]></da>
         </text>
 
         <text name="im_report_amount_label">
             <en><![CDATA[Payment]]></en>
             <de><![CDATA[Zahlung]]></de>
             <fr><![CDATA[Paiement]]></fr>
-            <pl><![CDATA[Pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­]]></pl>
+            <pl><![CDATA[P├àÔÇÜatno├àÔÇ║├äÔÇí]]></pl>
             <es><![CDATA[Pago]]></es>
             <it><![CDATA[Pagamento]]></it>
             <cz><![CDATA[Platba]]></cz>
             <br><![CDATA[Pagamento]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘]]></ru>
+            <uk><![CDATA[├ÉÔÇÖ├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░]]></uk>
+            <ru><![CDATA[├ÉÔÇÖ├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░]]></ru>
             <da><![CDATA[Betaling]]></da>
         </text>
 
@@ -546,13 +546,13 @@
             <en><![CDATA[Multiplier]]></en>
             <de><![CDATA[Multiplikator]]></de>
             <fr><![CDATA[Multiplicateur]]></fr>
-            <pl><![CDATA[Mnoâ”œÃ â”¬â•nik]]></pl>
+            <pl><![CDATA[Mno├à┬╝nik]]></pl>
             <es><![CDATA[Multiplicador]]></es>
             <it><![CDATA[Moltiplicatore]]></it>
-            <cz><![CDATA[Multiplikâ”œÃ¢â”¬Ã­tor]]></cz>
+            <cz><![CDATA[Multiplik├â┬ítor]]></cz>
             <br><![CDATA[Multiplicador]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†]]></ru>
+            <uk><![CDATA[├É┼ô├É┬¢├É┬¥├É┬Â├É┬¢├É┬©├É┬║]]></uk>
+            <ru><![CDATA[├É┼ô├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┼Æ]]></ru>
             <da><![CDATA[Multiplikator]]></da>
         </text>
 
@@ -563,54 +563,54 @@
             <pl><![CDATA[Sezonowe]]></pl>
             <es><![CDATA[Estacional]]></es>
             <it><![CDATA[Stagionale]]></it>
-            <cz><![CDATA[Sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡]]></cz>
+            <cz><![CDATA[Sez├â┬│nn├â┬¡]]></cz>
             <br><![CDATA[Sazonal]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ã]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã]]></ru>
-            <da><![CDATA[Sâ”œÃ¢â”¬Âªsonal]]></da>
+            <uk><![CDATA[├É┬í├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬Á]]></uk>
+            <ru><![CDATA[├É┬í├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬¥├É┬Á]]></ru>
+            <da><![CDATA[S├â┬ªsonal]]></da>
         </text>
 
         <!-- Income Report Dialog: stats labels -->
         <text name="im_report_total_label">
             <en><![CDATA[Total Earned]]></en>
             <de><![CDATA[Gesamtverdienst]]></de>
-            <fr><![CDATA[Total gagnâ”œÃ¢â”¬Â®]]></fr>
-            <pl><![CDATA[â”œÃ â”¬Ã¼â”œÃ¤Ã”Ã‡Âªcznie zarobiono]]></pl>
+            <fr><![CDATA[Total gagn├â┬®]]></fr>
+            <pl><![CDATA[├à┬ü├äÔÇªcznie zarobiono]]></pl>
             <es><![CDATA[Total ganado]]></es>
             <it><![CDATA[Totale guadagnato]]></it>
-            <cz><![CDATA[Celkem vydâ”œÃ¤Ã”Ã‡â•‘lâ”œÃ¢â”¬Ã­no]]></cz>
+            <cz><![CDATA[Celkem vyd├äÔÇ║l├â┬íno]]></cz>
             <br><![CDATA[Total ganho]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></ru>
+            <uk><![CDATA[├ÉÔÇÖ├æ┬ü├æ┼Æ├É┬¥├É┬│├É┬¥ ├É┬À├É┬░├æÔé¼├É┬¥├É┬▒├É┬╗├É┬Á├É┬¢├É┬¥]]></uk>
+            <ru><![CDATA[├ÉÔÇÖ├æ┬ü├É┬Á├É┬│├É┬¥ ├É┬À├É┬░├æÔé¼├É┬░├É┬▒├É┬¥├æÔÇÜ├É┬░├É┬¢├É┬¥]]></ru>
             <da><![CDATA[Totalt tjent]]></da>
         </text>
 
         <text name="im_report_avg_label">
             <en><![CDATA[Avg/Payment]]></en>
-            <de><![CDATA[â”œÃ¢â•¦Â£/Zahlung]]></de>
+            <de><![CDATA[├â╦£/Zahlung]]></de>
             <fr><![CDATA[Moy./Paiement]]></fr>
-            <pl><![CDATA[â”œÃ â”¼Ã­red./Pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­]]></pl>
+            <pl><![CDATA[├à┼íred./P├àÔÇÜatno├àÔÇ║├äÔÇí]]></pl>
             <es><![CDATA[Prom./Pago]]></es>
             <it><![CDATA[Media/Pag.]]></it>
-            <cz><![CDATA[Prâ”œÃ â”¬Â»mâ”œÃ¤Ã”Ã‡â•‘r/Platba]]></cz>
-            <br><![CDATA[Mâ”œÃ¢â”¬Â®dia/Pagto]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤./â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ¦Ã”Ã©Â¼./â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘]]></ru>
+            <cz><![CDATA[Pr├à┬»m├äÔÇ║r/Platba]]></cz>
+            <br><![CDATA[M├â┬®dia/Pagto]]></br>
+            <uk><![CDATA[├É┬í├É┬Á├æÔé¼├É┬Á├É┬┤./├ÉÔÇÖ├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░]]></uk>
+            <ru><![CDATA[├É┬í├æÔé¼./├ÉÔÇÖ├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░]]></ru>
             <da><![CDATA[Gennemsnitligt tjent]]></da>
         </text>
 
         <text name="im_report_next_label">
             <en><![CDATA[Next Payment]]></en>
-            <de><![CDATA[Nâ”œÃ¢â”¬Ã±chste Zahlung]]></de>
+            <de><![CDATA[N├â┬ñchste Zahlung]]></de>
             <fr><![CDATA[Prochain paiement]]></fr>
-            <pl><![CDATA[Nastâ”œÃ¤Ã”Ã¤Ã³pna pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­]]></pl>
-            <es><![CDATA[Prâ”œÃ¢â”¬â”‚ximo pago]]></es>
+            <pl><![CDATA[Nast├äÔäópna p├àÔÇÜatno├àÔÇ║├äÔÇí]]></pl>
+            <es><![CDATA[Pr├â┬│ximo pago]]></es>
             <it><![CDATA[Prossimo pagamento]]></it>
-            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡â”œÃ â”¬Ã­tâ”œÃ¢â”¬Â¡ platba]]></cz>
-            <br><![CDATA[Prâ”œÃ¢â”¬â”‚ximo pagamento]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â”â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã… â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘]]></ru>
-            <da><![CDATA[Nâ”œÃ¢â”¬Âªste betaling]]></da>
+            <cz><![CDATA[P├àÔäó├â┬¡├à┬ít├â┬¡ platba]]></cz>
+            <br><![CDATA[Pr├â┬│ximo pagamento]]></br>
+            <uk><![CDATA[├É┬Ø├É┬░├æ┬ü├æÔÇÜ├æãÆ├É┬┐├É┬¢├É┬░ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░]]></uk>
+            <ru><![CDATA[├É┬í├É┬╗├É┬Á├É┬┤├æãÆ├æ┼¢├æÔÇ░├É┬░├æ┬Å ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░]]></ru>
+            <da><![CDATA[N├â┬ªste betaling]]></da>
         </text>
 
         <!-- Income Report Dialog: table column headers -->
@@ -618,13 +618,13 @@
             <en><![CDATA[Day]]></en>
             <de><![CDATA[Tag]]></de>
             <fr><![CDATA[Jour]]></fr>
-            <pl><![CDATA[Dzieâ”œÃ Ã”Ã‡Ã—]]></pl>
-            <es><![CDATA[Dâ”œÃ¢â”¬Â¡a]]></es>
+            <pl><![CDATA[Dzie├àÔÇ×]]></pl>
+            <es><![CDATA[D├â┬¡a]]></es>
             <it><![CDATA[Giorno]]></it>
             <cz><![CDATA[Den]]></cz>
             <br><![CDATA[Dia]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã˜â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã˜â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†]]></ru>
+            <uk><![CDATA[├ÉÔÇØ├É┬Á├É┬¢├æ┼Æ]]></uk>
+            <ru><![CDATA[├ÉÔÇØ├É┬Á├É┬¢├æ┼Æ]]></ru>
             <da><![CDATA[Dag]]></da>
         </text>
 
@@ -635,10 +635,10 @@
             <pl><![CDATA[Godzina]]></pl>
             <es><![CDATA[Hora]]></es>
             <it><![CDATA[Ora]]></it>
-            <cz><![CDATA[â”œÃ¤â”¼Ã†as]]></cz>
+            <cz><![CDATA[├ä┼Æas]]></cz>
             <br><![CDATA[Hora]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Âºâ”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ¦â”¬Ã…]]></ru>
+            <uk><![CDATA[├É┬º├É┬░├æ┬ü]]></uk>
+            <ru><![CDATA[├ÉÔÇÖ├æÔé¼├É┬Á├É┬╝├æ┬Å]]></ru>
             <da><![CDATA[Tid]]></da>
         </text>
 
@@ -651,8 +651,8 @@
             <it><![CDATA[Tipo]]></it>
             <cz><![CDATA[Typ]]></cz>
             <br><![CDATA[Tipo]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã³â”œÃ‰â”¬Â©â”œÃ‰â”¬â”]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã³â”œÃ‰â”¬Â©â”œÃ‰â”¬â”]]></ru>
+            <uk><![CDATA[├É┬ó├É┬©├É┬┐]]></uk>
+            <ru><![CDATA[├É┬ó├É┬©├É┬┐]]></ru>
             <da><![CDATA[Type]]></da>
         </text>
 
@@ -663,11 +663,11 @@
             <pl><![CDATA[Kwota]]></pl>
             <es><![CDATA[Monto]]></es>
             <it><![CDATA[Importo]]></it>
-            <cz><![CDATA[â”œÃ¤â”¼Ã†â”œÃ¢â”¬Ã­stka]]></cz>
+            <cz><![CDATA[├ä┼Æ├â┬ístka]]></cz>
             <br><![CDATA[Valor]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘]]></ru>
-            <da><![CDATA[Belâ”œÃ¢â”¬Â©b]]></da>
+            <uk><![CDATA[├É┬í├æãÆ├É┬╝├É┬░]]></uk>
+            <ru><![CDATA[├É┬í├æãÆ├É┬╝├É┬╝├É┬░]]></ru>
+            <da><![CDATA[Bel├â┬©b]]></da>
         </text>
 
         <text name="im_report_col_seasonal">
@@ -677,141 +677,141 @@
             <pl><![CDATA[Sezonowe]]></pl>
             <es><![CDATA[Estacional]]></es>
             <it><![CDATA[Stagionale]]></it>
-            <cz><![CDATA[Sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡]]></cz>
+            <cz><![CDATA[Sez├â┬│nn├â┬¡]]></cz>
             <br><![CDATA[Sazonal]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ã]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã]]></ru>
-            <da><![CDATA[Sâ”œÃ¢â”¬Âªsonal]]></da>
+            <uk><![CDATA[├É┬í├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬Á]]></uk>
+            <ru><![CDATA[├É┬í├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬¥├É┬Á]]></ru>
+            <da><![CDATA[S├â┬ªsonal]]></da>
         </text>
 
         <!-- Income Report Dialog: no history message -->
         <text name="im_report_no_history">
             <en><![CDATA[No payment history yet. Income will be recorded after the first payment.]]></en>
             <de><![CDATA[Noch kein Zahlungsverlauf. Einkommen wird nach der ersten Zahlung aufgezeichnet.]]></de>
-            <fr><![CDATA[Pas encore d'historique de paiement. Les revenus seront enregistrâ”œÃ¢â”¬Â®s aprâ”œÃ¢â”¬Â¿s le premier paiement.]]></fr>
-            <pl><![CDATA[Brak historii pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci. Dochâ”œÃ¢â”¬â”‚d zostanie zarejestrowany po pierwszej pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci.]]></pl>
-            <es><![CDATA[Aâ”œÃ¢â”¬â•‘n no hay historial de pagos. Los ingresos se registrarâ”œÃ¢â”¬Ã­n despuâ”œÃ¢â”¬Â®s del primer pago.]]></es>
+            <fr><![CDATA[Pas encore d'historique de paiement. Les revenus seront enregistr├â┬®s apr├â┬¿s le premier paiement.]]></fr>
+            <pl><![CDATA[Brak historii p├àÔÇÜatno├àÔÇ║ci. Doch├â┬│d zostanie zarejestrowany po pierwszej p├àÔÇÜatno├àÔÇ║ci.]]></pl>
+            <es><![CDATA[A├â┬║n no hay historial de pagos. Los ingresos se registrar├â┬ín despu├â┬®s del primer pago.]]></es>
             <it><![CDATA[Nessuna cronologia pagamenti. I ricavi verranno registrati dopo il primo pagamento.]]></it>
-            <cz><![CDATA[Zatâ”œÃ¢â”¬Â¡m â”œÃ â”¬Â¥â”œÃ¢â”¬Ã­dnâ”œÃ¢â”¬Ã­ historie plateb. Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem bude zaznamenâ”œÃ¢â”¬Ã­n po prvnâ”œÃ¢â”¬Â¡ platbâ”œÃ¤Ã”Ã‡â•‘.]]></cz>
-            <br><![CDATA[Sem histâ”œÃ¢â”¬â”‚rico de pagamentos. A renda serâ”œÃ¢â”¬Ã­ registrada apâ”œÃ¢â”¬â”‚s o primeiro pagamento.]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Â®â”œÃ‰â”¬Ã â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜ â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ã¶ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ. â”œÃ‰Ã”Ã‡Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â–’â”œÃ¦Ã£Ã†â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ã â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã¶ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©.]]></uk>
-            <ru><![CDATA[â”œÃ‰â•¦Â£â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ. â”œÃ‰Ã”Ã‡Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â–’â”œÃ¦Ã£Ã†â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ã â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£.]]></ru>
-            <da><![CDATA[Ingen betalingshistorik endnu. Indkomst vil blive registreret efter den fâ”œÃ¢â”¬Â©rste betaling.]]></da>
+            <cz><![CDATA[Zat├â┬¡m ├à┬¥├â┬ídn├â┬í historie plateb. P├àÔäó├â┬¡jem bude zaznamen├â┬ín po prvn├â┬¡ platb├äÔÇ║.]]></cz>
+            <br><![CDATA[Sem hist├â┬│rico de pagamentos. A renda ser├â┬í registrada ap├â┬│s o primeiro pagamento.]]></br>
+            <uk><![CDATA[├É┬®├É┬Á ├É┬¢├É┬Á├É┬╝├É┬░├æÔÇØ ├æÔÇô├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├æÔÇô├æÔÇö ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ. ├ÉÔÇØ├É┬¥├æÔÇª├æÔÇô├É┬┤ ├É┬▒├æãÆ├É┬┤├É┬Á ├É┬À├É┬░├É┬┐├É┬©├æ┬ü├É┬░├É┬¢├É┬¥ ├É┬┐├æÔÇô├æ┬ü├É┬╗├æ┬Å ├É┬┐├É┬Á├æÔé¼├æ╦å├É┬¥├æÔÇö ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬©.]]></uk>
+            <ru><![CDATA[├É╦£├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├É┬©├É┬© ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ ├É┬┐├É┬¥├É┬║├É┬░ ├É┬¢├É┬Á├æÔÇÜ. ├ÉÔÇØ├É┬¥├æÔÇª├É┬¥├É┬┤ ├É┬▒├æãÆ├É┬┤├É┬Á├æÔÇÜ ├É┬À├É┬░├É┬┐├É┬©├æ┬ü├É┬░├É┬¢ ├É┬┐├É┬¥├æ┬ü├É┬╗├É┬Á ├É┬┐├É┬Á├æÔé¼├É┬▓├É┬¥├É┬╣ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣.]]></ru>
+            <da><![CDATA[Ingen betalingshistorik endnu. Indkomst vil blive registreret efter den f├â┬©rste betaling.]]></da>
         </text>
 
         <!-- Income Report Dialog: enabled/disabled status values -->
         <text name="im_report_enabled">
             <en><![CDATA[Enabled]]></en>
             <de><![CDATA[Aktiviert]]></de>
-            <fr><![CDATA[Activâ”œÃ¢â”¬Â®]]></fr>
-            <pl><![CDATA[Wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczone]]></pl>
+            <fr><![CDATA[Activ├â┬®]]></fr>
+            <pl><![CDATA[W├àÔÇÜ├äÔÇªczone]]></pl>
             <es><![CDATA[Activado]]></es>
             <it><![CDATA[Attivato]]></it>
             <cz><![CDATA[Povoleno]]></cz>
             <br><![CDATA[Ativado]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></ru>
+            <uk><![CDATA[├É┬ú├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├É┬Á├É┬¢├É┬¥]]></uk>
+            <ru><![CDATA[├ÉÔÇÖ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬¢├É┬¥]]></ru>
             <da><![CDATA[Aktiveret]]></da>
         </text>
 
         <text name="im_report_disabled">
             <en><![CDATA[Disabled]]></en>
             <de><![CDATA[Deaktiviert]]></de>
-            <fr><![CDATA[Dâ”œÃ¢â”¬Â®sactivâ”œÃ¢â”¬Â®]]></fr>
-            <pl><![CDATA[Wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczone]]></pl>
+            <fr><![CDATA[D├â┬®sactiv├â┬®]]></fr>
+            <pl><![CDATA[Wy├àÔÇÜ├äÔÇªczone]]></pl>
             <es><![CDATA[Desactivado]]></es>
             <it><![CDATA[Disattivato]]></it>
-            <cz><![CDATA[Zakâ”œÃ¢â”¬Ã­zâ”œÃ¢â”¬Ã­no]]></cz>
+            <cz><![CDATA[Zak├â┬íz├â┬íno]]></cz>
             <br><![CDATA[Desativado]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></ru>
+            <uk><![CDATA[├ÉÔÇÖ├É┬©├É┬╝├É┬║├É┬¢├É┬Á├É┬¢├É┬¥]]></uk>
+            <ru><![CDATA[├ÉÔÇÖ├æÔÇ╣├É┬║├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬¢├É┬¥]]></ru>
             <da><![CDATA[Deaktiveret]]></da>
         </text>
 
         <!-- Reset -->
         <text name="im_reset">
             <en><![CDATA[Reset Income Settings]]></en>
-            <de><![CDATA[Einkommenseinstellungen zurâ”œÃ¢â”¬â•cksetzen]]></de>
-            <fr><![CDATA[Râ”œÃ¢â”¬Â®initialiser les paramâ”œÃ¢â”¬Â¿tres de revenu]]></fr>
+            <de><![CDATA[Einkommenseinstellungen zur├â┬╝cksetzen]]></de>
+            <fr><![CDATA[R├â┬®initialiser les param├â┬¿tres de revenu]]></fr>
             <pl><![CDATA[Resetuj ustawienia dochodu]]></pl>
             <es><![CDATA[Restablecer config. ingresos]]></es>
             <it><![CDATA[Ripristina impostazioni reddito]]></it>
-            <cz><![CDATA[Resetovat nastavenâ”œÃ¢â”¬Â¡ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmu]]></cz>
-            <br><![CDATA[Restaurar configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães de renda]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
+            <cz><![CDATA[Resetovat nastaven├â┬¡ p├àÔäó├â┬¡jmu]]></cz>
+            <br><![CDATA[Restaurar configura├â┬º├â┬Áes de renda]]></br>
+            <uk><![CDATA[├É┬í├É┬║├É┬©├É┬¢├æãÆ├æÔÇÜ├É┬© ├É┬¢├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
+            <ru><![CDATA[├É┬í├É┬▒├æÔé¼├É┬¥├æ┬ü├É┬©├æÔÇÜ├æ┼Æ ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬© ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
             <da><![CDATA[Reset indkomstindstillinger]]></da>
         </text>
 
-        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Category titles â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
+        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Category titles ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
         <text name="im_help_cat_overview">
-            <en><![CDATA[Income Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Overview]]></en>
-            <de><![CDATA[Einkommens-Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ¢â”¼Ã´bersicht]]></de>
-            <fr><![CDATA[Mod de revenu â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Vue d'ensemble]]></fr>
-            <pl><![CDATA[Mod dochodâ”œÃ¢â”¬â”‚w â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Przeglâ”œÃ¤Ã”Ã‡Âªd]]></pl>
-            <es><![CDATA[Mod de ingresos â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Resumen]]></es>
-            <it><![CDATA[Mod reddito â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Panoramica]]></it>
-            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Pâ”œÃ Ã”Ã¤Ã³ehled]]></cz>
-            <br><![CDATA[Mod de renda â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Visâ”œÃ¢â”¬Ãºo geral]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã† â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¼Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ‰â”¬â”¤]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼]]></ru>
-            <da><![CDATA[Income Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Oversigt]]></da>
+            <en><![CDATA[Income Mod ├óÔé¼ÔÇØ Overview]]></en>
+            <de><![CDATA[Einkommens-Mod ├óÔé¼ÔÇØ ├â┼ôbersicht]]></de>
+            <fr><![CDATA[Mod de revenu ├óÔé¼ÔÇØ Vue d'ensemble]]></fr>
+            <pl><![CDATA[Mod dochod├â┬│w ├óÔé¼ÔÇØ Przegl├äÔÇªd]]></pl>
+            <es><![CDATA[Mod de ingresos ├óÔé¼ÔÇØ Resumen]]></es>
+            <it><![CDATA[Mod reddito ├óÔé¼ÔÇØ Panoramica]]></it>
+            <cz><![CDATA[P├àÔäó├â┬¡jmov├â┬¢ mod ├óÔé¼ÔÇØ P├àÔäóehled]]></cz>
+            <br><![CDATA[Mod de renda ├óÔé¼ÔÇØ Vis├â┬úo geral]]></br>
+            <uk><![CDATA[├É┼ô├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ ├óÔé¼ÔÇØ ├É┼¥├É┬│├É┬╗├æ┬Å├É┬┤]]></uk>
+            <ru><![CDATA[├É┼ô├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░ ├óÔé¼ÔÇØ ├É┼¥├É┬▒├É┬À├É┬¥├æÔé¼]]></ru>
+            <da><![CDATA[Income Mod ├óÔé¼ÔÇØ Oversigt]]></da>
         </text>
 
         <text name="im_help_cat_settings">
-            <en><![CDATA[Income Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Settings]]></en>
-            <de><![CDATA[Einkommens-Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Einstellungen]]></de>
-            <fr><![CDATA[Mod de revenu â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Paramâ”œÃ¢â”¬Â¿tres]]></fr>
-            <pl><![CDATA[Mod dochodâ”œÃ¢â”¬â”‚w â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Ustawienia]]></pl>
-            <es><![CDATA[Mod de ingresos â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Ajustes]]></es>
-            <it><![CDATA[Mod reddito â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Impostazioni]]></it>
-            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Nastavenâ”œÃ¢â”¬Â¡]]></cz>
-            <br><![CDATA[Mod de renda â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã† â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©]]></ru>
-            <da><![CDATA[Inkomst Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Indstillinger]]></da>
+            <en><![CDATA[Income Mod ├óÔé¼ÔÇØ Settings]]></en>
+            <de><![CDATA[Einkommens-Mod ├óÔé¼ÔÇØ Einstellungen]]></de>
+            <fr><![CDATA[Mod de revenu ├óÔé¼ÔÇØ Param├â┬¿tres]]></fr>
+            <pl><![CDATA[Mod dochod├â┬│w ├óÔé¼ÔÇØ Ustawienia]]></pl>
+            <es><![CDATA[Mod de ingresos ├óÔé¼ÔÇØ Ajustes]]></es>
+            <it><![CDATA[Mod reddito ├óÔé¼ÔÇØ Impostazioni]]></it>
+            <cz><![CDATA[P├àÔäó├â┬¡jmov├â┬¢ mod ├óÔé¼ÔÇØ Nastaven├â┬¡]]></cz>
+            <br><![CDATA[Mod de renda ├óÔé¼ÔÇØ Configura├â┬º├â┬Áes]]></br>
+            <uk><![CDATA[├É┼ô├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ ├óÔé¼ÔÇØ ├É┬Ø├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å]]></uk>
+            <ru><![CDATA[├É┼ô├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░ ├óÔé¼ÔÇØ ├É┬Ø├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬©]]></ru>
+            <da><![CDATA[Inkomst Mod ├óÔé¼ÔÇØ Indstillinger]]></da>
         </text>
 
         <text name="im_help_cat_tips">
-            <en><![CDATA[Income Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tips & Tricks]]></en>
-            <de><![CDATA[Einkommens-Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tipps & Tricks]]></de>
-            <fr><![CDATA[Mod de revenu â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Astuces]]></fr>
-            <pl><![CDATA[Mod dochodâ”œÃ¢â”¬â”‚w â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Porady i sztuczki]]></pl>
-            <es><![CDATA[Mod de ingresos â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Consejos]]></es>
-            <it><![CDATA[Mod reddito â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Consigli]]></it>
-            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tipy a triky]]></cz>
-            <br><![CDATA[Mod de renda â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Dicas e truques]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã† â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£]]></ru>
-            <da><![CDATA[Inkomst Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tips & Tricks]]></da>
+            <en><![CDATA[Income Mod ├óÔé¼ÔÇØ Tips & Tricks]]></en>
+            <de><![CDATA[Einkommens-Mod ├óÔé¼ÔÇØ Tipps & Tricks]]></de>
+            <fr><![CDATA[Mod de revenu ├óÔé¼ÔÇØ Astuces]]></fr>
+            <pl><![CDATA[Mod dochod├â┬│w ├óÔé¼ÔÇØ Porady i sztuczki]]></pl>
+            <es><![CDATA[Mod de ingresos ├óÔé¼ÔÇØ Consejos]]></es>
+            <it><![CDATA[Mod reddito ├óÔé¼ÔÇØ Consigli]]></it>
+            <cz><![CDATA[P├àÔäó├â┬¡jmov├â┬¢ mod ├óÔé¼ÔÇØ Tipy a triky]]></cz>
+            <br><![CDATA[Mod de renda ├óÔé¼ÔÇØ Dicas e truques]]></br>
+            <uk><![CDATA[├É┼ô├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ ├óÔé¼ÔÇØ ├É┼©├É┬¥├æÔé¼├É┬░├É┬┤├É┬©]]></uk>
+            <ru><![CDATA[├É┼ô├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░ ├óÔé¼ÔÇØ ├É┬í├É┬¥├É┬▓├É┬Á├æÔÇÜ├æÔÇ╣]]></ru>
+            <da><![CDATA[Inkomst Mod ├óÔé¼ÔÇØ Tips & Tricks]]></da>
         </text>
 
         <text name="im_help_cat_info">
             <en><![CDATA[About Income Mod]]></en>
-            <de><![CDATA[â”œÃ¢â”¼Ã´ber Einkommens-Mod]]></de>
-            <fr><![CDATA[â”œÃ¢Ã”Ã©Â¼ propos d'Income Mod]]></fr>
+            <de><![CDATA[├â┼ôber Einkommens-Mod]]></de>
+            <fr><![CDATA[├âÔé¼ propos d'Income Mod]]></fr>
             <pl><![CDATA[O Income Mod]]></pl>
             <es><![CDATA[Acerca de Income Mod]]></es>
             <it><![CDATA[Informazioni su Income Mod]]></it>
             <cz><![CDATA[O Income Modu]]></cz>
             <br><![CDATA[Sobre o Income Mod]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ Income Mod]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’ Income Mod]]></ru>
+            <uk><![CDATA[├É┼©├æÔé¼├É┬¥ Income Mod]]></uk>
+            <ru><![CDATA[├É┼¥├É┬▒ Income Mod]]></ru>
             <da><![CDATA[Om Inkomst Mod]]></da>
         </text>
 
-        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page titles â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
+        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page titles ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
         <text name="im_help_p1_title">
             <en><![CDATA[Introduction]]></en>
-            <de><![CDATA[Einfâ”œÃ¢â”¬â•hrung]]></de>
+            <de><![CDATA[Einf├â┬╝hrung]]></de>
             <fr><![CDATA[Introduction]]></fr>
             <pl><![CDATA[Wprowadzenie]]></pl>
-            <es><![CDATA[Introducciâ”œÃ¢â”¬â”‚n]]></es>
+            <es><![CDATA[Introducci├â┬│n]]></es>
             <it><![CDATA[Introduzione]]></it>
-            <cz><![CDATA[â”œÃ¢â”¼Ã­vod]]></cz>
-            <br><![CDATA[Introduâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ãºo]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â”]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã]]></ru>
+            <cz><![CDATA[├â┼ívod]]></cz>
+            <br><![CDATA[Introdu├â┬º├â┬úo]]></br>
+            <uk><![CDATA[├ÉÔÇÖ├æ┬ü├æÔÇÜ├æãÆ├É┬┐]]></uk>
+            <ru><![CDATA[├ÉÔÇÖ├É┬▓├É┬Á├É┬┤├É┬Á├É┬¢├É┬©├É┬Á]]></ru>
             <da><![CDATA[Introduktion]]></da>
         </text>
 
@@ -819,55 +819,55 @@
             <en><![CDATA[How Payments Work]]></en>
             <de><![CDATA[Wie Zahlungen funktionieren]]></de>
             <fr><![CDATA[Fonctionnement des paiements]]></fr>
-            <pl><![CDATA[Jak dziaâ”œÃ Ã”Ã‡Ãœajâ”œÃ¤Ã”Ã‡Âª pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci]]></pl>
-            <es><![CDATA[Câ”œÃ¢â”¬â”‚mo funcionan los pagos]]></es>
+            <pl><![CDATA[Jak dzia├àÔÇÜaj├äÔÇª p├àÔÇÜatno├àÔÇ║ci]]></pl>
+            <es><![CDATA[C├â┬│mo funcionan los pagos]]></es>
             <it><![CDATA[Come funzionano i pagamenti]]></it>
-            <cz><![CDATA[Jak fungujâ”œÃ¢â”¬Â¡ platby]]></cz>
+            <cz><![CDATA[Jak funguj├â┬¡ platby]]></cz>
             <br><![CDATA[Como os pagamentos funcionam]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Â»â”œÃ‰â”¬â•‘ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã¡â”œÃ¦â”¼Â¢â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Ã­â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•‘ â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£]]></ru>
-            <da><![CDATA[Sâ”œÃ¢â”¬Ã‘dan fungerer betalinger]]></da>
+            <uk><![CDATA[├É┬»├É┬║ ├É┬┐├æÔé¼├É┬░├æÔÇá├æ┼¢├æ┼¢├æÔÇÜ├æ┼Æ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬©]]></uk>
+            <ru><![CDATA[├É┼í├É┬░├É┬║ ├æÔé¼├É┬░├É┬▒├É┬¥├æÔÇÜ├É┬░├æ┼¢├æÔÇÜ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣]]></ru>
+            <da><![CDATA[S├â┬Ñdan fungerer betalinger]]></da>
         </text>
 
         <text name="im_help_s1_title">
             <en><![CDATA[Income Settings]]></en>
             <de><![CDATA[Einkommenseinstellungen]]></de>
-            <fr><![CDATA[Paramâ”œÃ¢â”¬Â¿tres de revenu]]></fr>
+            <fr><![CDATA[Param├â┬¿tres de revenu]]></fr>
             <pl><![CDATA[Ustawienia dochodu]]></pl>
             <es><![CDATA[Ajustes de ingresos]]></es>
             <it><![CDATA[Impostazioni reddito]]></it>
-            <cz><![CDATA[Nastavenâ”œÃ¢â”¬Â¡ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmu]]></cz>
-            <br><![CDATA[Configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães de renda]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
+            <cz><![CDATA[Nastaven├â┬¡ p├àÔäó├â┬¡jmu]]></cz>
+            <br><![CDATA[Configura├â┬º├â┬Áes de renda]]></br>
+            <uk><![CDATA[├É┬Ø├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
+            <ru><![CDATA[├É┬Ø├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬© ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
             <da><![CDATA[Inkomstindstillinger]]></da>
         </text>
 
         <text name="im_help_s2_title">
             <en><![CDATA[Advanced Settings]]></en>
             <de><![CDATA[Erweiterte Einstellungen]]></de>
-            <fr><![CDATA[Paramâ”œÃ¢â”¬Â¿tres avancâ”œÃ¢â”¬Â®s]]></fr>
+            <fr><![CDATA[Param├â┬¿tres avanc├â┬®s]]></fr>
             <pl><![CDATA[Ustawienia zaawansowane]]></pl>
             <es><![CDATA[Ajustes avanzados]]></es>
             <it><![CDATA[Impostazioni avanzate]]></it>
-            <cz><![CDATA[Rozâ”œÃ â”¬Ã­â”œÃ¢â”¬Â¡â”œÃ Ã”Ã¤Ã³enâ”œÃ¢â”¬Ã­ nastavenâ”œÃ¢â”¬Â¡]]></cz>
-            <br><![CDATA[Configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães avanâ”œÃ¢â”¬Âºadas]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã€â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬Ã â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©]]></ru>
+            <cz><![CDATA[Roz├à┬í├â┬¡├àÔäóen├â┬í nastaven├â┬¡]]></cz>
+            <br><![CDATA[Configura├â┬º├â┬Áes avan├â┬ºadas]]></br>
+            <uk><![CDATA[├É┬á├É┬¥├É┬À├æ╦å├É┬©├æÔé¼├É┬Á├É┬¢├æÔÇô ├É┬¢├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å]]></uk>
+            <ru><![CDATA[├É┬á├É┬░├æ┬ü├æ╦å├É┬©├æÔé¼├É┬Á├É┬¢├É┬¢├æÔÇ╣├É┬Á ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬©]]></ru>
             <da><![CDATA[Avancerede indstillinger]]></da>
         </text>
 
         <text name="im_help_s3_title">
             <en><![CDATA[Display & Reset]]></en>
-            <de><![CDATA[Anzeige & Zurâ”œÃ¢â”¬â•cksetzen]]></de>
-            <fr><![CDATA[Affichage & Râ”œÃ¢â”¬Â®initialisation]]></fr>
-            <pl><![CDATA[Wyâ”œÃ Ã”Ã‡â•‘wietlanie i reset]]></pl>
+            <de><![CDATA[Anzeige & Zur├â┬╝cksetzen]]></de>
+            <fr><![CDATA[Affichage & R├â┬®initialisation]]></fr>
+            <pl><![CDATA[Wy├àÔÇ║wietlanie i reset]]></pl>
             <es><![CDATA[Pantalla y restablecer]]></es>
             <it><![CDATA[Visualizzazione e reset]]></it>
-            <cz><![CDATA[Zobrazenâ”œÃ¢â”¬Â¡ a reset]]></cz>
-            <br><![CDATA[Exibiâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ãºo e redefiniâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ãºo]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼]]></ru>
+            <cz><![CDATA[Zobrazen├â┬¡ a reset]]></cz>
+            <br><![CDATA[Exibi├â┬º├â┬úo e redefini├â┬º├â┬úo]]></br>
+            <uk><![CDATA[├ÉÔÇÖ├æÔÇô├É┬┤├É┬¥├É┬▒├æÔé¼├É┬░├É┬Â├É┬Á├É┬¢├É┬¢├æ┬Å ├æÔÇÜ├É┬░ ├æ┬ü├É┬║├É┬©├É┬┤├É┬░├É┬¢├É┬¢├æ┬Å]]></uk>
+            <ru><![CDATA[├É┼¥├æÔÇÜ├É┬¥├É┬▒├æÔé¼├É┬░├É┬Â├É┬Á├É┬¢├É┬©├É┬Á ├É┬© ├æ┬ü├É┬▒├æÔé¼├É┬¥├æ┬ü]]></ru>
             <da><![CDATA[Visning og nulstilling]]></da>
         </text>
 
@@ -878,10 +878,10 @@
             <pl><![CDATA[HUD i raport dochodu]]></pl>
             <es><![CDATA[HUD e informe de ingresos]]></es>
             <it><![CDATA[HUD e rapporto reddito]]></it>
-            <cz><![CDATA[HUD a pâ”œÃ Ã”Ã¤Ã³ehled pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â»]]></cz>
-            <br><![CDATA[HUD e relatâ”œÃ¢â”¬â”‚rio de renda]]></br>
-            <uk><![CDATA[HUD â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©]]></uk>
-            <ru><![CDATA[HUD â”œÃ‰â”¬Â© â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã”Ã‡Ã¿â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª]]></ru>
+            <cz><![CDATA[HUD a p├àÔäóehled p├àÔäó├â┬¡jm├à┬»]]></cz>
+            <br><![CDATA[HUD e relat├â┬│rio de renda]]></br>
+            <uk><![CDATA[HUD ├æÔÇÜ├É┬░ ├É┬À├É┬▓├æÔÇô├æÔÇÜ ├É┬┐├æÔé¼├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬©]]></uk>
+            <ru><![CDATA[HUD ├É┬© ├É┬¥├æÔÇÜ├æÔÇí├æÔÇÿ├æÔÇÜ ├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░├æÔÇª]]></ru>
             <da><![CDATA[HUD og inkomstrapport]]></da>
         </text>
 
@@ -889,57 +889,57 @@
             <en><![CDATA[Income Tips]]></en>
             <de><![CDATA[Einkommenstipps]]></de>
             <fr><![CDATA[Conseils sur les revenus]]></fr>
-            <pl><![CDATA[Porady dotyczâ”œÃ¤Ã”Ã‡Âªce dochodu]]></pl>
+            <pl><![CDATA[Porady dotycz├äÔÇªce dochodu]]></pl>
             <es><![CDATA[Consejos de ingresos]]></es>
             <it><![CDATA[Consigli sul reddito]]></it>
-            <cz><![CDATA[Tipy pro pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem]]></cz>
+            <cz><![CDATA[Tipy pro p├àÔäó├â┬¡jem]]></cz>
             <br><![CDATA[Dicas de renda]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â© â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></ru>
+            <uk><![CDATA[├É┼©├É┬¥├æÔé¼├É┬░├É┬┤├É┬© ├æÔÇ░├É┬¥├É┬┤├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
+            <ru><![CDATA[├É┬í├É┬¥├É┬▓├É┬Á├æÔÇÜ├æÔÇ╣ ├É┬┐├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></ru>
             <da><![CDATA[Inkomst tips]]></da>
         </text>
 
         <text name="im_help_i1_title">
             <en><![CDATA[About Income Mod]]></en>
-            <de><![CDATA[â”œÃ¢â”¼Ã´ber Einkommens-Mod]]></de>
-            <fr><![CDATA[â”œÃ¢Ã”Ã©Â¼ propos d'Income Mod]]></fr>
+            <de><![CDATA[├â┼ôber Einkommens-Mod]]></de>
+            <fr><![CDATA[├âÔé¼ propos d'Income Mod]]></fr>
             <pl><![CDATA[O Income Mod]]></pl>
             <es><![CDATA[Acerca de Income Mod]]></es>
             <it><![CDATA[Informazioni su Income Mod]]></it>
             <cz><![CDATA[O Income Modu]]></cz>
             <br><![CDATA[Sobre o Income Mod]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ Income Mod]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’ Income Mod]]></ru>
+            <uk><![CDATA[├É┼©├æÔé¼├É┬¥ Income Mod]]></uk>
+            <ru><![CDATA[├É┼¥├É┬▒ Income Mod]]></ru>
             <da><![CDATA[Om Inkomst Mod]]></da>
         </text>
 
-        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page 1 â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Introduction â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
+        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page 1 ├óÔé¼ÔÇØ Introduction ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
         <text name="im_help_p1_what_title">
             <en><![CDATA[What Is Income Mod?]]></en>
             <de><![CDATA[Was ist der Einkommens-Mod?]]></de>
             <fr><![CDATA[Qu'est-ce qu'Income Mod ?]]></fr>
             <pl><![CDATA[Czym jest Income Mod?]]></pl>
-            <es><![CDATA[â”œÃ©â”¬â”Quâ”œÃ¢â”¬Â® es Income Mod?]]></es>
-            <it><![CDATA[Cos'â”œÃ¢â”¬Â¿ Income Mod?]]></it>
+            <es><![CDATA[├é┬┐Qu├â┬® es Income Mod?]]></es>
+            <it><![CDATA[Cos'├â┬¿ Income Mod?]]></it>
             <cz><![CDATA[Co je Income Mod?]]></cz>
-            <br><![CDATA[O que â”œÃ¢â”¬Â® o Income Mod?]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Â®â”œÃ‰â”¬Â¥ â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•‘â”œÃ‰â”¬Ã Income Mod?]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Âºâ”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥ â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã Income Mod?]]></ru>
+            <br><![CDATA[O que ├â┬® o Income Mod?]]></br>
+            <uk><![CDATA[├É┬®├É┬¥ ├æÔÇÜ├É┬░├É┬║├É┬Á Income Mod?]]></uk>
+            <ru><![CDATA[├É┬º├æÔÇÜ├É┬¥ ├æÔÇÜ├É┬░├É┬║├É┬¥├É┬Á Income Mod?]]></ru>
             <da><![CDATA[ hvad er Inkomst Mod? ]]></da>
         </text>
 
         <text name="im_help_p1_what_text">
             <en><![CDATA[Income Mod adds a passive income system to your farm. Your farm automatically earns money each in-game hour or day. Perfect for early-game cash flow or a relaxed playthrough.]]></en>
-            <de><![CDATA[Der Einkommens-Mod fâ”œÃ¢â”¬â•gt Ihrem Betrieb ein passives Einkommenssystem hinzu. Ihr Betrieb verdient automatisch Geld jede Spielstunde oder jeden Tag. Ideal fâ”œÃ¢â”¬â•r den frâ”œÃ¢â”¬â•hen Spielstart oder entspanntes Spielen.]]></de>
-            <fr><![CDATA[Income Mod ajoute des revenus passifs â”œÃ¢â”¬Ã¡ votre ferme. Votre ferme gagne automatiquement de l'argent chaque heure ou jour de jeu. Idâ”œÃ¢â”¬Â®al pour le dâ”œÃ¢â”¬Â®but de partie ou une session dâ”œÃ¢â”¬Â®tendue.]]></fr>
-            <pl><![CDATA[Income Mod dodaje pasywny system dochodâ”œÃ¢â”¬â”‚w do Twojego gospodarstwa. Farma automatycznie zarabia pieniâ”œÃ¤Ã”Ã‡Âªdze co godzinâ”œÃ¤Ã”Ã¤Ã³ lub dzieâ”œÃ Ã”Ã‡Ã— gry. Idealne na poczâ”œÃ¤Ã”Ã‡Âªtku rozgrywki lub do relaksujâ”œÃ¤Ã”Ã‡Âªcej zabawy.]]></pl>
-            <es><![CDATA[Income Mod aâ”œÃ¢â”¬â–’ade ingresos pasivos a tu granja. Tu granja gana dinero automâ”œÃ¢â”¬Ã­ticamente cada hora o dâ”œÃ¢â”¬Â¡a de juego. Perfecto para el flujo de caja inicial o una partida relajada.]]></es>
+            <de><![CDATA[Der Einkommens-Mod f├â┬╝gt Ihrem Betrieb ein passives Einkommenssystem hinzu. Ihr Betrieb verdient automatisch Geld jede Spielstunde oder jeden Tag. Ideal f├â┬╝r den fr├â┬╝hen Spielstart oder entspanntes Spielen.]]></de>
+            <fr><![CDATA[Income Mod ajoute des revenus passifs ├â┬á votre ferme. Votre ferme gagne automatiquement de l'argent chaque heure ou jour de jeu. Id├â┬®al pour le d├â┬®but de partie ou une session d├â┬®tendue.]]></fr>
+            <pl><![CDATA[Income Mod dodaje pasywny system dochod├â┬│w do Twojego gospodarstwa. Farma automatycznie zarabia pieni├äÔÇªdze co godzin├äÔäó lub dzie├àÔÇ× gry. Idealne na pocz├äÔÇªtku rozgrywki lub do relaksuj├äÔÇªcej zabawy.]]></pl>
+            <es><![CDATA[Income Mod a├â┬▒ade ingresos pasivos a tu granja. Tu granja gana dinero autom├â┬íticamente cada hora o d├â┬¡a de juego. Perfecto para el flujo de caja inicial o una partida relajada.]]></es>
             <it><![CDATA[Income Mod aggiunge un reddito passivo alla tua fattoria. La fattoria guadagna denaro automaticamente ogni ora o giorno di gioco. Perfetto per supporto iniziale o gameplay rilassato.]]></it>
-            <cz><![CDATA[Income Mod pâ”œÃ Ã”Ã¤Ã³idâ”œÃ¢â”¬Ã­vâ”œÃ¢â”¬Ã­ pasivnâ”œÃ¢â”¬Â¡ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ systâ”œÃ¢â”¬Â®m na vaâ”œÃ â”¬Ã­i farmu. Farma automaticky vydâ”œÃ¤Ã”Ã‡â•‘lâ”œÃ¢â”¬Ã­vâ”œÃ¢â”¬Ã­ penâ”œÃ¢â”¬Â¡ze kaâ”œÃ â”¬Â¥dou hernâ”œÃ¢â”¬Â¡ hodinu nebo den. Ideâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡ pro poâ”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­teâ”œÃ¤â”¬Ã¬nâ”œÃ¢â”¬Â¡ podporu nebo uvolnâ”œÃ¤Ã”Ã‡â•‘nou hru.]]></cz>
-            <br><![CDATA[O Income Mod adiciona renda passiva â”œÃ¢â”¬Ã¡ sua fazenda. Sua fazenda ganha dinheiro automaticamente a cada hora ou dia de jogo. Perfeito para suporte inicial ou partida relaxada.]]></br>
-            <uk><![CDATA[Income Mod â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â”â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã¶ â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬Â©. â”œÃ‰â”¬Ã±â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†. â”œÃ‰Ã”Ã‡Ã¡â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã….]]></uk>
-            <ru><![CDATA[Income Mod â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã£Ã† â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†. â”œÃ‰â”¬Ã±â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â© â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£ â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼ â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†. â”œÃ‰â•¦Â£â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã….]]></ru>
-            <da><![CDATA[Indkomst mod tilfâ”œÃ¢â”¬Â©jer et passivt indkomstsystem til din gâ”œÃ¢â”¬Ã‘rd. Din gâ”œÃ¢â”¬Ã‘rd tjener automatisk penge hver time eller dag i spillet. Perfekt til tidligt spil eller en afslappet gennemspilning.]]></da>
+            <cz><![CDATA[Income Mod p├àÔäóid├â┬ív├â┬í pasivn├â┬¡ p├àÔäó├â┬¡jmov├â┬¢ syst├â┬®m na va├à┬íi farmu. Farma automaticky vyd├äÔÇ║l├â┬ív├â┬í pen├â┬¡ze ka├à┬¥dou hern├â┬¡ hodinu nebo den. Ide├â┬íln├â┬¡ pro po├ä┬ì├â┬íte├ä┬ìn├â┬¡ podporu nebo uvoln├äÔÇ║nou hru.]]></cz>
+            <br><![CDATA[O Income Mod adiciona renda passiva ├â┬á sua fazenda. Sua fazenda ganha dinheiro automaticamente a cada hora ou dia de jogo. Perfeito para suporte inicial ou partida relaxada.]]></br>
+            <uk><![CDATA[Income Mod ├É┬┤├É┬¥├É┬┤├É┬░├æÔÇØ ├É┬┐├É┬░├æ┬ü├É┬©├É┬▓├É┬¢├É┬©├É┬╣ ├É┬┤├É┬¥├æÔÇª├æÔÇô├É┬┤ ├É┬┤├É┬¥ ├É┬▓├É┬░├æ╦å├É┬¥├æÔÇö ├æÔÇ×├É┬Á├æÔé¼├É┬╝├É┬©. ├É┬ñ├É┬Á├æÔé¼├É┬╝├É┬░ ├É┬░├É┬▓├æÔÇÜ├É┬¥├É┬╝├É┬░├æÔÇÜ├É┬©├æÔÇí├É┬¢├É┬¥ ├É┬À├É┬░├æÔé¼├É┬¥├É┬▒├É┬╗├æ┬Å├æÔÇØ ├É┬│├æÔé¼├É┬¥├æ╦å├æÔÇô ├É┬║├É┬¥├É┬Â├É┬¢├æãÆ ├æÔÇô├É┬│├æÔé¼├É┬¥├É┬▓├æãÆ ├É┬│├É┬¥├É┬┤├É┬©├É┬¢├æãÆ ├É┬░├É┬▒├É┬¥ ├É┬┤├É┬Á├É┬¢├æ┼Æ. ├ÉÔÇá├É┬┤├É┬Á├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥ ├É┬┤├É┬╗├æ┬Å ├É┬┐├æÔÇô├É┬┤├æÔÇÜ├æÔé¼├É┬©├É┬╝├É┬║├É┬© ├É┬¢├É┬░ ├É┬┐├É┬¥├æÔÇí├É┬░├æÔÇÜ├É┬║├æãÆ ├É┬░├É┬▒├É┬¥ ├æ┬ü├É┬┐├É┬¥├É┬║├æÔÇô├É┬╣├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┐├æÔé¼├É┬¥├æÔÇª├É┬¥├É┬┤├É┬Â├É┬Á├É┬¢├É┬¢├æ┬Å.]]></uk>
+            <ru><![CDATA[Income Mod ├É┬┤├É┬¥├É┬▒├É┬░├É┬▓├É┬╗├æ┬Å├É┬Á├æÔÇÜ ├É┬┐├É┬░├æ┬ü├æ┬ü├É┬©├É┬▓├É┬¢├æÔÇ╣├É┬╣ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤ ├É┬¢├É┬░ ├É┬▓├É┬░├æ╦å├æãÆ ├æÔÇ×├É┬Á├æÔé¼├É┬╝├æãÆ. ├É┬ñ├É┬Á├æÔé¼├É┬╝├É┬░ ├É┬░├É┬▓├æÔÇÜ├É┬¥├É┬╝├É┬░├æÔÇÜ├É┬©├æÔÇí├É┬Á├æ┬ü├É┬║├É┬© ├É┬À├É┬░├æÔé¼├É┬░├É┬▒├É┬░├æÔÇÜ├æÔÇ╣├É┬▓├É┬░├É┬Á├æÔÇÜ ├É┬┤├É┬Á├É┬¢├æ┼Æ├É┬│├É┬© ├É┬║├É┬░├É┬Â├É┬┤├æÔÇ╣├É┬╣ ├É┬©├É┬│├æÔé¼├É┬¥├É┬▓├É┬¥├É┬╣ ├æÔÇí├É┬░├æ┬ü ├É┬©├É┬╗├É┬© ├É┬┤├É┬Á├É┬¢├æ┼Æ. ├É╦£├É┬┤├É┬Á├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥ ├É┬┤├É┬╗├æ┬Å ├É┬¢├É┬░├æÔÇí├É┬░├É┬╗├É┬░ ├É┬©├É┬│├æÔé¼├æÔÇ╣ ├É┬©├É┬╗├É┬© ├æ┬ü├É┬┐├É┬¥├É┬║├É┬¥├É┬╣├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┐├æÔé¼├É┬¥├æÔÇª├É┬¥├É┬Â├É┬┤├É┬Á├É┬¢├É┬©├æ┬Å.]]></ru>
+            <da><![CDATA[Indkomst mod tilf├â┬©jer et passivt indkomstsystem til din g├â┬Ñrd. Din g├â┬Ñrd tjener automatisk penge hver time eller dag i spillet. Perfekt til tidligt spil eller en afslappet gennemspilning.]]></da>
         </text>
 
         <text name="im_help_p1_mp_title">
@@ -949,196 +949,196 @@
             <pl><![CDATA[Wsparcie wieloosobowe]]></pl>
             <es><![CDATA[Soporte multijugador]]></es>
             <it><![CDATA[Supporto multigiocatore]]></it>
-            <cz><![CDATA[Podpora vâ”œÃ¢â”¬Â¡ce hrâ”œÃ¢â”¬Ã­â”œÃ¤â”¬Ã¬â”œÃ â”¬Â»]]></cz>
+            <cz><![CDATA[Podpora v├â┬¡ce hr├â┬í├ä┬ì├à┬»]]></cz>
             <br><![CDATA[Suporte multiplayer]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘]]></ru>
+            <uk><![CDATA[├É┼©├æÔÇô├É┬┤├æÔÇÜ├æÔé¼├É┬©├É┬╝├É┬║├É┬░ ├É┬╝├æãÆ├É┬╗├æ┼Æ├æÔÇÜ├É┬©├É┬┐├É┬╗├É┬Á├æÔÇØ├æÔé¼├É┬░]]></uk>
+            <ru><![CDATA[├É┼©├É┬¥├É┬┤├É┬┤├É┬Á├æÔé¼├É┬Â├É┬║├É┬░ ├É┬╝├æãÆ├É┬╗├æ┼Æ├æÔÇÜ├É┬©├É┬┐├É┬╗├É┬Á├É┬Á├æÔé¼├É┬░]]></ru>
             <da><![CDATA[Multiplayer Support]]></da>
         </text>
 
         <text name="im_help_p1_mp_text">
-            <en><![CDATA[Fully compatible with multiplayer. Only the server processes payments â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ income is never duplicated. Each active farm gets its own income, automatically synced to all clients.]]></en>
-            <de><![CDATA[Vollstâ”œÃ¢â”¬Ã±ndig multiplayer-kompatibel. Nur der Server verarbeitet Zahlungen â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Einkommen wird nie dupliziert. Jeder aktive Betrieb erhâ”œÃ¢â”¬Ã±lt sein eigenes Einkommen, automatisch an alle Clients synchronisiert.]]></de>
-            <fr><![CDATA[Entiâ”œÃ¢â”¬Â¿rement compatible multijoueur. Seul le serveur traite les paiements â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ les revenus ne sont jamais dupliquâ”œÃ¢â”¬Â®s. Chaque ferme active reâ”œÃ¢â”¬Âºoit ses propres revenus, synchronisâ”œÃ¢â”¬Â®s automatiquement.]]></fr>
-            <pl><![CDATA[W peâ”œÃ Ã”Ã‡Ãœni kompatybilny z wieloosobowym. Tylko serwer przetwarza pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ dochâ”œÃ¢â”¬â”‚d nigdy nie jest powielony. Kaâ”œÃ â”¬â•de gospodarstwo otrzymuje wâ”œÃ Ã”Ã‡Ãœasny dochâ”œÃ¢â”¬â”‚d, synchronizowany ze wszystkimi klientami.]]></pl>
-            <es><![CDATA[Totalmente compatible con multijugador. Solo el servidor procesa los pagos â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ los ingresos nunca se duplican. Cada granja activa recibe sus propios ingresos, sincronizados automâ”œÃ¢â”¬Ã­ticamente.]]></es>
-            <it><![CDATA[Completamente compatibile con il multigiocatore. Solo il server elabora i pagamenti â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ il reddito non viene mai duplicato. Ogni fattoria attiva riceve il proprio reddito, sincronizzato automaticamente.]]></it>
-            <cz><![CDATA[Plnâ”œÃ¤Ã”Ã‡â•‘ kompatibilnâ”œÃ¢â”¬Â¡ s vâ”œÃ¢â”¬Â¡ce hrâ”œÃ¢â”¬Ã­â”œÃ¤â”¬Ã¬i. Pouze server zpracovâ”œÃ¢â”¬Ã­vâ”œÃ¢â”¬Ã­ platby â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem nenâ”œÃ¢â”¬Â¡ nikdy zdvojen. Kaâ”œÃ â”¬Â¥dâ”œÃ¢â”¬Ã­ aktivnâ”œÃ¢â”¬Â¡ farma obdrâ”œÃ â”¬Â¥â”œÃ¢â”¬Â¡ vlastnâ”œÃ¢â”¬Â¡ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem, automaticky synchronizovanâ”œÃ¢â”¬Â¢ se vâ”œÃ â”¬Ã­emi klienty.]]></cz>
-            <br><![CDATA[Totalmente compatâ”œÃ¢â”¬Â¡vel com multiplayer. Apenas o servidor processa os pagamentos â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ a renda nunca â”œÃ¢â”¬Â® duplicada. Cada fazenda ativa recebe sua prâ”œÃ¢â”¬â”‚pria renda, sincronizada automaticamente.]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Â¢ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬Ã€ â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•. â”œÃ‰â”¬Ã³â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼ â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ã â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–’â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã…. â”œÃ‰â”¼Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤, â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬Ã€ â”œÃ¦Ã£Ã†â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ã˜â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ‰â”¬Â©.]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¼Â¢ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ¦â”¬Ã¼ â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•. â”œÃ‰â”¬Ã³â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼ â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£ â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ã â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–’â”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã…. â”œÃ‰â”¼Ã­â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã… â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤, â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ‰â”¬Â©.]]></ru>
-            <da><![CDATA[Fuldt kompatibel med multiplayer. Kun serveren behandler betalinger â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ indkomst bliver aldrig duplikeret. Hver aktiv farm fâ”œÃ¢â”¬Ã‘r sin egen indkomst, automatisk synkroniseret til alle klienter.]]></da>
+            <en><![CDATA[Fully compatible with multiplayer. Only the server processes payments ├óÔé¼ÔÇØ income is never duplicated. Each active farm gets its own income, automatically synced to all clients.]]></en>
+            <de><![CDATA[Vollst├â┬ñndig multiplayer-kompatibel. Nur der Server verarbeitet Zahlungen ├óÔé¼ÔÇØ Einkommen wird nie dupliziert. Jeder aktive Betrieb erh├â┬ñlt sein eigenes Einkommen, automatisch an alle Clients synchronisiert.]]></de>
+            <fr><![CDATA[Enti├â┬¿rement compatible multijoueur. Seul le serveur traite les paiements ├óÔé¼ÔÇØ les revenus ne sont jamais dupliqu├â┬®s. Chaque ferme active re├â┬ºoit ses propres revenus, synchronis├â┬®s automatiquement.]]></fr>
+            <pl><![CDATA[W pe├àÔÇÜni kompatybilny z wieloosobowym. Tylko serwer przetwarza p├àÔÇÜatno├àÔÇ║ci ├óÔé¼ÔÇØ doch├â┬│d nigdy nie jest powielony. Ka├à┬╝de gospodarstwo otrzymuje w├àÔÇÜasny doch├â┬│d, synchronizowany ze wszystkimi klientami.]]></pl>
+            <es><![CDATA[Totalmente compatible con multijugador. Solo el servidor procesa los pagos ├óÔé¼ÔÇØ los ingresos nunca se duplican. Cada granja activa recibe sus propios ingresos, sincronizados autom├â┬íticamente.]]></es>
+            <it><![CDATA[Completamente compatibile con il multigiocatore. Solo il server elabora i pagamenti ├óÔé¼ÔÇØ il reddito non viene mai duplicato. Ogni fattoria attiva riceve il proprio reddito, sincronizzato automaticamente.]]></it>
+            <cz><![CDATA[Pln├äÔÇ║ kompatibiln├â┬¡ s v├â┬¡ce hr├â┬í├ä┬ìi. Pouze server zpracov├â┬ív├â┬í platby ├óÔé¼ÔÇØ p├àÔäó├â┬¡jem nen├â┬¡ nikdy zdvojen. Ka├à┬¥d├â┬í aktivn├â┬¡ farma obdr├à┬¥├â┬¡ vlastn├â┬¡ p├àÔäó├â┬¡jem, automaticky synchronizovan├â┬¢ se v├à┬íemi klienty.]]></cz>
+            <br><![CDATA[Totalmente compat├â┬¡vel com multiplayer. Apenas o servidor processa os pagamentos ├óÔé¼ÔÇØ a renda nunca ├â┬® duplicada. Cada fazenda ativa recebe sua pr├â┬│pria renda, sincronizada automaticamente.]]></br>
+            <uk><![CDATA[├É┼©├É┬¥├É┬▓├É┬¢├æÔÇô├æ┬ü├æÔÇÜ├æ┼¢ ├æ┬ü├æãÆ├É┬╝├æÔÇô├æ┬ü├É┬¢├É┬©├É┬╣ ├É┬À ├É┬╝├æãÆ├É┬╗├æ┼Æ├æÔÇÜ├É┬©├É┬┐├É┬╗├É┬Á├æÔÇØ├æÔé¼├É┬¥├É┬╝. ├É┬ó├æÔÇô├É┬╗├æ┼Æ├É┬║├É┬© ├æ┬ü├É┬Á├æÔé¼├É┬▓├É┬Á├æÔé¼ ├É┬¥├É┬▒├æÔé¼├É┬¥├É┬▒├É┬╗├æ┬Å├æÔÇØ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬© ├óÔé¼ÔÇØ ├É┬┤├É┬¥├æÔÇª├æÔÇô├É┬┤ ├É┬¢├æÔÇô├É┬║├É┬¥├É┬╗├É┬© ├É┬¢├É┬Á ├É┬┤├æãÆ├É┬▒├É┬╗├æ┼¢├æÔÇØ├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å. ├É┼í├É┬¥├É┬Â├É┬¢├É┬░ ├æÔÇ×├É┬Á├æÔé¼├É┬╝├É┬░ ├É┬¥├æÔÇÜ├æÔé¼├É┬©├É┬╝├æãÆ├æÔÇØ ├É┬▓├É┬╗├É┬░├æ┬ü├É┬¢├É┬©├É┬╣ ├É┬┤├É┬¥├æÔÇª├æÔÇô├É┬┤, ├É┬░├É┬▓├æÔÇÜ├É┬¥├É┬╝├É┬░├æÔÇÜ├É┬©├æÔÇí├É┬¢├É┬¥ ├æ┬ü├É┬©├É┬¢├æÔÇª├æÔé¼├É┬¥├É┬¢├æÔÇô├É┬À├É┬¥├É┬▓├É┬░├É┬¢├É┬©├É┬╣ ├É┬À ├æãÆ├æ┬ü├æÔÇô├É┬╝├É┬░ ├É┬║├É┬╗├æÔÇô├æÔÇØ├É┬¢├æÔÇÜ├É┬░├É┬╝├É┬©.]]></uk>
+            <ru><![CDATA[├É┼©├É┬¥├É┬╗├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æ┼Æ├æ┼¢ ├æ┬ü├É┬¥├É┬▓├É┬╝├É┬Á├æ┬ü├æÔÇÜ├É┬©├É┬╝ ├æ┬ü ├É┬╝├æãÆ├É┬╗├æ┼Æ├æÔÇÜ├É┬©├É┬┐├É┬╗├É┬Á├É┬Á├æÔé¼├É┬¥├É┬╝. ├É┬ó├É┬¥├É┬╗├æ┼Æ├É┬║├É┬¥ ├æ┬ü├É┬Á├æÔé¼├É┬▓├É┬Á├æÔé¼ ├É┬¥├É┬▒├æÔé¼├É┬░├É┬▒├É┬░├æÔÇÜ├æÔÇ╣├É┬▓├É┬░├É┬Á├æÔÇÜ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣ ├óÔé¼ÔÇØ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤ ├É┬¢├É┬©├É┬║├É┬¥├É┬│├É┬┤├É┬░ ├É┬¢├É┬Á ├É┬┤├æãÆ├É┬▒├É┬╗├É┬©├æÔé¼├æãÆ├É┬Á├æÔÇÜ├æ┬ü├æ┬Å. ├É┼í├É┬░├É┬Â├É┬┤├É┬░├æ┬Å ├æÔÇ×├É┬Á├æÔé¼├É┬╝├É┬░ ├É┬┐├É┬¥├É┬╗├æãÆ├æÔÇí├É┬░├É┬Á├æÔÇÜ ├æ┬ü├É┬▓├É┬¥├É┬╣ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤, ├É┬░├É┬▓├æÔÇÜ├É┬¥├É┬╝├É┬░├æÔÇÜ├É┬©├æÔÇí├É┬Á├æ┬ü├É┬║├É┬© ├æ┬ü├É┬©├É┬¢├æÔÇª├æÔé¼├É┬¥├É┬¢├É┬©├É┬À├É┬©├æÔé¼├É┬¥├É┬▓├É┬░├É┬¢├É┬¢├æÔÇ╣├É┬╣ ├æ┬ü├É┬¥ ├É┬▓├æ┬ü├É┬Á├É┬╝├É┬© ├É┬║├É┬╗├É┬©├É┬Á├É┬¢├æÔÇÜ├É┬░├É┬╝├É┬©.]]></ru>
+            <da><![CDATA[Fuldt kompatibel med multiplayer. Kun serveren behandler betalinger ├óÔé¼ÔÇØ indkomst bliver aldrig duplikeret. Hver aktiv farm f├â┬Ñr sin egen indkomst, automatisk synkroniseret til alle klienter.]]></da>
         </text>
 
-        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page 2 â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ How Payments Work â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
+        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page 2 ├óÔé¼ÔÇØ How Payments Work ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
         <text name="im_help_p2_modes_title">
             <en><![CDATA[Pay Modes]]></en>
             <de><![CDATA[Zahlungsmodi]]></de>
             <fr><![CDATA[Modes de paiement]]></fr>
-            <pl><![CDATA[Tryby pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci]]></pl>
+            <pl><![CDATA[Tryby p├àÔÇÜatno├àÔÇ║ci]]></pl>
             <es><![CDATA[Modos de pago]]></es>
-            <it><![CDATA[Modalitâ”œÃ¢â”¬Ã¡ di pagamento]]></it>
-            <cz><![CDATA[Platebnâ”œÃ¢â”¬Â¡ reâ”œÃ â”¬Â¥imy]]></cz>
+            <it><![CDATA[Modalit├â┬á di pagamento]]></it>
+            <cz><![CDATA[Platebn├â┬¡ re├à┬¥imy]]></cz>
             <br><![CDATA[Modos de pagamento]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ]]></ru>
+            <uk><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝├É┬© ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ]]></uk>
+            <ru><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝├æÔÇ╣ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ]]></ru>
             <da><![CDATA[Betalingstyper]]></da>
         </text>
 
         <text name="im_help_p2_modes_text">
-            <en><![CDATA[Hourly: one payment every in-game hour (24 per day). Daily: one payment at the start of each in-game day. Switch at any time via ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Settings â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></en>
-            <de><![CDATA[Stâ”œÃ¢â”¬â•ndlich: eine Zahlung pro Spielstunde (24 pro Tag). Tâ”œÃ¢â”¬Ã±glich: eine Zahlung zu Beginn jedes Spieltages. Jederzeit wechseln: ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Einstellungen â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Einkommens-Mod.]]></de>
-            <fr><![CDATA[Horaire : un paiement par heure de jeu (24 par jour). Quotidien : un paiement au dâ”œÃ¢â”¬Â®but de chaque journâ”œÃ¢â”¬Â®e. Changez via â”œÃ¢Ã”Ã‡â–‘chap â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Paramâ”œÃ¢â”¬Â¿tres â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></fr>
-            <pl><![CDATA[Godzinowy: jedna pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­ co godzinâ”œÃ¤Ã”Ã¤Ã³ gry (24 na dzieâ”œÃ Ã”Ã‡Ã—). Dzienny: jedna pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­ na poczâ”œÃ¤Ã”Ã‡Âªtku kaâ”œÃ â”¬â•dego dnia. Zmieâ”œÃ Ã”Ã‡Ã— w ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Ustawienia â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></pl>
-            <es><![CDATA[Horario: un pago por hora de juego (24 al dâ”œÃ¢â”¬Â¡a). Diario: un pago al inicio de cada dâ”œÃ¢â”¬Â¡a. Cambia en ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Ajustes â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></es>
-            <it><![CDATA[Orario: un pagamento ogni ora (24 al giorno). Giornaliero: un pagamento all'inizio di ogni giorno. Cambia in ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Impostazioni â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></it>
-            <cz><![CDATA[Hodinovâ”œÃ¤Ã”Ã‡â•‘: jedna platba kaâ”œÃ â”¬Â¥dou hernâ”œÃ¢â”¬Â¡ hodinu (24 za den). Dennâ”œÃ¤Ã”Ã‡â•‘: jedna platba na zaâ”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­tku kaâ”œÃ â”¬Â¥dâ”œÃ¢â”¬Â®ho dne. Zmâ”œÃ¤Ã”Ã‡â•‘â”œÃ â•¦Ã¥te v ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Nastavenâ”œÃ¢â”¬Â¡ â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></cz>
-            <br><![CDATA[Por hora: um pagamento por hora de jogo (24 ao dia). Diâ”œÃ¢â”¬Ã­rio: um pagamento no inâ”œÃ¢â”¬Â¡cio de cada dia. Mude em ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† (24 â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†). â”œÃ‰â”¬Â®â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ¦Ã£Ã† â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…. â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬â•â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©: ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥: â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£ â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼ (24 â”œÃ‰â”¬â–“ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†). â”œÃ‰Ã”Ã‡Ã³â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬Ã â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…. â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â–“ ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></ru>
-            <da><![CDATA[Timevis: en betaling hver in-game time (24 pr. dag). Dagligt: en betaling ved starten af hver in-game dag. Skift nâ”œÃ¢â”¬Ã‘r som helst via ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Indstillinger â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></da>
+            <en><![CDATA[Hourly: one payment every in-game hour (24 per day). Daily: one payment at the start of each in-game day. Switch at any time via ESC ├óÔÇáÔÇÖ Settings ├óÔÇáÔÇÖ Income Mod.]]></en>
+            <de><![CDATA[St├â┬╝ndlich: eine Zahlung pro Spielstunde (24 pro Tag). T├â┬ñglich: eine Zahlung zu Beginn jedes Spieltages. Jederzeit wechseln: ESC ├óÔÇáÔÇÖ Einstellungen ├óÔÇáÔÇÖ Einkommens-Mod.]]></de>
+            <fr><![CDATA[Horaire : un paiement par heure de jeu (24 par jour). Quotidien : un paiement au d├â┬®but de chaque journ├â┬®e. Changez via ├âÔÇ░chap ├óÔÇáÔÇÖ Param├â┬¿tres ├óÔÇáÔÇÖ Income Mod.]]></fr>
+            <pl><![CDATA[Godzinowy: jedna p├àÔÇÜatno├àÔÇ║├äÔÇí co godzin├äÔäó gry (24 na dzie├àÔÇ×). Dzienny: jedna p├àÔÇÜatno├àÔÇ║├äÔÇí na pocz├äÔÇªtku ka├à┬╝dego dnia. Zmie├àÔÇ× w ESC ├óÔÇáÔÇÖ Ustawienia ├óÔÇáÔÇÖ Income Mod.]]></pl>
+            <es><![CDATA[Horario: un pago por hora de juego (24 al d├â┬¡a). Diario: un pago al inicio de cada d├â┬¡a. Cambia en ESC ├óÔÇáÔÇÖ Ajustes ├óÔÇáÔÇÖ Income Mod.]]></es>
+            <it><![CDATA[Orario: un pagamento ogni ora (24 al giorno). Giornaliero: un pagamento all'inizio di ogni giorno. Cambia in ESC ├óÔÇáÔÇÖ Impostazioni ├óÔÇáÔÇÖ Income Mod.]]></it>
+            <cz><![CDATA[Hodinov├äÔÇ║: jedna platba ka├à┬¥dou hern├â┬¡ hodinu (24 za den). Denn├äÔÇ║: jedna platba na za├ä┬ì├â┬ítku ka├à┬¥d├â┬®ho dne. Zm├äÔÇ║├à╦åte v ESC ├óÔÇáÔÇÖ Nastaven├â┬¡ ├óÔÇáÔÇÖ Income Mod.]]></cz>
+            <br><![CDATA[Por hora: um pagamento por hora de jogo (24 ao dia). Di├â┬írio: um pagamento no in├â┬¡cio de cada dia. Mude em ESC ├óÔÇáÔÇÖ Configura├â┬º├â┬Áes ├óÔÇáÔÇÖ Income Mod.]]></br>
+            <uk><![CDATA[├É┼©├É┬¥├É┬│├É┬¥├É┬┤├É┬©├É┬¢├É┬¢├É┬¥: ├É┬¥├É┬┤├É┬¢├É┬░ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░ ├É┬║├É┬¥├É┬Â├É┬¢├æãÆ ├æÔÇô├É┬│├æÔé¼├É┬¥├É┬▓├æãÆ ├É┬│├É┬¥├É┬┤├É┬©├É┬¢├æãÆ (24 ├É┬¢├É┬░ ├É┬┤├É┬Á├É┬¢├æ┼Æ). ├É┬®├É┬¥├É┬┤├É┬Á├É┬¢├É┬¢├É┬¥: ├É┬¥├É┬┤├É┬¢├É┬░ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░ ├É┬¢├É┬░ ├É┬┐├É┬¥├æÔÇí├É┬░├æÔÇÜ├É┬║├æãÆ ├É┬║├É┬¥├É┬Â├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¢├æ┬Å. ├ÉÔÇö├É┬╝├æÔÇô├É┬¢├É┬©├æÔÇÜ├É┬©: ESC ├óÔÇáÔÇÖ ├É┬Ø├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å ├óÔÇáÔÇÖ Income Mod.]]></uk>
+            <ru><![CDATA[├É┼©├É┬¥├æÔÇí├É┬░├æ┬ü├É┬¥├É┬▓├É┬¥: ├É┬¥├É┬┤├É┬¢├É┬░ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░ ├É┬║├É┬░├É┬Â├É┬┤├æÔÇ╣├É┬╣ ├É┬©├É┬│├æÔé¼├É┬¥├É┬▓├É┬¥├É┬╣ ├æÔÇí├É┬░├æ┬ü (24 ├É┬▓ ├É┬┤├É┬Á├É┬¢├æ┼Æ). ├ÉÔÇó├É┬Â├É┬Á├É┬┤├É┬¢├É┬Á├É┬▓├É┬¢├É┬¥: ├É┬¥├É┬┤├É┬¢├É┬░ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░ ├É┬▓ ├É┬¢├É┬░├æÔÇí├É┬░├É┬╗├É┬Á ├É┬║├É┬░├É┬Â├É┬┤├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¢├æ┬Å. ├É┬í├É┬╝├É┬Á├É┬¢├É┬©├æÔÇÜ├É┬Á ├É┬▓ ESC ├óÔÇáÔÇÖ ├É┬Ø├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬© ├óÔÇáÔÇÖ Income Mod.]]></ru>
+            <da><![CDATA[Timevis: en betaling hver in-game time (24 pr. dag). Dagligt: en betaling ved starten af hver in-game dag. Skift n├â┬Ñr som helst via ESC ├óÔÇáÔÇÖ Indstillinger ├óÔÇáÔÇÖ Income Mod.]]></da>
         </text>
 
         <text name="im_help_p2_persist_title">
             <en><![CDATA[No Double-Payments]]></en>
             <de><![CDATA[Keine Doppelzahlungen]]></de>
             <fr><![CDATA[Pas de double paiement]]></fr>
-            <pl><![CDATA[Brak podwâ”œÃ¢â”¬â”‚jnych pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci]]></pl>
+            <pl><![CDATA[Brak podw├â┬│jnych p├àÔÇÜatno├àÔÇ║ci]]></pl>
             <es><![CDATA[Sin dobles pagos]]></es>
             <it><![CDATA[Nessun pagamento doppio]]></it>
-            <cz><![CDATA[â”œÃ â”¬Â¢â”œÃ¢â”¬Ã­dnâ”œÃ¢â”¬Â® dvojitâ”œÃ¢â”¬Â® platby]]></cz>
+            <cz><![CDATA[├à┬¢├â┬ídn├â┬® dvojit├â┬® platby]]></cz>
             <br><![CDATA[Sem pagamentos duplos]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã¿â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Âª â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã¿â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Âª â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ]]></ru>
+            <uk><![CDATA[├ÉÔÇÿ├É┬Á├É┬À ├É┬┐├É┬¥├É┬┤├É┬▓├æÔÇô├É┬╣├É┬¢├É┬©├æÔÇª ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ]]></uk>
+            <ru><![CDATA[├ÉÔÇÿ├É┬Á├É┬À ├É┬┤├É┬▓├É┬¥├É┬╣├É┬¢├æÔÇ╣├æÔÇª ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ]]></ru>
             <da><![CDATA[Ingen dobbelte betalinger]]></da>
         </text>
 
         <text name="im_help_p2_persist_text">
             <en><![CDATA[The last payment time is saved with your game. If you exit and reload, payments resume correctly. You will never be paid twice for the same hour or day.]]></en>
-            <de><![CDATA[Der letzte Zahlungszeitpunkt wird mit dem Spielstand gespeichert. Beim Neuladen werden Zahlungen korrekt fortgesetzt. Sie werden nie zweimal fâ”œÃ¢â”¬â•r dieselbe Stunde oder denselben Tag bezahlt.]]></de>
-            <fr><![CDATA[Le dernier paiement est sauvegardâ”œÃ¢â”¬Â® avec la partie. Au rechargement, les paiements reprennent correctement. Vous ne serez jamais payâ”œÃ¢â”¬Â® deux fois pour la mâ”œÃ¢â”¬Â¬me heure ou le mâ”œÃ¢â”¬Â¬me jour.]]></fr>
-            <pl><![CDATA[Ostatni czas pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci jest zapisywany z grâ”œÃ¤Ã”Ã‡Âª. Po przeâ”œÃ Ã”Ã‡Ãœadowaniu pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci wznawiajâ”œÃ¤Ã”Ã‡Âª siâ”œÃ¤Ã”Ã¤Ã³ poprawnie. Nigdy nie otrzymasz podwâ”œÃ¢â”¬â”‚jnej pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci za tâ”œÃ¤Ã”Ã¤Ã³ samâ”œÃ¤Ã”Ã‡Âª godzinâ”œÃ¤Ã”Ã¤Ã³ lub dzieâ”œÃ Ã”Ã‡Ã—.]]></pl>
-            <es><![CDATA[El â”œÃ¢â”¬â•‘ltimo pago se guarda con la partida. Al recargar, los pagos se reanudan correctamente. Nunca recibirâ”œÃ¢â”¬Ã­s dos pagos por la misma hora o dâ”œÃ¢â”¬Â¡a.]]></es>
+            <de><![CDATA[Der letzte Zahlungszeitpunkt wird mit dem Spielstand gespeichert. Beim Neuladen werden Zahlungen korrekt fortgesetzt. Sie werden nie zweimal f├â┬╝r dieselbe Stunde oder denselben Tag bezahlt.]]></de>
+            <fr><![CDATA[Le dernier paiement est sauvegard├â┬® avec la partie. Au rechargement, les paiements reprennent correctement. Vous ne serez jamais pay├â┬® deux fois pour la m├â┬¬me heure ou le m├â┬¬me jour.]]></fr>
+            <pl><![CDATA[Ostatni czas p├àÔÇÜatno├àÔÇ║ci jest zapisywany z gr├äÔÇª. Po prze├àÔÇÜadowaniu p├àÔÇÜatno├àÔÇ║ci wznawiaj├äÔÇª si├äÔäó poprawnie. Nigdy nie otrzymasz podw├â┬│jnej p├àÔÇÜatno├àÔÇ║ci za t├äÔäó sam├äÔÇª godzin├äÔäó lub dzie├àÔÇ×.]]></pl>
+            <es><![CDATA[El ├â┬║ltimo pago se guarda con la partida. Al recargar, los pagos se reanudan correctamente. Nunca recibir├â┬ís dos pagos por la misma hora o d├â┬¡a.]]></es>
             <it><![CDATA[L'ultimo pagamento viene salvato con la partita. Al ricaricamento i pagamenti riprendono correttamente. Non riceverai mai due pagamenti per la stessa ora o giorno.]]></it>
-            <cz><![CDATA[â”œÃ¤â”¼Ã†as poslednâ”œÃ¢â”¬Â¡ platby se uklâ”œÃ¢â”¬Ã­dâ”œÃ¢â”¬Ã­ se hrou. Po naâ”œÃ¤â”¬Ã¬tenâ”œÃ¢â”¬Â¡ platby pokraâ”œÃ¤â”¬Ã¬ujâ”œÃ¢â”¬Â¡ sprâ”œÃ¢â”¬Ã­vnâ”œÃ¤Ã”Ã‡â•‘. Nikdy neobdrâ”œÃ â”¬Â¥â”œÃ¢â”¬Â¡te dvojitou platbu za tutâ”œÃ¢â”¬Â®â”œÃ â”¬Â¥ hodinu nebo den.]]></cz>
-            <br><![CDATA[O â”œÃ¢â”¬â•‘ltimo pagamento â”œÃ¢â”¬Â® salvo com o jogo. Ao recarregar, os pagamentos retomam corretamente. Vocâ”œÃ¢â”¬Â¬ nunca receberâ”œÃ¢â”¬Ã­ dois pagamentos pela mesma hora ou dia.]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Âºâ”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼ â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã¶ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–’â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”‚â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â• â”œÃ‰â”¬Ã€ â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ¦â”¼Â¢. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥. â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ã â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ‰â”¬â•£ â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†.]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•£ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â–“â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ¦â”¬Ã¼ â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â© â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬Ã€â”œÃ‰â”¬â•‘â”œÃ‰â”¬Ã â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥. â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ã â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢ â”œÃ‰â”¬Â© â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ã â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼ â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†.]]></ru>
-            <da><![CDATA[Det sidste betalingstidspunkt gemmes sammen med dit spil. Hvis du afslutter og genindlâ”œÃ¢â”¬Âªser, genoptages betalingerne korrekt. Du vil aldrig blive betalt to gange for den samme time eller dag.]]></da>
+            <cz><![CDATA[├ä┼Æas posledn├â┬¡ platby se ukl├â┬íd├â┬í se hrou. Po na├ä┬ìten├â┬¡ platby pokra├ä┬ìuj├â┬¡ spr├â┬ívn├äÔÇ║. Nikdy neobdr├à┬¥├â┬¡te dvojitou platbu za tut├â┬®├à┬¥ hodinu nebo den.]]></cz>
+            <br><![CDATA[O ├â┬║ltimo pagamento ├â┬® salvo com o jogo. Ao recarregar, os pagamentos retomam corretamente. Voc├â┬¬ nunca receber├â┬í dois pagamentos pela mesma hora ou dia.]]></br>
+            <uk><![CDATA[├É┬º├É┬░├æ┬ü ├É┬¥├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¢├æ┼Æ├É┬¥├æÔÇö ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬© ├É┬À├É┬▒├É┬Á├æÔé¼├æÔÇô├É┬│├É┬░├æÔÇØ├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├æÔé¼├É┬░├É┬À├É┬¥├É┬╝ ├É┬À ├É┬│├æÔé¼├É┬¥├æ┼¢. ├É┼©├æÔÇô├æ┬ü├É┬╗├æ┬Å ├É┬┐├É┬Á├æÔé¼├É┬Á├É┬À├É┬░├É┬▓├É┬░├É┬¢├æÔÇÜ├É┬░├É┬Â├É┬Á├É┬¢├É┬¢├æ┬Å ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬© ├É┬▓├æÔÇô├É┬┤├É┬¢├É┬¥├É┬▓├É┬╗├æ┼¢├æ┼¢├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├É┬┐├æÔé¼├É┬░├É┬▓├É┬©├É┬╗├æ┼Æ├É┬¢├É┬¥. ├ÉÔÇÖ├É┬© ├É┬¢├æÔÇô├É┬║├É┬¥├É┬╗├É┬© ├É┬¢├É┬Á ├É┬¥├æÔÇÜ├æÔé¼├É┬©├É┬╝├É┬░├æÔÇØ├æÔÇÜ├É┬Á ├É┬┐├É┬¥├É┬┤├É┬▓├æÔÇô├É┬╣├É┬¢├æãÆ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ ├É┬À├É┬░ ├É┬¥├É┬┤├É┬¢├æãÆ ├É┬╣ ├æÔÇÜ├æãÆ ├æ┬ü├É┬░├É┬╝├æãÆ ├É┬│├É┬¥├É┬┤├É┬©├É┬¢├æãÆ ├É┬░├É┬▒├É┬¥ ├É┬┤├É┬Á├É┬¢├æ┼Æ.]]></uk>
+            <ru><![CDATA[├ÉÔÇÖ├æÔé¼├É┬Á├É┬╝├æ┬Å ├É┬┐├É┬¥├æ┬ü├É┬╗├É┬Á├É┬┤├É┬¢├É┬Á├É┬╣ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣ ├æ┬ü├É┬¥├æÔÇª├æÔé¼├É┬░├É┬¢├æ┬Å├É┬Á├æÔÇÜ├æ┬ü├æ┬Å ├É┬▓├É┬╝├É┬Á├æ┬ü├æÔÇÜ├É┬Á ├æ┬ü ├É┬©├É┬│├æÔé¼├É┬¥├É┬╣. ├É┼©├æÔé¼├É┬© ├É┬┐├É┬Á├æÔé¼├É┬Á├É┬À├É┬░├É┬│├æÔé¼├æãÆ├É┬À├É┬║├É┬Á ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣ ├É┬▓├É┬¥├É┬À├É┬¥├É┬▒├É┬¢├É┬¥├É┬▓├É┬╗├æ┬Å├æ┼¢├æÔÇÜ├æ┬ü├æ┬Å ├É┬║├É┬¥├æÔé¼├æÔé¼├É┬Á├É┬║├æÔÇÜ├É┬¢├É┬¥. ├ÉÔÇÖ├æÔÇ╣ ├É┬¢├É┬©├É┬║├É┬¥├É┬│├É┬┤├É┬░ ├É┬¢├É┬Á ├É┬┐├É┬¥├É┬╗├æãÆ├æÔÇí├É┬©├æÔÇÜ├É┬Á ├É┬┤├É┬▓├É┬¥├É┬╣├É┬¢├æãÆ├æ┼¢ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ ├É┬À├É┬░ ├É┬¥├É┬┤├É┬©├É┬¢ ├É┬© ├æÔÇÜ├É┬¥├æÔÇÜ ├É┬Â├É┬Á ├æÔÇí├É┬░├æ┬ü ├É┬©├É┬╗├É┬© ├É┬┤├É┬Á├É┬¢├æ┼Æ.]]></ru>
+            <da><![CDATA[Det sidste betalingstidspunkt gemmes sammen med dit spil. Hvis du afslutter og genindl├â┬ªser, genoptages betalingerne korrekt. Du vil aldrig blive betalt to gange for den samme time eller dag.]]></da>
         </text>
 
-        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page 3 â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Income Settings â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
+        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page 3 ├óÔé¼ÔÇØ Income Settings ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
         <text name="im_help_s1_enable_title">
             <en><![CDATA[Enable / Disable]]></en>
             <de><![CDATA[Aktivieren / Deaktivieren]]></de>
-            <fr><![CDATA[Activer / Dâ”œÃ¢â”¬Â®sactiver]]></fr>
-            <pl><![CDATA[Wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz / Wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz]]></pl>
+            <fr><![CDATA[Activer / D├â┬®sactiver]]></fr>
+            <pl><![CDATA[W├àÔÇÜ├äÔÇªcz / Wy├àÔÇÜ├äÔÇªcz]]></pl>
             <es><![CDATA[Activar / Desactivar]]></es>
             <it><![CDATA[Attiva / Disattiva]]></it>
-            <cz><![CDATA[Povolit / Zakâ”œÃ¢â”¬Ã­zat]]></cz>
+            <cz><![CDATA[Povolit / Zak├â┬ízat]]></cz>
             <br><![CDATA[Ativar / Desativar]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© / â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† / â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†]]></ru>
+            <uk><![CDATA[├É┬ú├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© / ├ÉÔÇÖ├É┬©├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬©]]></uk>
+            <ru><![CDATA[├ÉÔÇÖ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ / ├ÉÔÇÖ├æÔÇ╣├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ]]></ru>
             <da><![CDATA[Aktiver / Deaktiver]]></da>
         </text>
 
         <text name="im_help_s1_enable_text">
             <en><![CDATA[The master switch. When disabled, no income is paid and the HUD is hidden. Re-enabling resumes payments from the current in-game time.]]></en>
             <de><![CDATA[Der Hauptschalter. Wenn deaktiviert, werden keine Einnahmen ausgezahlt und der HUD ist ausgeblendet. Bei erneuter Aktivierung werden Zahlungen fortgesetzt.]]></de>
-            <fr><![CDATA[L'interrupteur principal. Dâ”œÃ¢â”¬Â®sactivâ”œÃ¢â”¬Â® : pas de revenu, HUD masquâ”œÃ¢â”¬Â®. Râ”œÃ¢â”¬Â®activâ”œÃ¢â”¬Â® : les paiements reprennent â”œÃ¢â”¬Ã¡ partir du temps de jeu actuel.]]></fr>
-            <pl><![CDATA[Gâ”œÃ Ã”Ã‡Ãœâ”œÃ¢â”¬â”‚wny przeâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcznik. Gdy wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczony â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ brak dochodâ”œÃ¢â”¬â”‚w i HUD jest ukryty. Po ponownym wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczeniu pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci wznawiajâ”œÃ¤Ã”Ã‡Âª siâ”œÃ¤Ã”Ã¤Ã³ od bieâ”œÃ â”¬â•â”œÃ¤Ã”Ã‡Âªcego czasu gry.]]></pl>
+            <fr><![CDATA[L'interrupteur principal. D├â┬®sactiv├â┬® : pas de revenu, HUD masqu├â┬®. R├â┬®activ├â┬® : les paiements reprennent ├â┬á partir du temps de jeu actuel.]]></fr>
+            <pl><![CDATA[G├àÔÇÜ├â┬│wny prze├àÔÇÜ├äÔÇªcznik. Gdy wy├àÔÇÜ├äÔÇªczony ├óÔé¼ÔÇØ brak dochod├â┬│w i HUD jest ukryty. Po ponownym w├àÔÇÜ├äÔÇªczeniu p├àÔÇÜatno├àÔÇ║ci wznawiaj├äÔÇª si├äÔäó od bie├à┬╝├äÔÇªcego czasu gry.]]></pl>
             <es><![CDATA[El interruptor principal. Desactivado: sin ingresos, HUD oculto. Al reactivar, los pagos se reanudan desde el tiempo de juego actual.]]></es>
             <it><![CDATA[L'interruttore principale. Disabilitato: nessun reddito, HUD nascosto. Riabilitato: i pagamenti riprendono dal tempo di gioco attuale.]]></it>
-            <cz><![CDATA[Hlavnâ”œÃ¢â”¬Â¡ pâ”œÃ Ã”Ã¤Ã³epâ”œÃ¢â”¬Â¡naâ”œÃ¤â”¬Ã¬. Zakâ”œÃ¢â”¬Ã­zâ”œÃ¢â”¬Ã­no: â”œÃ â”¬Â¥â”œÃ¢â”¬Ã­dnâ”œÃ¢â”¬Â¢ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem, HUD je skrytâ”œÃ¢â”¬Â¢. Po opâ”œÃ¤Ã”Ã‡â•‘tovnâ”œÃ¢â”¬Â®m povolenâ”œÃ¢â”¬Â¡ se platby obnovâ”œÃ¢â”¬Â¡ od aktuâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡ho hernâ”œÃ¢â”¬Â¡ho â”œÃ¤â”¬Ã¬asu.]]></cz>
+            <cz><![CDATA[Hlavn├â┬¡ p├àÔäóep├â┬¡na├ä┬ì. Zak├â┬íz├â┬íno: ├à┬¥├â┬ídn├â┬¢ p├àÔäó├â┬¡jem, HUD je skryt├â┬¢. Po op├äÔÇ║tovn├â┬®m povolen├â┬¡ se platby obnov├â┬¡ od aktu├â┬íln├â┬¡ho hern├â┬¡ho ├ä┬ìasu.]]></cz>
             <br><![CDATA[O interruptor principal. Desativado: sem renda, HUD oculto. Reativado: os pagamentos retomam do tempo de jogo atual.]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Â£â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã­. â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†, HUD â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â© â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬â•â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬Ã€ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†.]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Â£â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†. â”œÃ‰â”¼Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã”Ã‡Ã¿â”œÃ‰â”¬Â¢: â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ã â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã…, HUD â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ãœ. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â© â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â• â”œÃ‰â”¬â–“â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼ â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©.]]></ru>
-            <da><![CDATA[Den hovedsâ”œÃ¢â”¬Âªtning. Nâ”œÃ¢â”¬Ã‘r deaktiveret, bliver der ikke betalt noget indkomst og HUD er skjult. Genaktivering genoptager betalinger fra det nuvâ”œÃ¢â”¬Âªrende in-game tidspunkt.]]></da>
+            <uk><![CDATA[├ÉÔÇ£├É┬¥├É┬╗├É┬¥├É┬▓├É┬¢├É┬©├É┬╣ ├É┬┐├É┬Á├æÔé¼├É┬Á├É┬╝├É┬©├É┬║├É┬░├æÔÇí. ├ÉÔÇÖ├É┬©├É┬╝├É┬║├É┬¢├É┬Á├É┬¢├É┬¥: ├É┬¢├É┬Á├É┬╝├É┬░├æÔÇØ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ, HUD ├É┬┐├æÔé¼├É┬©├æÔÇª├É┬¥├É┬▓├É┬░├É┬¢├É┬©├É┬╣. ├É┼©├æÔé¼├É┬© ├É┬┐├É┬¥├É┬▓├æÔÇÜ├É┬¥├æÔé¼├É┬¢├É┬¥├É┬╝├æãÆ ├É┬▓├É┬╝├É┬©├É┬║├É┬░├É┬¢├É┬¢├æÔÇô ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬© ├É┬▓├æÔÇô├É┬┤├É┬¢├É┬¥├É┬▓├É┬╗├æ┼¢├æ┼¢├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├É┬À ├É┬┐├É┬¥├æÔÇÜ├É┬¥├æÔÇí├É┬¢├É┬¥├É┬│├É┬¥ ├æÔÇô├É┬│├æÔé¼├É┬¥├É┬▓├É┬¥├É┬│├É┬¥ ├æÔÇí├É┬░├æ┬ü├æãÆ.]]></uk>
+            <ru><![CDATA[├ÉÔÇ£├É┬╗├É┬░├É┬▓├É┬¢├æÔÇ╣├É┬╣ ├É┬┐├É┬Á├æÔé¼├É┬Á├É┬║├É┬╗├æ┼¢├æÔÇí├É┬░├æÔÇÜ├É┬Á├É┬╗├æ┼Æ. ├É┼¥├æÔÇÜ├É┬║├É┬╗├æ┼¢├æÔÇí├æÔÇÿ├É┬¢: ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤ ├É┬¢├É┬Á ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇí├É┬©├É┬▓├É┬░├É┬Á├æÔÇÜ├æ┬ü├æ┬Å, HUD ├æ┬ü├É┬║├æÔé¼├æÔÇ╣├æÔÇÜ. ├É┼©├æÔé¼├É┬© ├É┬┐├É┬¥├É┬▓├æÔÇÜ├É┬¥├æÔé¼├É┬¢├É┬¥├É┬╝ ├É┬▓├É┬║├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬¢├É┬©├É┬© ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣ ├É┬▓├É┬¥├É┬À├É┬¥├É┬▒├É┬¢├É┬¥├É┬▓├É┬╗├æ┬Å├æ┼¢├æÔÇÜ├æ┬ü├æ┬Å ├æ┬ü ├æÔÇÜ├É┬Á├É┬║├æãÆ├æÔÇ░├É┬Á├É┬│├É┬¥ ├É┬©├É┬│├æÔé¼├É┬¥├É┬▓├É┬¥├É┬│├É┬¥ ├É┬▓├æÔé¼├É┬Á├É┬╝├É┬Á├É┬¢├É┬©.]]></ru>
+            <da><![CDATA[Den hoveds├â┬ªtning. N├â┬Ñr deaktiveret, bliver der ikke betalt noget indkomst og HUD er skjult. Genaktivering genoptager betalinger fra det nuv├â┬ªrende in-game tidspunkt.]]></da>
         </text>
 
         <text name="im_help_s1_mode_title">
             <en><![CDATA[Pay Mode]]></en>
             <de><![CDATA[Zahlungsmodus]]></de>
             <fr><![CDATA[Mode de paiement]]></fr>
-            <pl><![CDATA[Tryb pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci]]></pl>
+            <pl><![CDATA[Tryb p├àÔÇÜatno├àÔÇ║ci]]></pl>
             <es><![CDATA[Modo de pago]]></es>
-            <it><![CDATA[Modalitâ”œÃ¢â”¬Ã¡ pagamento]]></it>
-            <cz><![CDATA[Platebnâ”œÃ¢â”¬Â¡ reâ”œÃ â”¬Â¥im]]></cz>
+            <it><![CDATA[Modalit├â┬á pagamento]]></it>
+            <cz><![CDATA[Platebn├â┬¡ re├à┬¥im]]></cz>
             <br><![CDATA[Modo de pagamento]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ]]></ru>
+            <uk><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ]]></uk>
+            <ru><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ]]></ru>
             <da><![CDATA[Betalingstyper]]></da>
         </text>
 
         <text name="im_help_s1_mode_text">
             <en><![CDATA[Hourly pays 24 times per in-game day. Daily pays once per day. Hourly gives steady small payments; daily gives larger, less frequent ones. Both modes suit all playstyles.]]></en>
-            <de><![CDATA[Stâ”œÃ¢â”¬â•ndlich: 24 Zahlungen pro Tag. Tâ”œÃ¢â”¬Ã±glich: einmal pro Tag. Stâ”œÃ¢â”¬â•ndlich bietet gleichmâ”œÃ¢â”¬Ã±â”œÃ¢â”¼Â©ige kleine Zahlungen; tâ”œÃ¢â”¬Ã±glich grâ”œÃ¢â”¬Ã‚â”œÃ¢â”¼Â©ere, seltenere. Beide Modi sind fâ”œÃ¢â”¬â•r alle Spielstile geeignet.]]></de>
-            <fr><![CDATA[Horaire : 24 paiements par jour. Quotidien : une fois par jour. Horaire donne des petits paiements râ”œÃ¢â”¬Â®guliers ; quotidien des paiements plus grands et moins frâ”œÃ¢â”¬Â®quents.]]></fr>
-            <pl><![CDATA[Godzinowy: 24 pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci na dzieâ”œÃ Ã”Ã‡Ã—. Dzienny: raz na dzieâ”œÃ Ã”Ã‡Ã—. Godzinowy daje maâ”œÃ Ã”Ã‡Ãœe, regularne pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci; dzienny â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ wiâ”œÃ¤Ã”Ã¤Ã³ksze, rzadsze. Oba tryby pasujâ”œÃ¤Ã”Ã‡Âª do kaâ”œÃ â”¬â•dego stylu gry.]]></pl>
-            <es><![CDATA[Horario: 24 pagos por dâ”œÃ¢â”¬Â¡a. Diario: una vez al dâ”œÃ¢â”¬Â¡a. Horario da pagos pequeâ”œÃ¢â”¬â–’os regulares; diario da pagos mâ”œÃ¢â”¬Ã­s grandes y menos frecuentes. Ambos modos se adaptan a todos los estilos.]]></es>
-            <it><![CDATA[Orario: 24 pagamenti al giorno. Giornaliero: una volta al giorno. Orario dâ”œÃ¢â”¬Ã¡ pagamenti piccoli regolari; giornaliero dâ”œÃ¢â”¬Ã¡ pagamenti piâ”œÃ¢â”¬â•£ grandi e meno frequenti.]]></it>
-            <cz><![CDATA[Hodinovâ”œÃ¤Ã”Ã‡â•‘: 24 plateb za den. Dennâ”œÃ¤Ã”Ã‡â•‘: jednou za den. Hodinovâ”œÃ¤Ã”Ã‡â•‘ pâ”œÃ Ã”Ã¤Ã³inâ”œÃ¢â”¬Ã­â”œÃ â”¬Ã­â”œÃ¢â”¬Â¡ pravidelnâ”œÃ¢â”¬Â® malâ”œÃ¢â”¬Â® platby; dennâ”œÃ¤Ã”Ã‡â•‘ vâ”œÃ¤Ã”Ã‡â•‘tâ”œÃ â”¬Ã­â”œÃ¢â”¬Â¡, mâ”œÃ¢â”¬Â®nâ”œÃ¤Ã”Ã‡â•‘ â”œÃ¤â”¬Ã¬astâ”œÃ¢â”¬Â®. Oba reâ”œÃ â”¬Â¥imy se hodâ”œÃ¢â”¬Â¡ pro vâ”œÃ â”¬Ã­echny styly hry.]]></cz>
-            <br><![CDATA[Por hora: 24 pagamentos por dia. Diâ”œÃ¢â”¬Ã­rio: uma vez ao dia. Por hora dâ”œÃ¢â”¬Ã­ pagamentos pequenos e regulares; diâ”œÃ¢â”¬Ã­rio dâ”œÃ¢â”¬Ã­ pagamentos maiores e menos frequentes.]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: 24 â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†. â”œÃ‰â”¬Â®â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†. â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ã´ â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©; â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ã´, â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬Ã â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ã´. â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬Â©â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘ â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦â”¬Ã…â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â–’â”œÃ¦Ã£Ã†â”œÃ‰â”¬â”¤â”œÃ¦â”¼Ã†-â”œÃ¦â”¬Ã…â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©.]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥: 24 â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬â–“ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†. â”œÃ‰Ã”Ã‡Ã³â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€ â”œÃ‰â”¬â–“ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†. â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã¿â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬Ã â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£; â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã, â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã. â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘ â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦â”¬Ã…â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡â•£.]]></ru>
-            <da><![CDATA[Timevis: 24 betalinger pr. in-game time. Dagligt: en betaling ved starten af hver in-game dag. Skift nâ”œÃ¢â”¬Ã‘r som helst via ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Indstillinger â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></da>
+            <de><![CDATA[St├â┬╝ndlich: 24 Zahlungen pro Tag. T├â┬ñglich: einmal pro Tag. St├â┬╝ndlich bietet gleichm├â┬ñ├â┼©ige kleine Zahlungen; t├â┬ñglich gr├â┬Â├â┼©ere, seltenere. Beide Modi sind f├â┬╝r alle Spielstile geeignet.]]></de>
+            <fr><![CDATA[Horaire : 24 paiements par jour. Quotidien : une fois par jour. Horaire donne des petits paiements r├â┬®guliers ; quotidien des paiements plus grands et moins fr├â┬®quents.]]></fr>
+            <pl><![CDATA[Godzinowy: 24 p├àÔÇÜatno├àÔÇ║ci na dzie├àÔÇ×. Dzienny: raz na dzie├àÔÇ×. Godzinowy daje ma├àÔÇÜe, regularne p├àÔÇÜatno├àÔÇ║ci; dzienny ├óÔé¼ÔÇØ wi├äÔäóksze, rzadsze. Oba tryby pasuj├äÔÇª do ka├à┬╝dego stylu gry.]]></pl>
+            <es><![CDATA[Horario: 24 pagos por d├â┬¡a. Diario: una vez al d├â┬¡a. Horario da pagos peque├â┬▒os regulares; diario da pagos m├â┬ís grandes y menos frecuentes. Ambos modos se adaptan a todos los estilos.]]></es>
+            <it><![CDATA[Orario: 24 pagamenti al giorno. Giornaliero: una volta al giorno. Orario d├â┬á pagamenti piccoli regolari; giornaliero d├â┬á pagamenti pi├â┬╣ grandi e meno frequenti.]]></it>
+            <cz><![CDATA[Hodinov├äÔÇ║: 24 plateb za den. Denn├äÔÇ║: jednou za den. Hodinov├äÔÇ║ p├àÔäóin├â┬í├à┬í├â┬¡ pravideln├â┬® mal├â┬® platby; denn├äÔÇ║ v├äÔÇ║t├à┬í├â┬¡, m├â┬®n├äÔÇ║ ├ä┬ìast├â┬®. Oba re├à┬¥imy se hod├â┬¡ pro v├à┬íechny styly hry.]]></cz>
+            <br><![CDATA[Por hora: 24 pagamentos por dia. Di├â┬írio: uma vez ao dia. Por hora d├â┬í pagamentos pequenos e regulares; di├â┬írio d├â┬í pagamentos maiores e menos frequentes.]]></br>
+            <uk><![CDATA[├É┼©├É┬¥├É┬│├É┬¥├É┬┤├É┬©├É┬¢├É┬¢├É┬¥: 24 ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬© ├É┬¢├É┬░ ├É┬┤├É┬Á├É┬¢├æ┼Æ. ├É┬®├É┬¥├É┬┤├É┬Á├É┬¢├É┬¢├É┬¥: ├æÔé¼├É┬░├É┬À ├É┬¢├É┬░ ├É┬┤├É┬Á├É┬¢├æ┼Æ. ├É┼©├É┬¥├É┬│├É┬¥├É┬┤├É┬©├É┬¢├É┬¢├É┬¥ ├É┬┤├É┬░├æÔÇØ ├É┬¢├É┬Á├É┬▓├É┬Á├É┬╗├É┬©├É┬║├æÔÇô ├æÔé¼├É┬Á├É┬│├æãÆ├É┬╗├æ┬Å├æÔé¼├É┬¢├æÔÇô ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬©; ├æÔÇ░├É┬¥├É┬┤├É┬Á├É┬¢├É┬¢├É┬¥ ├óÔé¼ÔÇØ ├É┬▒├æÔÇô├É┬╗├æ┼Æ├æ╦å├æÔÇô, ├É┬░├É┬╗├É┬Á ├æÔé¼├æÔÇô├É┬┤├æ╦å├æÔÇô. ├É┼¥├É┬▒├É┬©├É┬┤├É┬▓├É┬░ ├æÔé¼├É┬Á├É┬Â├É┬©├É┬╝├É┬© ├É┬┐├æÔÇô├É┬┤├æÔÇª├É┬¥├É┬┤├æ┬Å├æÔÇÜ├æ┼Æ ├É┬┤├É┬╗├æ┬Å ├É┬▒├æãÆ├É┬┤├æ┼Æ-├æ┬Å├É┬║├É┬¥├É┬│├É┬¥ ├æ┬ü├æÔÇÜ├É┬©├É┬╗├æ┼¢ ├É┬│├æÔé¼├É┬©.]]></uk>
+            <ru><![CDATA[├É┼©├É┬¥├æÔÇí├É┬░├æ┬ü├É┬¥├É┬▓├É┬¥: 24 ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣ ├É┬▓ ├É┬┤├É┬Á├É┬¢├æ┼Æ. ├ÉÔÇó├É┬Â├É┬Á├É┬┤├É┬¢├É┬Á├É┬▓├É┬¢├É┬¥: ├æÔé¼├É┬░├É┬À ├É┬▓ ├É┬┤├É┬Á├É┬¢├æ┼Æ. ├É┼©├É┬¥├æÔÇí├É┬░├æ┬ü├É┬¥├É┬▓├É┬¥ ├É┬┤├É┬░├æÔÇÿ├æÔÇÜ ├É┬¢├É┬Á├É┬▒├É┬¥├É┬╗├æ┼Æ├æ╦å├É┬©├É┬Á ├æÔé¼├É┬Á├É┬│├æãÆ├É┬╗├æ┬Å├æÔé¼├É┬¢├æÔÇ╣├É┬Á ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣; ├É┬Á├É┬Â├É┬Á├É┬┤├É┬¢├É┬Á├É┬▓├É┬¢├É┬¥ ├óÔé¼ÔÇØ ├É┬▒├É┬¥├É┬╗├æ┼Æ├æ╦å├É┬©├É┬Á, ├É┬¢├É┬¥ ├æÔé¼├É┬Á├É┬┤├É┬║├É┬©├É┬Á. ├É┼¥├É┬▒├É┬░ ├æÔé¼├É┬Á├É┬Â├É┬©├É┬╝├É┬░ ├É┬┐├É┬¥├É┬┤├æÔÇª├É┬¥├É┬┤├æ┬Å├æÔÇÜ ├É┬┤├É┬╗├æ┬Å ├É┬╗├æ┼¢├É┬▒├É┬¥├É┬│├É┬¥ ├æ┬ü├æÔÇÜ├É┬©├É┬╗├æ┬Å ├É┬©├É┬│├æÔé¼├æÔÇ╣.]]></ru>
+            <da><![CDATA[Timevis: 24 betalinger pr. in-game time. Dagligt: en betaling ved starten af hver in-game dag. Skift n├â┬Ñr som helst via ESC ├óÔÇáÔÇÖ Indstillinger ├óÔÇáÔÇÖ Income Mod.]]></da>
         </text>
 
         <text name="im_help_s1_diff_title">
             <en><![CDATA[Difficulty]]></en>
             <de><![CDATA[Schwierigkeit]]></de>
-            <fr><![CDATA[Difficultâ”œÃ¢â”¬Â®]]></fr>
-            <pl><![CDATA[Trudnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­]]></pl>
+            <fr><![CDATA[Difficult├â┬®]]></fr>
+            <pl><![CDATA[Trudno├àÔÇ║├äÔÇí]]></pl>
             <es><![CDATA[Dificultad]]></es>
-            <it><![CDATA[Difficoltâ”œÃ¢â”¬Ã¡]]></it>
-            <cz><![CDATA[Obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nost]]></cz>
+            <it><![CDATA[Difficolt├â┬á]]></it>
+            <cz><![CDATA[Obt├â┬¡├à┬¥nost]]></cz>
             <br><![CDATA[Dificuldade]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†]]></ru>
-            <da><![CDATA[Svâ”œÃ¢â”¬Âªrhedsgrad]]></da>
+            <uk><![CDATA[├É┬í├É┬║├É┬╗├É┬░├É┬┤├É┬¢├æÔÇô├æ┬ü├æÔÇÜ├æ┼Æ]]></uk>
+            <ru><![CDATA[├É┬í├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æ┼Æ]]></ru>
+            <da><![CDATA[Sv├â┬ªrhedsgrad]]></da>
         </text>
 
         <text name="im_help_s1_diff_text">
             <en><![CDATA[Sets the base income per payment. Easy: $5,000. Normal: $2,400. Hard: $1,100. These are base amounts before any multiplier or seasonal modifier is applied.]]></en>
-            <de><![CDATA[Legt den Basiseinkommensbetrag fest. Einfach: 5.000$. Normal: 2.400$. Schwer: 1.100$. Das sind Grundbetrâ”œÃ¢â”¬Ã±ge vor jeglichem Multiplikator oder saisonalem Modifikator.]]></de>
-            <fr><![CDATA[Dâ”œÃ¢â”¬Â®finit le revenu de base par paiement. Facile : 5 000$. Normal : 2 400$. Difficile : 1 100$. Ce sont des montants de base avant tout multiplicateur ou modificateur saisonnier.]]></fr>
-            <pl><![CDATA[Ustawia podstawowâ”œÃ¤Ã”Ã‡Âª kwotâ”œÃ¤Ã”Ã¤Ã³ za pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­. â”œÃ â”¬Ã¼atwy: 5 000$. Normalny: 2 400$. Trudny: 1 100$. Sâ”œÃ¤Ã”Ã‡Âª to kwoty bazowe przed zastosowaniem mnoâ”œÃ â”¬â•nika lub modyfikatora sezonowego.]]></pl>
-            <es><![CDATA[Define el ingreso base por pago. Fâ”œÃ¢â”¬Ã­cil: $5.000. Normal: $2.400. Difâ”œÃ¢â”¬Â¡cil: $1.100. Estos son montos base antes de cualquier multiplicador o modificador estacional.]]></es>
+            <de><![CDATA[Legt den Basiseinkommensbetrag fest. Einfach: 5.000$. Normal: 2.400$. Schwer: 1.100$. Das sind Grundbetr├â┬ñge vor jeglichem Multiplikator oder saisonalem Modifikator.]]></de>
+            <fr><![CDATA[D├â┬®finit le revenu de base par paiement. Facile : 5 000$. Normal : 2 400$. Difficile : 1 100$. Ce sont des montants de base avant tout multiplicateur ou modificateur saisonnier.]]></fr>
+            <pl><![CDATA[Ustawia podstawow├äÔÇª kwot├äÔäó za p├àÔÇÜatno├àÔÇ║├äÔÇí. ├à┬üatwy: 5 000$. Normalny: 2 400$. Trudny: 1 100$. S├äÔÇª to kwoty bazowe przed zastosowaniem mno├à┬╝nika lub modyfikatora sezonowego.]]></pl>
+            <es><![CDATA[Define el ingreso base por pago. F├â┬ícil: $5.000. Normal: $2.400. Dif├â┬¡cil: $1.100. Estos son montos base antes de cualquier multiplicador o modificador estacional.]]></es>
             <it><![CDATA[Imposta il reddito base per pagamento. Facile: $5.000. Normale: $2.400. Difficile: $1.100. Sono importi base prima di qualsiasi moltiplicatore o modificatore stagionale.]]></it>
-            <cz><![CDATA[Nastavuje zâ”œÃ¢â”¬Ã­kladnâ”œÃ¢â”¬Â¡ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem za platbu. Snadnâ”œÃ¢â”¬Â®: 5 000$. Normâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡: 2 400$. Tâ”œÃ¤Ã”Ã‡â•‘â”œÃ â”¬Â¥kâ”œÃ¢â”¬Â®: 1 100$. Jde o zâ”œÃ¢â”¬Ã­kladnâ”œÃ¢â”¬Â¡ â”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­stky pâ”œÃ Ã”Ã¤Ã³ed jakâ”œÃ¢â”¬Â¢mkoli multiplikâ”œÃ¢â”¬Ã­torem nebo sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡m modifikâ”œÃ¢â”¬Ã­torem.]]></cz>
-            <br><![CDATA[Define a renda base por pagamento. Fâ”œÃ¢â”¬Ã­cil: $5.000. Normal: $2.400. Difâ”œÃ¢â”¬Â¡cil: $1.100. Sâ”œÃ¢â”¬Ãºo valores base antes de qualquer multiplicador ou modificador sazonal.]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†. â”œÃ‰Ã”Ã‡â•‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥: $5 000. â”œÃ‰â”¬Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: $2 400. â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥: $1 100. â”œÃ‰â”¬Âªâ”œÃ‰â”¬Ã â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬â–’â”œÃ¦Ã£Ã†â”œÃ‰â”¬â”¤â”œÃ¦â”¼Ã†-â”œÃ¦â”¬Ã…â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â•â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã—â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘.]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†. â”œÃ‰Ã”Ã‡â•‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥: $5 000. â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: $2 400. â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: $1 100. â”œÃ‰â”¬Â¡â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬Ã â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘.]]></ru>
-            <da><![CDATA[Indstiller den grundlâ”œÃ¢â”¬Âªggende indkomst pr. betaling. Let: $5.000. Normal: $2.400. Svâ”œÃ¢â”¬Âªr: $1.100. Dette er grundbelâ”œÃ¢â”¬Â©b fâ”œÃ¢â”¬Â©r nogen multiplikator eller sâ”œÃ¢â”¬Âªsonmâ”œÃ¢â”¬Âªssig modifikator anvendes.]]></da>
+            <cz><![CDATA[Nastavuje z├â┬íkladn├â┬¡ p├àÔäó├â┬¡jem za platbu. Snadn├â┬®: 5 000$. Norm├â┬íln├â┬¡: 2 400$. T├äÔÇ║├à┬¥k├â┬®: 1 100$. Jde o z├â┬íkladn├â┬¡ ├ä┬ì├â┬ístky p├àÔäóed jak├â┬¢mkoli multiplik├â┬ítorem nebo sez├â┬│nn├â┬¡m modifik├â┬ítorem.]]></cz>
+            <br><![CDATA[Define a renda base por pagamento. F├â┬ícil: $5.000. Normal: $2.400. Dif├â┬¡cil: $1.100. S├â┬úo valores base antes de qualquer multiplicador ou modificador sazonal.]]></br>
+            <uk><![CDATA[├ÉÔÇÖ├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¥├É┬▓├É┬╗├æ┼¢├æÔÇØ ├É┬▒├É┬░├É┬À├É┬¥├É┬▓├É┬©├É┬╣ ├É┬┤├É┬¥├æÔÇª├æÔÇô├É┬┤ ├É┬À├É┬░ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ. ├ÉÔÇ║├É┬Á├É┬│├É┬║├É┬¥: $5 000. ├É┬Ø├É┬¥├æÔé¼├É┬╝├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥: $2 400. ├ÉÔÇÖ├É┬░├É┬Â├É┬║├É┬¥: $1 100. ├É┬ª├É┬Á ├É┬▒├É┬░├É┬À├É┬¥├É┬▓├æÔÇô ├æ┬ü├æãÆ├É┬╝├É┬© ├É┬┤├É┬¥ ├É┬À├É┬░├æ┬ü├æÔÇÜ├É┬¥├æ┬ü├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å ├É┬▒├æãÆ├É┬┤├æ┼Æ-├æ┬Å├É┬║├É┬¥├É┬│├É┬¥ ├É┬╝├É┬¢├É┬¥├É┬Â├É┬¢├É┬©├É┬║├É┬░ ├É┬░├É┬▒├É┬¥ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬¥├É┬│├É┬¥ ├É┬╝├É┬¥├É┬┤├É┬©├æÔÇ×├æÔÇô├É┬║├É┬░├æÔÇÜ├É┬¥├æÔé¼├É┬░.]]></uk>
+            <ru><![CDATA[├É┬ú├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬░├É┬▓├É┬╗├É┬©├É┬▓├É┬░├É┬Á├æÔÇÜ ├É┬▒├É┬░├É┬À├É┬¥├É┬▓├æÔÇ╣├É┬╣ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤ ├É┬À├É┬░ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ. ├ÉÔÇ║├É┬Á├É┬│├É┬║├É┬¥: $5 000. ├É┼¥├É┬▒├æÔÇ╣├æÔÇí├É┬¢├É┬¥: $2 400. ├É┬í├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥: $1 100. ├É┬¡├æÔÇÜ├É┬¥ ├É┬▒├É┬░├É┬À├É┬¥├É┬▓├æÔÇ╣├É┬Á ├æ┬ü├æãÆ├É┬╝├É┬╝├æÔÇ╣ ├É┬┤├É┬¥ ├É┬┐├æÔé¼├É┬©├É┬╝├É┬Á├É┬¢├É┬Á├É┬¢├É┬©├æ┬Å ├É┬╝├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┬Å ├É┬©├É┬╗├É┬© ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬¥├É┬│├É┬¥ ├É┬╝├É┬¥├É┬┤├É┬©├æÔÇ×├É┬©├É┬║├É┬░├æÔÇÜ├É┬¥├æÔé¼├É┬░.]]></ru>
+            <da><![CDATA[Indstiller den grundl├â┬ªggende indkomst pr. betaling. Let: $5.000. Normal: $2.400. Sv├â┬ªr: $1.100. Dette er grundbel├â┬©b f├â┬©r nogen multiplikator eller s├â┬ªsonm├â┬ªssig modifikator anvendes.]]></da>
         </text>
 
-        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page 4 â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Advanced Settings â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
+        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page 4 ├óÔé¼ÔÇØ Advanced Settings ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
         <text name="im_help_s2_mult_title">
             <en><![CDATA[Income Multiplier]]></en>
             <de><![CDATA[Einkommensmultiplikator]]></de>
             <fr><![CDATA[Multiplicateur de revenu]]></fr>
-            <pl><![CDATA[Mnoâ”œÃ â”¬â•nik dochodu]]></pl>
+            <pl><![CDATA[Mno├à┬╝nik dochodu]]></pl>
             <es><![CDATA[Multiplicador de ingresos]]></es>
             <it><![CDATA[Moltiplicatore reddito]]></it>
-            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ multiplikâ”œÃ¢â”¬Ã­tor]]></cz>
+            <cz><![CDATA[P├àÔäó├â┬¡jmov├â┬¢ multiplik├â┬ítor]]></cz>
             <br><![CDATA[Multiplicador de renda]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
+            <uk><![CDATA[├É┼ô├É┬¢├É┬¥├É┬Â├É┬¢├É┬©├É┬║ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
+            <ru><![CDATA[├É┼ô├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┼Æ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
             <da><![CDATA[Indkomstmultiplikator]]></da>
         </text>
 
         <text name="im_help_s2_mult_text">
-            <en><![CDATA[Scales all income by 1x, 2x, 5x, or 10x. Applied after difficulty, before seasonal. Example: Normal ($2,400) â”œÃ¢Ã”Ã‡Ã¶ 5x = $12,000 per payment. Great for creative or boosted playthroughs.]]></en>
-            <de><![CDATA[Skaliert alle Einnahmen um 1x, 2x, 5x oder 10x. Wird nach Schwierigkeit, vor Saison angewendet. Beispiel: Normal (2.400$) â”œÃ¢Ã”Ã‡Ã¶ 5x = 12.000$ pro Zahlung.]]></de>
-            <fr><![CDATA[Multiplie tous les revenus par 1x, 2x, 5x ou 10x. Appliquâ”œÃ¢â”¬Â® aprâ”œÃ¢â”¬Â¿s la difficultâ”œÃ¢â”¬Â®, avant le saisonnier. Exemple : Normal (2 400$) â”œÃ¢Ã”Ã‡Ã¶ 5x = 12 000$ par paiement.]]></fr>
-            <pl><![CDATA[Skaluje wszystkie dochody 1x, 2x, 5x lub 10x. Stosowany po trudnoâ”œÃ Ã”Ã‡â•‘ci, przed sezonem. Przykâ”œÃ Ã”Ã‡Ãœad: Normalny (2 400$) â”œÃ¢Ã”Ã‡Ã¶ 5x = 12 000$ za pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­.]]></pl>
-            <es><![CDATA[Escala los ingresos por 1x, 2x, 5x o 10x. Aplicado tras la dificultad, antes del estacional. Ejemplo: Normal ($2.400) â”œÃ¢Ã”Ã‡Ã¶ 5x = $12.000 por pago.]]></es>
-            <it><![CDATA[Moltiplica il reddito per 1x, 2x, 5x o 10x. Applicato dopo la difficoltâ”œÃ¢â”¬Ã¡, prima del stagionale. Esempio: Normale ($2.400) â”œÃ¢Ã”Ã‡Ã¶ 5x = $12.000 per pagamento.]]></it>
-            <cz><![CDATA[â”œÃ â”¬Ã¡kâ”œÃ¢â”¬Ã­luje pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmy 1x, 2x, 5x nebo 10x. Aplikuje se po obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nosti, pâ”œÃ Ã”Ã¤Ã³ed sezâ”œÃ¢â”¬â”‚nou. Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡klad: Normâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡ (2 400$) â”œÃ¢Ã”Ã‡Ã¶ 5x = 12 000$ za platbu.]]></cz>
-            <br><![CDATA[Escala a renda em 1x, 2x, 5x ou 10x. Aplicado apâ”œÃ¢â”¬â”‚s a dificuldade, antes do sazonal. Exemplo: Normal ($2.400) â”œÃ¢Ã”Ã‡Ã¶ 5x = $12.000 por pagamento.]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ¦â”¼Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ 1x, 2x, 5x â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ 10x. â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã´, â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤: â”œÃ‰â”¬Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ ($2 400) â”œÃ¢Ã”Ã‡Ã¶ 5x = $12 000 â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†.]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ¦â”¼Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ 1x, 2x, 5x â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© 10x. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ã â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©, â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼: â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ ($2 400) â”œÃ¢Ã”Ã‡Ã¶ 5x = $12 000 â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†.]]></ru>
-            <da><![CDATA[Skalerer al indkomst med 1x, 2x, 5x eller 10x. Anvendes efter svâ”œÃ¢â”¬Âªrhedsgrad, fâ”œÃ¢â”¬Â©r sâ”œÃ¢â”¬Âªson. Eksempel: Normal ($2.400) â”œÃ¢Ã”Ã‡Ã¶ 5x = $12.000 pr. betaling.]]></da>
+            <en><![CDATA[Scales all income by 1x, 2x, 5x, or 10x. Applied after difficulty, before seasonal. Example: Normal ($2,400) ├âÔÇö 5x = $12,000 per payment. Great for creative or boosted playthroughs.]]></en>
+            <de><![CDATA[Skaliert alle Einnahmen um 1x, 2x, 5x oder 10x. Wird nach Schwierigkeit, vor Saison angewendet. Beispiel: Normal (2.400$) ├âÔÇö 5x = 12.000$ pro Zahlung.]]></de>
+            <fr><![CDATA[Multiplie tous les revenus par 1x, 2x, 5x ou 10x. Appliqu├â┬® apr├â┬¿s la difficult├â┬®, avant le saisonnier. Exemple : Normal (2 400$) ├âÔÇö 5x = 12 000$ par paiement.]]></fr>
+            <pl><![CDATA[Skaluje wszystkie dochody 1x, 2x, 5x lub 10x. Stosowany po trudno├àÔÇ║ci, przed sezonem. Przyk├àÔÇÜad: Normalny (2 400$) ├âÔÇö 5x = 12 000$ za p├àÔÇÜatno├àÔÇ║├äÔÇí.]]></pl>
+            <es><![CDATA[Escala los ingresos por 1x, 2x, 5x o 10x. Aplicado tras la dificultad, antes del estacional. Ejemplo: Normal ($2.400) ├âÔÇö 5x = $12.000 por pago.]]></es>
+            <it><![CDATA[Moltiplica il reddito per 1x, 2x, 5x o 10x. Applicato dopo la difficolt├â┬á, prima del stagionale. Esempio: Normale ($2.400) ├âÔÇö 5x = $12.000 per pagamento.]]></it>
+            <cz><![CDATA[├à┬ák├â┬íluje p├àÔäó├â┬¡jmy 1x, 2x, 5x nebo 10x. Aplikuje se po obt├â┬¡├à┬¥nosti, p├àÔäóed sez├â┬│nou. P├àÔäó├â┬¡klad: Norm├â┬íln├â┬¡ (2 400$) ├âÔÇö 5x = 12 000$ za platbu.]]></cz>
+            <br><![CDATA[Escala a renda em 1x, 2x, 5x ou 10x. Aplicado ap├â┬│s a dificuldade, antes do sazonal. Exemplo: Normal ($2.400) ├âÔÇö 5x = $12.000 por pagamento.]]></br>
+            <uk><![CDATA[├É┼ô├É┬░├æ┬ü├æ╦å├æÔÇÜ├É┬░├É┬▒├æãÆ├æÔÇØ ├É┬▓├É┬Á├æ┬ü├æ┼Æ ├É┬┤├É┬¥├æÔÇª├æÔÇô├É┬┤ ├É┬¢├É┬░ 1x, 2x, 5x ├É┬░├É┬▒├É┬¥ 10x. ├ÉÔÇö├É┬░├æ┬ü├æÔÇÜ├É┬¥├æ┬ü├É┬¥├É┬▓├æãÆ├æÔÇØ├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├É┬┐├æÔÇô├æ┬ü├É┬╗├æ┬Å ├æ┬ü├É┬║├É┬╗├É┬░├É┬┤├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æÔÇô, ├É┬┐├É┬Á├æÔé¼├É┬Á├É┬┤ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬©├É┬╝. ├É┼©├æÔé¼├É┬©├É┬║├É┬╗├É┬░├É┬┤: ├É┬Ø├É┬¥├æÔé¼├É┬╝├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥ ($2 400) ├âÔÇö 5x = $12 000 ├É┬À├É┬░ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ.]]></uk>
+            <ru><![CDATA[├É┼ô├É┬░├æ┬ü├æ╦å├æÔÇÜ├É┬░├É┬▒├É┬©├æÔé¼├æãÆ├É┬Á├æÔÇÜ ├É┬▓├É┬Á├æ┬ü├æ┼Æ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤ ├É┬¢├É┬░ 1x, 2x, 5x ├É┬©├É┬╗├É┬© 10x. ├É┼©├æÔé¼├É┬©├É┬╝├É┬Á├É┬¢├æ┬Å├É┬Á├æÔÇÜ├æ┬ü├æ┬Å ├É┬┐├É┬¥├æ┬ü├É┬╗├É┬Á ├æ┬ü├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├É┬©, ├É┬┤├É┬¥ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬¥├É┬│├É┬¥. ├É┼©├æÔé¼├É┬©├É┬╝├É┬Á├æÔé¼: ├É┼¥├É┬▒├æÔÇ╣├æÔÇí├É┬¢├É┬¥ ($2 400) ├âÔÇö 5x = $12 000 ├É┬À├É┬░ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ.]]></ru>
+            <da><![CDATA[Skalerer al indkomst med 1x, 2x, 5x eller 10x. Anvendes efter sv├â┬ªrhedsgrad, f├â┬©r s├â┬ªson. Eksempel: Normal ($2.400) ├âÔÇö 5x = $12.000 pr. betaling.]]></da>
         </text>
 
         <text name="im_help_s2_seasonal_title">
@@ -1148,56 +1148,56 @@
             <pl><![CDATA[Efekty sezonowe]]></pl>
             <es><![CDATA[Efectos estacionales]]></es>
             <it><![CDATA[Effetti stagionali]]></it>
-            <cz><![CDATA[Sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡ efekty]]></cz>
+            <cz><![CDATA[Sez├â┬│nn├â┬¡ efekty]]></cz>
             <br><![CDATA[Efeitos sazonais]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬Ã â”œÃ¦â”¬Ã¬â”œÃ¦Ã”Ã‡Ã—â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£]]></ru>
-            <da><![CDATA[Sâ”œÃ¢â”¬Âªsonale effekter]]></da>
+            <uk><![CDATA[├É┬í├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├æÔÇô ├É┬Á├æÔÇ×├É┬Á├É┬║├æÔÇÜ├É┬©]]></uk>
+            <ru><![CDATA[├É┬í├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├æÔÇ╣├É┬Á ├æ┬ì├æÔÇ×├æÔÇ×├É┬Á├É┬║├æÔÇÜ├æÔÇ╣]]></ru>
+            <da><![CDATA[S├â┬ªsonale effekter]]></da>
         </text>
 
         <text name="im_help_s2_seasonal_text">
             <en><![CDATA[When enabled, a seasonal modifier is applied. Spring: 0.8x. Summer: 1.0x. Autumn: 1.2x (peak). Winter: 0.7x (off-season). Disabled by default.]]></en>
-            <de><![CDATA[Wenn aktiviert, wird ein saisonaler Modifikator angewendet. Frâ”œÃ¢â”¬â•hling: 0,8x. Sommer: 1,0x. Herbst: 1,2x (Hâ”œÃ¢â”¬Ã‚hepunkt). Winter: 0,7x. Standardmâ”œÃ¢â”¬Ã±â”œÃ¢â”¼Â©ig deaktiviert.]]></de>
-            <fr><![CDATA[Quand activâ”œÃ¢â”¬Â®, un modificateur saisonnier est appliquâ”œÃ¢â”¬Â®. Printemps : 0,8x. â”œÃ¢Ã”Ã‡â–‘tâ”œÃ¢â”¬Â® : 1,0x. Automne : 1,2x (pic). Hiver : 0,7x (hors-saison). Dâ”œÃ¢â”¬Â®sactivâ”œÃ¢â”¬Â® par dâ”œÃ¢â”¬Â®faut.]]></fr>
-            <pl><![CDATA[Po wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczeniu stosowany jest modyfikator sezonowy. Wiosna: 0,8x. Lato: 1,0x. Jesieâ”œÃ Ã”Ã‡Ã—: 1,2x (szczyt). Zima: 0,7x. Domyâ”œÃ Ã”Ã‡â•‘lnie wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczone.]]></pl>
-            <es><![CDATA[Cuando estâ”œÃ¢â”¬Ã­ habilitado se aplica un modificador estacional. Primavera: 0,8x. Verano: 1,0x. Otoâ”œÃ¢â”¬â–’o: 1,2x (pico). Invierno: 0,7x. Desactivado por defecto.]]></es>
+            <de><![CDATA[Wenn aktiviert, wird ein saisonaler Modifikator angewendet. Fr├â┬╝hling: 0,8x. Sommer: 1,0x. Herbst: 1,2x (H├â┬Âhepunkt). Winter: 0,7x. Standardm├â┬ñ├â┼©ig deaktiviert.]]></de>
+            <fr><![CDATA[Quand activ├â┬®, un modificateur saisonnier est appliqu├â┬®. Printemps : 0,8x. ├âÔÇ░t├â┬® : 1,0x. Automne : 1,2x (pic). Hiver : 0,7x (hors-saison). D├â┬®sactiv├â┬® par d├â┬®faut.]]></fr>
+            <pl><![CDATA[Po w├àÔÇÜ├äÔÇªczeniu stosowany jest modyfikator sezonowy. Wiosna: 0,8x. Lato: 1,0x. Jesie├àÔÇ×: 1,2x (szczyt). Zima: 0,7x. Domy├àÔÇ║lnie wy├àÔÇÜ├äÔÇªczone.]]></pl>
+            <es><![CDATA[Cuando est├â┬í habilitado se aplica un modificador estacional. Primavera: 0,8x. Verano: 1,0x. Oto├â┬▒o: 1,2x (pico). Invierno: 0,7x. Desactivado por defecto.]]></es>
             <it><![CDATA[Quando abilitato, viene applicato un modificatore stagionale. Primavera: 0,8x. Estate: 1,0x. Autunno: 1,2x (picco). Inverno: 0,7x. Disabilitato per default.]]></it>
-            <cz><![CDATA[Kdyâ”œÃ â”¬Â¥ je povoleno, pouâ”œÃ â”¬Â¥ije se sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡ modifikâ”œÃ¢â”¬Ã­tor. Jaro: 0,8x. Lâ”œÃ¢â”¬Â®to: 1,0x. Podzim: 1,2x (vrchol). Zima: 0,7x. Ve vâ”œÃ¢â”¬Â¢chozâ”œÃ¢â”¬Â¡m nastavenâ”œÃ¢â”¬Â¡ zakâ”œÃ¢â”¬Ã­zâ”œÃ¢â”¬Ã­no.]]></cz>
-            <br><![CDATA[Quando ativado, um modificador sazonal â”œÃ¢â”¬Â® aplicado. Primavera: 0,8x. Verâ”œÃ¢â”¬Ãºo: 1,0x. Outono: 1,2x (pico). Inverno: 0,7x. Desativado por padrâ”œÃ¢â”¬Ãºo.]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥, â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã—â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼. â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘: 0,8x. â”œÃ‰Ã”Ã‡â•‘â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥: 1,0x. â”œÃ‰â”¼Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†: 1,2x (â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•‘). â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘: 0,7x. â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬â• â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥.]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥, â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼. â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘: 0,8x. â”œÃ‰Ã”Ã‡â•‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥: 1,0x. â”œÃ‰â”¼Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†: 1,2x (â”œÃ‰â”¬â”â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘). â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘: 0,7x. â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥ â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¼Â¢ â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥.]]></ru>
-            <da><![CDATA[Nâ”œÃ¢â”¬Ã‘r aktiveret, anvendes en sâ”œÃ¢â”¬Âªsonmâ”œÃ¢â”¬Âªssig modifikator. Forâ”œÃ¢â”¬Ã‘r: 0,8x. Sommer: 1,0x. Efterâ”œÃ¢â”¬Ã‘r: 1,2x (top). Vinter: 0,7x. Deaktiveret som standard.]]></da>
+            <cz><![CDATA[Kdy├à┬¥ je povoleno, pou├à┬¥ije se sez├â┬│nn├â┬¡ modifik├â┬ítor. Jaro: 0,8x. L├â┬®to: 1,0x. Podzim: 1,2x (vrchol). Zima: 0,7x. Ve v├â┬¢choz├â┬¡m nastaven├â┬¡ zak├â┬íz├â┬íno.]]></cz>
+            <br><![CDATA[Quando ativado, um modificador sazonal ├â┬® aplicado. Primavera: 0,8x. Ver├â┬úo: 1,0x. Outono: 1,2x (pico). Inverno: 0,7x. Desativado por padr├â┬úo.]]></br>
+            <uk><![CDATA[├É┼í├É┬¥├É┬╗├É┬© ├æãÆ├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├É┬Á├É┬¢├É┬¥, ├É┬À├É┬░├æ┬ü├æÔÇÜ├É┬¥├æ┬ü├É┬¥├É┬▓├æãÆ├æÔÇØ├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬©├É┬╣ ├É┬╝├É┬¥├É┬┤├É┬©├æÔÇ×├æÔÇô├É┬║├É┬░├æÔÇÜ├É┬¥├æÔé¼. ├ÉÔÇÖ├É┬Á├æ┬ü├É┬¢├É┬░: 0,8x. ├ÉÔÇ║├æÔÇô├æÔÇÜ├É┬¥: 1,0x. ├É┼¥├æ┬ü├æÔÇô├É┬¢├æ┼Æ: 1,2x (├É┬┐├æÔÇô├É┬║). ├ÉÔÇö├É┬©├É┬╝├É┬░: 0,7x. ├ÉÔÇö├É┬░ ├É┬À├É┬░├É┬╝├É┬¥├É┬▓├æÔÇí├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å├É┬╝ ├É┬▓├É┬©├É┬╝├É┬║├É┬¢├É┬Á├É┬¢├É┬¥.]]></uk>
+            <ru><![CDATA[├É┼í├É┬¥├É┬│├É┬┤├É┬░ ├É┬▓├É┬║├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬¢├É┬¥, ├É┬┐├æÔé¼├É┬©├É┬╝├É┬Á├É┬¢├æ┬Å├É┬Á├æÔÇÜ├æ┬ü├æ┬Å ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├æÔÇ╣├É┬╣ ├É┬╝├É┬¥├É┬┤├É┬©├æÔÇ×├É┬©├É┬║├É┬░├æÔÇÜ├É┬¥├æÔé¼. ├ÉÔÇÖ├É┬Á├æ┬ü├É┬¢├É┬░: 0,8x. ├ÉÔÇ║├É┬Á├æÔÇÜ├É┬¥: 1,0x. ├É┼¥├æ┬ü├É┬Á├É┬¢├æ┼Æ: 1,2x (├É┬┐├É┬©├É┬║). ├ÉÔÇö├É┬©├É┬╝├É┬░: 0,7x. ├É┼©├É┬¥ ├æãÆ├É┬╝├É┬¥├É┬╗├æÔÇí├É┬░├É┬¢├É┬©├æ┼¢ ├É┬¥├æÔÇÜ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬¢├É┬¥.]]></ru>
+            <da><![CDATA[N├â┬Ñr aktiveret, anvendes en s├â┬ªsonm├â┬ªssig modifikator. For├â┬Ñr: 0,8x. Sommer: 1,0x. Efter├â┬Ñr: 1,2x (top). Vinter: 0,7x. Deaktiveret som standard.]]></da>
         </text>
 
         <text name="im_help_s2_custom_title">
             <en><![CDATA[Custom Amount]]></en>
             <de><![CDATA[Benutzerdefinierter Betrag]]></de>
-            <fr><![CDATA[Montant personnalisâ”œÃ¢â”¬Â®]]></fr>
+            <fr><![CDATA[Montant personnalis├â┬®]]></fr>
             <pl><![CDATA[Niestandardowa kwota]]></pl>
             <es><![CDATA[Cantidad personalizada]]></es>
             <it><![CDATA[Importo personalizzato]]></it>
-            <cz><![CDATA[Vlastnâ”œÃ¢â”¬Â¡ â”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­stka]]></cz>
+            <cz><![CDATA[Vlastn├â┬¡ ├ä┬ì├â┬ístka]]></cz>
             <br><![CDATA[Valor personalizado]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘]]></ru>
-            <da><![CDATA[Brugerdefineret belâ”œÃ¢â”¬Â©b]]></da>
+            <uk><![CDATA[├ÉÔÇÖ├É┬╗├É┬░├æ┬ü├É┬¢├É┬░ ├æ┬ü├æãÆ├É┬╝├É┬░]]></uk>
+            <ru><![CDATA[├É┼©├É┬¥├É┬╗├æ┼Æ├É┬À├É┬¥├É┬▓├É┬░├æÔÇÜ├É┬Á├É┬╗├æ┼Æ├æ┬ü├É┬║├É┬░├æ┬Å ├æ┬ü├æãÆ├É┬╝├É┬╝├É┬░]]></ru>
+            <da><![CDATA[Brugerdefineret bel├â┬©b]]></da>
         </text>
 
         <text name="im_help_s2_custom_text">
             <en><![CDATA[Override the difficulty amount with a fixed value via console: IncomeSetCustomAmount 3000. Set to 0 to return to the difficulty-based amount. The multiplier still applies on top.]]></en>
-            <de><![CDATA[â”œÃ¢â”¼Ã´berschreibt den Schwierigkeitsbetrag per Konsole: IncomeSetCustomAmount 3000. Auf 0 setzen, um zur schwierigkeitsbezogenen Menge zurâ”œÃ¢â”¬â•ckzukehren. Der Multiplikator gilt weiterhin.]]></de>
-            <fr><![CDATA[Remplace le montant de difficultâ”œÃ¢â”¬Â® via console : IncomeSetCustomAmount 3000. Mettre 0 pour revenir au montant de difficultâ”œÃ¢â”¬Â®. Le multiplicateur s'applique toujours par-dessus.]]></fr>
-            <pl><![CDATA[Zastâ”œÃ¤Ã”Ã¤Ã³puje kwotâ”œÃ¤Ã”Ã¤Ã³ trudnoâ”œÃ Ã”Ã‡â•‘ci przez konsolâ”œÃ¤Ã”Ã¤Ã³: IncomeSetCustomAmount 3000. Ustaw 0, aby wrâ”œÃ¢â”¬â”‚ciâ”œÃ¤Ã”Ã‡Ã­ do kwoty opartej na trudnoâ”œÃ Ã”Ã‡â•‘ci. Mnoâ”œÃ â”¬â•nik nadal obowiâ”œÃ¤Ã”Ã‡Âªzuje.]]></pl>
-            <es><![CDATA[Anula el monto de dificultad via consola: IncomeSetCustomAmount 3000. Establece 0 para volver al monto por dificultad. El multiplicador aâ”œÃ¢â”¬â•‘n se aplica encima.]]></es>
-            <it><![CDATA[Sostituisce l'importo di difficoltâ”œÃ¢â”¬Ã¡ via console: IncomeSetCustomAmount 3000. Imposta 0 per tornare all'importo basato sulla difficoltâ”œÃ¢â”¬Ã¡. Il moltiplicatore si applica comunque.]]></it>
-            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³epâ”œÃ¢â”¬Â¡â”œÃ â”¬Ã­e obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nostnâ”œÃ¢â”¬Â¡ â”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­stku pâ”œÃ Ã”Ã¤Ã³es konzoli: IncomeSetCustomAmount 3000. Nastavte 0 pro nâ”œÃ¢â”¬Ã­vrat k obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nostnâ”œÃ¢â”¬Â¡ â”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­stce. Multiplikâ”œÃ¢â”¬Ã­tor se stâ”œÃ¢â”¬Ã­le pouâ”œÃ â”¬Â¥ije.]]></cz>
+            <de><![CDATA[├â┼ôberschreibt den Schwierigkeitsbetrag per Konsole: IncomeSetCustomAmount 3000. Auf 0 setzen, um zur schwierigkeitsbezogenen Menge zur├â┬╝ckzukehren. Der Multiplikator gilt weiterhin.]]></de>
+            <fr><![CDATA[Remplace le montant de difficult├â┬® via console : IncomeSetCustomAmount 3000. Mettre 0 pour revenir au montant de difficult├â┬®. Le multiplicateur s'applique toujours par-dessus.]]></fr>
+            <pl><![CDATA[Zast├äÔäópuje kwot├äÔäó trudno├àÔÇ║ci przez konsol├äÔäó: IncomeSetCustomAmount 3000. Ustaw 0, aby wr├â┬│ci├äÔÇí do kwoty opartej na trudno├àÔÇ║ci. Mno├à┬╝nik nadal obowi├äÔÇªzuje.]]></pl>
+            <es><![CDATA[Anula el monto de dificultad via consola: IncomeSetCustomAmount 3000. Establece 0 para volver al monto por dificultad. El multiplicador a├â┬║n se aplica encima.]]></es>
+            <it><![CDATA[Sostituisce l'importo di difficolt├â┬á via console: IncomeSetCustomAmount 3000. Imposta 0 per tornare all'importo basato sulla difficolt├â┬á. Il moltiplicatore si applica comunque.]]></it>
+            <cz><![CDATA[P├àÔäóep├â┬¡├à┬íe obt├â┬¡├à┬¥nostn├â┬¡ ├ä┬ì├â┬ístku p├àÔäóes konzoli: IncomeSetCustomAmount 3000. Nastavte 0 pro n├â┬ívrat k obt├â┬¡├à┬¥nostn├â┬¡ ├ä┬ì├â┬ístce. Multiplik├â┬ítor se st├â┬íle pou├à┬¥ije.]]></cz>
             <br><![CDATA[Substitui o valor de dificuldade via console: IncomeSetCustomAmount 3000. Defina 0 para voltar ao valor de dificuldade. O multiplicador ainda se aplica.]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¢â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã˜ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã´ â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€ â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†: IncomeSetCustomAmount 3000. â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† 0 â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã´. â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘ â”œÃ‰â”¬â–“â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ã â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã….]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€ â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†: IncomeSetCustomAmount 3000. â”œÃ‰â”¬Ãºâ”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã 0 â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬â•‘ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ‰â”¬Ã â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©. â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã† â”œÃ‰â”¬â–“â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã¿ â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã….]]></ru>
-            <da><![CDATA[Erstatter svâ”œÃ¢â”¬Âªrhedsgradsbelâ”œÃ¢â”¬Â©bet via konsol: IncomeSetCustomAmount 3000. Indstil 0 for at vende tilbage til svâ”œÃ¢â”¬Âªrhedsgradsbelâ”œÃ¢â”¬Â©bet. Multiplikatoren anvendes stadig.]]></da>
+            <uk><![CDATA[├ÉÔÇö├É┬░├É┬╝├æÔÇô├É┬¢├æ┼¢├æÔÇØ ├æ┬ü├æãÆ├É┬╝├æãÆ ├æ┬ü├É┬║├É┬╗├É┬░├É┬┤├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æÔÇô ├æÔÇí├É┬Á├æÔé¼├É┬Á├É┬À ├É┬║├É┬¥├É┬¢├æ┬ü├É┬¥├É┬╗├æ┼Æ: IncomeSetCustomAmount 3000. ├ÉÔÇÖ├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¥├É┬▓├æÔÇô├æÔÇÜ├æ┼Æ 0 ├É┬┤├É┬╗├æ┬Å ├É┬┐├É┬¥├É┬▓├É┬Á├æÔé¼├É┬¢├É┬Á├É┬¢├É┬¢├æ┬Å ├É┬┤├É┬¥ ├æ┬ü├æãÆ├É┬╝├É┬© ├É┬¢├É┬░ ├É┬¥├æ┬ü├É┬¢├É┬¥├É┬▓├æÔÇô ├æ┬ü├É┬║├É┬╗├É┬░├É┬┤├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æÔÇô. ├É┼ô├É┬¢├É┬¥├É┬Â├É┬¢├É┬©├É┬║ ├É┬▓├æ┬ü├É┬Á ├É┬¥├É┬┤├É┬¢├É┬¥ ├É┬À├É┬░├æ┬ü├æÔÇÜ├É┬¥├æ┬ü├É┬¥├É┬▓├æãÆ├æÔÇØ├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å.]]></uk>
+            <ru><![CDATA[├ÉÔÇö├É┬░├É┬╝├É┬Á├É┬¢├æ┬Å├É┬Á├æÔÇÜ ├æ┬ü├æãÆ├É┬╝├É┬╝├æãÆ ├æ┬ü├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├É┬© ├æÔÇí├É┬Á├æÔé¼├É┬Á├É┬À ├É┬║├É┬¥├É┬¢├æ┬ü├É┬¥├É┬╗├æ┼Æ: IncomeSetCustomAmount 3000. ├É┬ú├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¥├É┬▓├É┬©├æÔÇÜ├É┬Á 0 ├É┬┤├É┬╗├æ┬Å ├É┬▓├É┬¥├É┬À├É┬▓├æÔé¼├É┬░├æÔÇÜ├É┬░ ├É┬║ ├æ┬ü├æãÆ├É┬╝├É┬╝├É┬Á ├æ┬ü├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├É┬©. ├É┼ô├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┼Æ ├É┬▓├æ┬ü├æÔÇÿ ├æÔé¼├É┬░├É┬▓├É┬¢├É┬¥ ├É┬┐├æÔé¼├É┬©├É┬╝├É┬Á├É┬¢├æ┬Å├É┬Á├æÔÇÜ├æ┬ü├æ┬Å.]]></ru>
+            <da><![CDATA[Erstatter sv├â┬ªrhedsgradsbel├â┬©bet via konsol: IncomeSetCustomAmount 3000. Indstil 0 for at vende tilbage til sv├â┬ªrhedsgradsbel├â┬©bet. Multiplikatoren anvendes stadig.]]></da>
         </text>
 
-        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page 5 â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Display & Reset â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
+        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page 5 ├óÔé¼ÔÇØ Display & Reset ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
         <text name="im_help_s3_hud_title">
             <en><![CDATA[Income HUD]]></en>
             <de><![CDATA[Einkommens-HUD]]></de>
@@ -1205,25 +1205,25 @@
             <pl><![CDATA[HUD dochodu]]></pl>
             <es><![CDATA[HUD de ingresos]]></es>
             <it><![CDATA[HUD reddito]]></it>
-            <cz><![CDATA[HUD pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â»]]></cz>
+            <cz><![CDATA[HUD p├àÔäó├â┬¡jm├à┬»]]></cz>
             <br><![CDATA[HUD de renda]]></br>
-            <uk><![CDATA[HUD â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
-            <ru><![CDATA[HUD â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
+            <uk><![CDATA[HUD ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
+            <ru><![CDATA[HUD ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
             <da><![CDATA[Indkomst-HUD]]></da>
         </text>
 
         <text name="im_help_s3_hud_text">
             <en><![CDATA[Shows your income rate, mode, difficulty, multiplier, seasonal status, next payment time, and last 5 payments. Toggle with the I key or disable permanently in Settings.]]></en>
-            <de><![CDATA[Zeigt Einkommenshâ”œÃ¢â”¬Ã‚he, Modus, Schwierigkeit, Multiplikator, Saisonstatus, nâ”œÃ¢â”¬Ã±chste Zahlung und die letzten 5 Zahlungen. Mit I umschalten oder in Einstellungen dauerhaft deaktivieren.]]></de>
-            <fr><![CDATA[Affiche revenu, mode, difficultâ”œÃ¢â”¬Â®, multiplicateur, â”œÃ¢â”¬Â®tat saisonnier, prochain paiement et 5 derniers paiements. Touche I pour basculer ou dâ”œÃ¢â”¬Â®sactiver dans Paramâ”œÃ¢â”¬Â¿tres.]]></fr>
-            <pl><![CDATA[Pokazuje dochâ”œÃ¢â”¬â”‚d, tryb, trudnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­, mnoâ”œÃ â”¬â•nik, status sezonowy, nastâ”œÃ¤Ã”Ã¤Ã³pnâ”œÃ¤Ã”Ã‡Âª pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­ i 5 ostatnich pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci. Przeâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz klawiszem I lub wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz w ustawieniach.]]></pl>
-            <es><![CDATA[Muestra ingreso, modo, dificultad, multiplicador, estado estacional, prâ”œÃ¢â”¬â”‚ximo pago y â”œÃ¢â”¬â•‘ltimos 5 pagos. Tecla I para alternar o desactivar en Ajustes.]]></es>
-            <it><![CDATA[Mostra reddito, modalitâ”œÃ¢â”¬Ã¡, difficoltâ”œÃ¢â”¬Ã¡, moltiplicatore, stato stagionale, prossimo pagamento e ultimi 5 pagamenti. Tasto I per alternare o disabilitare nelle Impostazioni.]]></it>
-            <cz><![CDATA[Zobrazuje pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem, reâ”œÃ â”¬Â¥im, obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nost, multiplikâ”œÃ¢â”¬Ã­tor, sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡ stav, pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡â”œÃ â”¬Ã­tâ”œÃ¢â”¬Â¡ platbu a poslednâ”œÃ¢â”¬Â¡ch 5 plateb. Klâ”œÃ¢â”¬Ã­vesou I pâ”œÃ Ã”Ã¤Ã³epnâ”œÃ¤Ã”Ã‡â•‘te nebo trvale zakaâ”œÃ â”¬Â¥te v Nastavenâ”œÃ¢â”¬Â¡.]]></cz>
-            <br><![CDATA[Mostra renda, modo, dificuldade, multiplicador, status sazonal, prâ”œÃ¢â”¬â”‚ximo pagamento e â”œÃ¢â”¬â•‘ltimos 5 pagamentos. Tecla I para alternar ou desativar nas Configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães.]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤, â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â•, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†, â”œÃ‰â”¬â•â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ¦â”¬Ã¼, â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â”â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ 5 â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Âª â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ. â”œÃ‰â”¼Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘ I â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â–“ â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ¦Ã”Ã‡Âª.]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤, â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â•, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†, â”œÃ‰â”¬â•â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ¦â”¬Ã¼, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡â–‘â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ‰â”¬Â© â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã 5 â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ. â”œÃ‰â”¼Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘ I â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â–“ â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª.]]></ru>
-            <da><![CDATA[Viser indkomst, tilstand, svâ”œÃ¢â”¬Âªrhedsgrad, multiplikator, sâ”œÃ¢â”¬Âªsonstatus, nâ”œÃ¢â”¬Âªste betaling og de sidste 5 betalinger. Tasten I for at skifte eller deaktivere i Indstillinger.]]></da>
+            <de><![CDATA[Zeigt Einkommensh├â┬Âhe, Modus, Schwierigkeit, Multiplikator, Saisonstatus, n├â┬ñchste Zahlung und die letzten 5 Zahlungen. Mit I umschalten oder in Einstellungen dauerhaft deaktivieren.]]></de>
+            <fr><![CDATA[Affiche revenu, mode, difficult├â┬®, multiplicateur, ├â┬®tat saisonnier, prochain paiement et 5 derniers paiements. Touche I pour basculer ou d├â┬®sactiver dans Param├â┬¿tres.]]></fr>
+            <pl><![CDATA[Pokazuje doch├â┬│d, tryb, trudno├àÔÇ║├äÔÇí, mno├à┬╝nik, status sezonowy, nast├äÔäópn├äÔÇª p├àÔÇÜatno├àÔÇ║├äÔÇí i 5 ostatnich p├àÔÇÜatno├àÔÇ║ci. Prze├àÔÇÜ├äÔÇªcz klawiszem I lub wy├àÔÇÜ├äÔÇªcz w ustawieniach.]]></pl>
+            <es><![CDATA[Muestra ingreso, modo, dificultad, multiplicador, estado estacional, pr├â┬│ximo pago y ├â┬║ltimos 5 pagos. Tecla I para alternar o desactivar en Ajustes.]]></es>
+            <it><![CDATA[Mostra reddito, modalit├â┬á, difficolt├â┬á, moltiplicatore, stato stagionale, prossimo pagamento e ultimi 5 pagamenti. Tasto I per alternare o disabilitare nelle Impostazioni.]]></it>
+            <cz><![CDATA[Zobrazuje p├àÔäó├â┬¡jem, re├à┬¥im, obt├â┬¡├à┬¥nost, multiplik├â┬ítor, sez├â┬│nn├â┬¡ stav, p├àÔäó├â┬¡├à┬ít├â┬¡ platbu a posledn├â┬¡ch 5 plateb. Kl├â┬ívesou I p├àÔäóepn├äÔÇ║te nebo trvale zaka├à┬¥te v Nastaven├â┬¡.]]></cz>
+            <br><![CDATA[Mostra renda, modo, dificuldade, multiplicador, status sazonal, pr├â┬│ximo pagamento e ├â┬║ltimos 5 pagamentos. Tecla I para alternar ou desativar nas Configura├â┬º├â┬Áes.]]></br>
+            <uk><![CDATA[├É┼©├É┬¥├É┬║├É┬░├É┬À├æãÆ├æÔÇØ ├É┬┤├É┬¥├æÔÇª├æÔÇô├É┬┤, ├æÔé¼├É┬Á├É┬Â├É┬©├É┬╝, ├æ┬ü├É┬║├É┬╗├É┬░├É┬┤├É┬¢├æÔÇô├æ┬ü├æÔÇÜ├æ┼Æ, ├É┬╝├É┬¢├É┬¥├É┬Â├É┬¢├É┬©├É┬║, ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬©├É┬╣ ├æ┬ü├æÔÇÜ├É┬░├æÔÇÜ├æãÆ├æ┬ü, ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æãÆ├É┬┐├É┬¢├æãÆ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ ├æÔÇÜ├É┬░ 5 ├É┬¥├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¢├æÔÇô├æÔÇª ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ. ├É┼í├É┬╗├É┬░├É┬▓├æÔÇô├æ╦å├É┬░ I ├É┬┤├É┬╗├æ┬Å ├É┬┐├É┬Á├æÔé¼├É┬Á├É┬╝├É┬©├É┬║├É┬░├É┬¢├É┬¢├æ┬Å ├É┬░├É┬▒├É┬¥ ├É┬▓├É┬©├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© ├É┬▓ ├É┬Ø├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å├æÔÇª.]]></uk>
+            <ru><![CDATA[├É┼©├É┬¥├É┬║├É┬░├É┬À├æÔÇ╣├É┬▓├É┬░├É┬Á├æÔÇÜ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤, ├æÔé¼├É┬Á├É┬Â├É┬©├É┬╝, ├æ┬ü├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æ┼Æ, ├É┬╝├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┼Æ, ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├æÔÇ╣├É┬╣ ├æ┬ü├æÔÇÜ├É┬░├æÔÇÜ├æãÆ├æ┬ü, ├æ┬ü├É┬╗├É┬Á├É┬┤├æãÆ├æ┼¢├æÔÇ░├æãÆ├æ┼¢ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ ├É┬© ├É┬┐├É┬¥├æ┬ü├É┬╗├É┬Á├É┬┤├É┬¢├É┬©├É┬Á 5 ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ. ├É┼í├É┬╗├É┬░├É┬▓├É┬©├æ╦å├É┬░ I ├É┬┤├É┬╗├æ┬Å ├É┬┐├É┬Á├æÔé¼├É┬Á├É┬║├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬¢├É┬©├æ┬Å ├É┬©├É┬╗├É┬© ├É┬¥├æÔÇÜ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ ├É┬▓ ├É┬Ø├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬░├æÔÇª.]]></ru>
+            <da><![CDATA[Viser indkomst, tilstand, sv├â┬ªrhedsgrad, multiplikator, s├â┬ªsonstatus, n├â┬ªste betaling og de sidste 5 betalinger. Tasten I for at skifte eller deaktivere i Indstillinger.]]></da>
         </text>
 
         <text name="im_help_s3_notify_title">
@@ -1233,196 +1233,196 @@
             <pl><![CDATA[Powiadomienia]]></pl>
             <es><![CDATA[Notificaciones]]></es>
             <it><![CDATA[Notifiche]]></it>
-            <cz><![CDATA[Upozornâ”œÃ¤Ã”Ã‡â•‘nâ”œÃ¢â”¬Â¡]]></cz>
-            <br><![CDATA[Notificaâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã…]]></ru>
+            <cz><![CDATA[Upozorn├äÔÇ║n├â┬¡]]></cz>
+            <br><![CDATA[Notifica├â┬º├â┬Áes]]></br>
+            <uk><![CDATA[├É┬í├É┬┐├É┬¥├É┬▓├æÔÇô├æÔÇ░├É┬Á├É┬¢├É┬¢├æ┬Å]]></uk>
+            <ru><![CDATA[├É┬ú├É┬▓├É┬Á├É┬┤├É┬¥├É┬╝├É┬╗├É┬Á├É┬¢├É┬©├æ┬Å]]></ru>
             <da><![CDATA[Notifikationer]]></da>
         </text>
 
         <text name="im_help_s3_notify_text">
             <en><![CDATA[When enabled, a pop-up appears each time income is paid showing the amount received. Disable if you prefer a quieter experience without payment alerts.]]></en>
-            <de><![CDATA[Wenn aktiviert, erscheint bei jeder Zahlung ein Pop-up mit dem erhaltenen Betrag. Deaktivieren fâ”œÃ¢â”¬â•r eine ruhigere Spielerfahrung ohne Zahlungsbenachrichtigungen.]]></de>
-            <fr><![CDATA[Quand activâ”œÃ¢â”¬Â®, un pop-up apparaâ”œÃ¢â”¬Â«t â”œÃ¢â”¬Ã¡ chaque paiement avec le montant reâ”œÃ¢â”¬Âºu. Dâ”œÃ¢â”¬Â®sactiver pour une expâ”œÃ¢â”¬Â®rience plus calme sans alertes de paiement.]]></fr>
-            <pl><![CDATA[Po wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczeniu pojawia siâ”œÃ¤Ã”Ã¤Ã³ powiadomienie pop-up przy kaâ”œÃ â”¬â•dej pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci z kwotâ”œÃ¤Ã”Ã‡Âª. Wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz dla spokojniejszej rozgrywki bez alertâ”œÃ¢â”¬â”‚w pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci.]]></pl>
-            <es><![CDATA[Cuando estâ”œÃ¢â”¬Ã­ habilitado, aparece un pop-up con cada pago mostrando el monto recibido. Desactiva para una experiencia sin alertas de pago.]]></es>
-            <it><![CDATA[Quando abilitato, appare un pop-up ad ogni pagamento con l'importo ricevuto. Disabilita per un'esperienza piâ”œÃ¢â”¬â•£ silenziosa senza avvisi di pagamento.]]></it>
-            <cz><![CDATA[Kdyâ”œÃ â”¬Â¥ je povoleno, pâ”œÃ Ã”Ã¤Ã³i kaâ”œÃ â”¬Â¥dâ”œÃ¢â”¬Â® platbâ”œÃ¤Ã”Ã‡â•‘ se zobrazâ”œÃ¢â”¬Â¡ pop-up s pâ”œÃ Ã”Ã¤Ã³ijatou â”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­stkou. Zakaâ”œÃ â”¬Â¥te pro klidnâ”œÃ¤Ã”Ã‡â•‘jâ”œÃ â”¬Ã­â”œÃ¢â”¬Â¡ hernâ”œÃ¢â”¬Â¡ zâ”œÃ¢â”¬Ã­â”œÃ â”¬Â¥itek bez platebnâ”œÃ¢â”¬Â¡ch upozornâ”œÃ¤Ã”Ã‡â•‘nâ”œÃ¢â”¬Â¡.]]></cz>
-            <br><![CDATA[Quando ativado, um pop-up aparece a cada pagamento mostrando o valor recebido. Desative para uma experiâ”œÃ¢â”¬Â¬ncia mais tranquila sem alertas de pagamento.]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥, â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â© â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•£ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬Ã€'â”œÃ¦â”¬Ã…â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ã â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬Ã€ â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¼Â¢ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ¦â”¼Â¢. â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–’â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†.]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥, â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â© â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã…â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â–“â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã â”œÃ¦â”¬Ã¼ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£. â”œÃ‰â”¼Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–’â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€ â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª.]]></ru>
-            <da><![CDATA[Nâ”œÃ¢â”¬Ã‘r aktiveret, vises et pop-up ved hver betaling med det modtagne belâ”œÃ¢â”¬Â©b. Deaktiver for en roligere oplevelse uden betalingsbeskeder.]]></da>
+            <de><![CDATA[Wenn aktiviert, erscheint bei jeder Zahlung ein Pop-up mit dem erhaltenen Betrag. Deaktivieren f├â┬╝r eine ruhigere Spielerfahrung ohne Zahlungsbenachrichtigungen.]]></de>
+            <fr><![CDATA[Quand activ├â┬®, un pop-up appara├â┬«t ├â┬á chaque paiement avec le montant re├â┬ºu. D├â┬®sactiver pour une exp├â┬®rience plus calme sans alertes de paiement.]]></fr>
+            <pl><![CDATA[Po w├àÔÇÜ├äÔÇªczeniu pojawia si├äÔäó powiadomienie pop-up przy ka├à┬╝dej p├àÔÇÜatno├àÔÇ║ci z kwot├äÔÇª. Wy├àÔÇÜ├äÔÇªcz dla spokojniejszej rozgrywki bez alert├â┬│w p├àÔÇÜatno├àÔÇ║ci.]]></pl>
+            <es><![CDATA[Cuando est├â┬í habilitado, aparece un pop-up con cada pago mostrando el monto recibido. Desactiva para una experiencia sin alertas de pago.]]></es>
+            <it><![CDATA[Quando abilitato, appare un pop-up ad ogni pagamento con l'importo ricevuto. Disabilita per un'esperienza pi├â┬╣ silenziosa senza avvisi di pagamento.]]></it>
+            <cz><![CDATA[Kdy├à┬¥ je povoleno, p├àÔäói ka├à┬¥d├â┬® platb├äÔÇ║ se zobraz├â┬¡ pop-up s p├àÔäóijatou ├ä┬ì├â┬ístkou. Zaka├à┬¥te pro klidn├äÔÇ║j├à┬í├â┬¡ hern├â┬¡ z├â┬í├à┬¥itek bez platebn├â┬¡ch upozorn├äÔÇ║n├â┬¡.]]></cz>
+            <br><![CDATA[Quando ativado, um pop-up aparece a cada pagamento mostrando o valor recebido. Desative para uma experi├â┬¬ncia mais tranquila sem alertas de pagamento.]]></br>
+            <uk><![CDATA[├É┼í├É┬¥├É┬╗├É┬© ├æãÆ├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├É┬Á├É┬¢├É┬¥, ├É┬┐├æÔé¼├É┬© ├É┬║├É┬¥├É┬Â├É┬¢├æÔÇô├É┬╣ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇô ├É┬À'├æ┬Å├É┬▓├É┬╗├æ┬Å├æÔÇØ├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├æ┬ü├É┬┐├É┬╗├É┬©├É┬▓├É┬░├æ┼¢├æÔÇí├É┬Á ├æ┬ü├É┬┐├É┬¥├É┬▓├æÔÇô├æÔÇ░├É┬Á├É┬¢├É┬¢├æ┬Å ├É┬À ├É┬¥├æÔÇÜ├æÔé¼├É┬©├É┬╝├É┬░├É┬¢├É┬¥├æ┼¢ ├æ┬ü├æãÆ├É┬╝├É┬¥├æ┼¢. ├ÉÔÇÖ├É┬©├É┬╝├É┬║├É┬¢├æÔÇô├æÔÇÜ├æ┼Æ ├É┬┤├É┬╗├æ┬Å ├æ┬ü├É┬┐├É┬¥├É┬║├æÔÇô├É┬╣├É┬¢├æÔÇô├æ╦å├É┬¥├É┬│├É┬¥ ├æÔÇô├É┬│├æÔé¼├É┬¥├É┬▓├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¥├æ┬ü├É┬▓├æÔÇô├É┬┤├æãÆ ├É┬▒├É┬Á├É┬À ├æ┬ü├É┬┐├É┬¥├É┬▓├æÔÇô├æÔÇ░├É┬Á├É┬¢├æ┼Æ.]]></uk>
+            <ru><![CDATA[├É┼í├É┬¥├É┬│├É┬┤├É┬░ ├É┬▓├É┬║├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬¢├É┬¥, ├É┬┐├æÔé¼├É┬© ├É┬║├É┬░├É┬Â├É┬┤├É┬¥├É┬╣ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬Á ├É┬┐├É┬¥├æ┬Å├É┬▓├É┬╗├æ┬Å├É┬Á├æÔÇÜ├æ┬ü├æ┬Å ├É┬▓├æ┬ü├É┬┐├É┬╗├æÔÇ╣├É┬▓├É┬░├æ┼¢├æÔÇ░├É┬Á├É┬Á ├æãÆ├É┬▓├É┬Á├É┬┤├É┬¥├É┬╝├É┬╗├É┬Á├É┬¢├É┬©├É┬Á ├æ┬ü ├æ┬ü├æãÆ├É┬╝├É┬╝├É┬¥├É┬╣. ├É┼¥├æÔÇÜ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├É┬Á ├É┬┤├É┬╗├æ┬Å ├æ┬ü├É┬┐├É┬¥├É┬║├É┬¥├É┬╣├É┬¢├É┬¥├É┬│├É┬¥ ├É┬©├É┬│├æÔé¼├É┬¥├É┬▓├É┬¥├É┬│├É┬¥ ├É┬¥├É┬┐├æÔÇ╣├æÔÇÜ├É┬░ ├É┬▒├É┬Á├É┬À ├æãÆ├É┬▓├É┬Á├É┬┤├É┬¥├É┬╝├É┬╗├É┬Á├É┬¢├É┬©├É┬╣ ├É┬¥ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░├æÔÇª.]]></ru>
+            <da><![CDATA[N├â┬Ñr aktiveret, vises et pop-up ved hver betaling med det modtagne bel├â┬©b. Deaktiver for en roligere oplevelse uden betalingsbeskeder.]]></da>
         </text>
 
         <text name="im_help_s3_reset_title">
             <en><![CDATA[Reset Settings]]></en>
-            <de><![CDATA[Einstellungen zurâ”œÃ¢â”¬â•cksetzen]]></de>
-            <fr><![CDATA[Râ”œÃ¢â”¬Â®initialiser les paramâ”œÃ¢â”¬Â¿tres]]></fr>
+            <de><![CDATA[Einstellungen zur├â┬╝cksetzen]]></de>
+            <fr><![CDATA[R├â┬®initialiser les param├â┬¿tres]]></fr>
             <pl><![CDATA[Resetuj ustawienia]]></pl>
             <es><![CDATA[Restablecer ajustes]]></es>
             <it><![CDATA[Ripristina impostazioni]]></it>
-            <cz><![CDATA[Resetovat nastavenâ”œÃ¢â”¬Â¡]]></cz>
-            <br><![CDATA[Redefinir configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©]]></ru>
+            <cz><![CDATA[Resetovat nastaven├â┬¡]]></cz>
+            <br><![CDATA[Redefinir configura├â┬º├â┬Áes]]></br>
+            <uk><![CDATA[├É┬í├É┬║├É┬©├É┬¢├æãÆ├æÔÇÜ├É┬© ├É┬¢├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å]]></uk>
+            <ru><![CDATA[├É┬í├É┬▒├æÔé¼├É┬¥├æ┬ü├É┬©├æÔÇÜ├æ┼Æ ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬©]]></ru>
             <da><![CDATA[Nulstil indstillinger]]></da>
         </text>
 
         <text name="im_help_s3_reset_text">
             <en><![CDATA[Press the X key while on the Settings page to reset all Income Mod settings to defaults. Useful if settings become inconsistent. This action cannot be undone.]]></en>
-            <de><![CDATA[Drâ”œÃ¢â”¬â•cken Sie X auf der Einstellungsseite, um alle Income-Mod-Einstellungen zurâ”œÃ¢â”¬â•ckzusetzen. Nâ”œÃ¢â”¬â•tzlich bei inkonsistenten Einstellungen. Kann nicht râ”œÃ¢â”¬â•ckgâ”œÃ¢â”¬Ã±ngig gemacht werden.]]></de>
-            <fr><![CDATA[Appuyez sur X dans Paramâ”œÃ¢â”¬Â¿tres pour râ”œÃ¢â”¬Â®initialiser tous les paramâ”œÃ¢â”¬Â¿tres d'Income Mod. Utile si les paramâ”œÃ¢â”¬Â¿tres deviennent incohâ”œÃ¢â”¬Â®rents. Cette action est irrâ”œÃ¢â”¬Â®versible.]]></fr>
-            <pl><![CDATA[Naciâ”œÃ Ã”Ã‡â•‘nij X na stronie Ustawieâ”œÃ Ã”Ã‡Ã—, aby zresetowaâ”œÃ¤Ã”Ã‡Ã­ wszystkie ustawienia Income Mod do domyâ”œÃ Ã”Ã‡â•‘lnych. Tej akcji nie moâ”œÃ â”¬â•na cofnâ”œÃ¤Ã”Ã‡Âªâ”œÃ¤Ã”Ã‡Ã­.]]></pl>
-            <es><![CDATA[Pulsa X en la pâ”œÃ¢â”¬Ã­gina de Ajustes para restablecer todos los ajustes de Income Mod. Esta acciâ”œÃ¢â”¬â”‚n no se puede deshacer.]]></es>
-            <it><![CDATA[Premi X nella pagina Impostazioni per ripristinare tutte le impostazioni di Income Mod ai valori predefiniti. Questa azione non puâ”œÃ¢â”¬â–“ essere annullata.]]></it>
-            <cz><![CDATA[Stisknâ”œÃ¤Ã”Ã‡â•‘te X na strâ”œÃ¢â”¬Ã­nce Nastavenâ”œÃ¢â”¬Â¡ pro reset vâ”œÃ â”¬Ã­ech nastavenâ”œÃ¢â”¬Â¡ Income Modu. Tuto akci nelze vrâ”œÃ¢â”¬Ã­tit zpâ”œÃ¤Ã”Ã‡â•‘t.]]></cz>
-            <br><![CDATA[Pressione X nas Configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães para redefinir todas as configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães do Income Mod. Esta aâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ãºo nâ”œÃ¢â”¬Ãºo pode ser desfeita.]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† X â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã¡â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†, â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… Income Mod â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã† â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬â•. â”œÃ‰â”¬Âªâ”œÃ¦â”¼Â¢ â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¼Â¢ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ã â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©.]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã X â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã¡â”œÃ‰â”¬Ã â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘, â”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡â•£ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â–“â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ã â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© Income Mod â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥ â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¼Â¢. â”œÃ‰â”¬Â¡â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•£â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Ã€â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†.]]></ru>
-            <da><![CDATA[Tryk pâ”œÃ¢â”¬Ã‘ X pâ”œÃ¢â”¬Ã‘ siden Indstillinger for at nulstille alle Income Mod indstillinger til standard. Denne handling kan ikke fortrydes.]]></da>
+            <de><![CDATA[Dr├â┬╝cken Sie X auf der Einstellungsseite, um alle Income-Mod-Einstellungen zur├â┬╝ckzusetzen. N├â┬╝tzlich bei inkonsistenten Einstellungen. Kann nicht r├â┬╝ckg├â┬ñngig gemacht werden.]]></de>
+            <fr><![CDATA[Appuyez sur X dans Param├â┬¿tres pour r├â┬®initialiser tous les param├â┬¿tres d'Income Mod. Utile si les param├â┬¿tres deviennent incoh├â┬®rents. Cette action est irr├â┬®versible.]]></fr>
+            <pl><![CDATA[Naci├àÔÇ║nij X na stronie Ustawie├àÔÇ×, aby zresetowa├äÔÇí wszystkie ustawienia Income Mod do domy├àÔÇ║lnych. Tej akcji nie mo├à┬╝na cofn├äÔÇª├äÔÇí.]]></pl>
+            <es><![CDATA[Pulsa X en la p├â┬ígina de Ajustes para restablecer todos los ajustes de Income Mod. Esta acci├â┬│n no se puede deshacer.]]></es>
+            <it><![CDATA[Premi X nella pagina Impostazioni per ripristinare tutte le impostazioni di Income Mod ai valori predefiniti. Questa azione non pu├â┬▓ essere annullata.]]></it>
+            <cz><![CDATA[Stiskn├äÔÇ║te X na str├â┬ínce Nastaven├â┬¡ pro reset v├à┬íech nastaven├â┬¡ Income Modu. Tuto akci nelze vr├â┬ítit zp├äÔÇ║t.]]></cz>
+            <br><![CDATA[Pressione X nas Configura├â┬º├â┬Áes para redefinir todas as configura├â┬º├â┬Áes do Income Mod. Esta a├â┬º├â┬úo n├â┬úo pode ser desfeita.]]></br>
+            <uk><![CDATA[├É┬Ø├É┬░├æÔÇÜ├É┬©├æ┬ü├É┬¢├æÔÇô├æÔÇÜ├æ┼Æ X ├É┬¢├É┬░ ├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├æÔÇô├É┬¢├æÔÇá├æÔÇô ├É┬Ø├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├æ┼Æ, ├æÔÇ░├É┬¥├É┬▒ ├æ┬ü├É┬║├É┬©├É┬¢├æãÆ├æÔÇÜ├É┬© ├É┬▓├æ┬ü├æÔÇô ├É┬¢├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å Income Mod ├É┬┤├É┬¥ ├É┬À├É┬¢├É┬░├æÔÇí├É┬Á├É┬¢├æ┼Æ ├É┬À├É┬░ ├É┬À├É┬░├É┬╝├É┬¥├É┬▓├æÔÇí├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å├É┬╝. ├É┬ª├æ┼¢ ├É┬┤├æÔÇô├æ┼¢ ├É┬¢├É┬Á ├É┬╝├É┬¥├É┬Â├É┬¢├É┬░ ├æ┬ü├É┬║├É┬░├æ┬ü├æãÆ├É┬▓├É┬░├æÔÇÜ├É┬©.]]></uk>
+            <ru><![CDATA[├É┬Ø├É┬░├É┬Â├É┬╝├É┬©├æÔÇÜ├É┬Á X ├É┬¢├É┬░ ├æ┬ü├æÔÇÜ├æÔé¼├É┬░├É┬¢├É┬©├æÔÇá├É┬Á ├É┬Ø├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬Á├É┬║, ├æÔÇí├æÔÇÜ├É┬¥├É┬▒├æÔÇ╣ ├æ┬ü├É┬▒├æÔé¼├É┬¥├æ┬ü├É┬©├æÔÇÜ├æ┼Æ ├É┬▓├æ┬ü├É┬Á ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬© Income Mod ├É┬┤├É┬¥ ├É┬À├É┬¢├É┬░├æÔÇí├É┬Á├É┬¢├É┬©├É┬╣ ├É┬┐├É┬¥ ├æãÆ├É┬╝├É┬¥├É┬╗├æÔÇí├É┬░├É┬¢├É┬©├æ┼¢. ├É┬¡├æÔÇÜ├É┬¥ ├É┬┤├É┬Á├É┬╣├æ┬ü├æÔÇÜ├É┬▓├É┬©├É┬Á ├É┬¢├É┬Á├É┬╗├æ┼Æ├É┬À├æ┬Å ├É┬¥├æÔÇÜ├É┬╝├É┬Á├É┬¢├É┬©├æÔÇÜ├æ┼Æ.]]></ru>
+            <da><![CDATA[Tryk p├â┬Ñ X p├â┬Ñ siden Indstillinger for at nulstille alle Income Mod indstillinger til standard. Denne handling kan ikke fortrydes.]]></da>
         </text>
 
-        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page 6 â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ HUD & Income Report â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
+        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page 6 ├óÔé¼ÔÇØ HUD & Income Report ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
         <text name="im_help_t1_hud_title">
-            <en><![CDATA[Income HUD â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ I Key]]></en>
-            <de><![CDATA[Einkommens-HUD â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Taste I]]></de>
-            <fr><![CDATA[HUD de revenu â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Touche I]]></fr>
-            <pl><![CDATA[HUD dochodu â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Klawisz I]]></pl>
-            <es><![CDATA[HUD de ingresos â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tecla I]]></es>
-            <it><![CDATA[HUD reddito â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tasto I]]></it>
-            <cz><![CDATA[HUD pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â» â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Klâ”œÃ¢â”¬Ã­vesa I]]></cz>
-            <br><![CDATA[HUD de renda â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tecla I]]></br>
-            <uk><![CDATA[HUD â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã† â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¼Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘ I]]></uk>
-            <ru><![CDATA[HUD â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¼Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘ I]]></ru>
-            <da><![CDATA[Indkomst-HUD â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tasten I]]></da>
+            <en><![CDATA[Income HUD ├óÔé¼ÔÇØ I Key]]></en>
+            <de><![CDATA[Einkommens-HUD ├óÔé¼ÔÇØ Taste I]]></de>
+            <fr><![CDATA[HUD de revenu ├óÔé¼ÔÇØ Touche I]]></fr>
+            <pl><![CDATA[HUD dochodu ├óÔé¼ÔÇØ Klawisz I]]></pl>
+            <es><![CDATA[HUD de ingresos ├óÔé¼ÔÇØ Tecla I]]></es>
+            <it><![CDATA[HUD reddito ├óÔé¼ÔÇØ Tasto I]]></it>
+            <cz><![CDATA[HUD p├àÔäó├â┬¡jm├à┬» ├óÔé¼ÔÇØ Kl├â┬ívesa I]]></cz>
+            <br><![CDATA[HUD de renda ├óÔé¼ÔÇØ Tecla I]]></br>
+            <uk><![CDATA[HUD ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ ├óÔé¼ÔÇØ ├É┼í├É┬╗├É┬░├É┬▓├æÔÇô├æ╦å├É┬░ I]]></uk>
+            <ru><![CDATA[HUD ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░ ├óÔé¼ÔÇØ ├É┼í├É┬╗├É┬░├É┬▓├É┬©├æ╦å├É┬░ I]]></ru>
+            <da><![CDATA[Indkomst-HUD ├óÔé¼ÔÇØ Tasten I]]></da>
         </text>
 
         <text name="im_help_t1_hud_text">
             <en><![CDATA[Press I during gameplay to toggle the income HUD on or off. It shows your income, payment mode, next payment time, and recent history. The HUD setting persists between sessions.]]></en>
-            <de><![CDATA[Drâ”œÃ¢â”¬â•cken Sie I wâ”œÃ¢â”¬Ã±hrend des Spiels, um das Einkommens-HUD ein- oder auszublenden. Es zeigt Einkommen, Zahlungsmodus, nâ”œÃ¢â”¬Ã±chste Zahlung und den Verlauf. Die Einstellung bleibt erhalten.]]></de>
-            <fr><![CDATA[Appuyez sur I pendant le jeu pour afficher ou masquer le HUD. Il affiche revenu, mode de paiement, prochain paiement et historique râ”œÃ¢â”¬Â®cent. Le râ”œÃ¢â”¬Â®glage persiste entre sessions.]]></fr>
-            <pl><![CDATA[Naciâ”œÃ Ã”Ã‡â•‘nij I podczas gry, aby wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczyâ”œÃ¤Ã”Ã‡Ã­ lub wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczyâ”œÃ¤Ã”Ã‡Ã­ HUD dochodu. Pokazuje dochâ”œÃ¢â”¬â”‚d, tryb pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci, nastâ”œÃ¤Ã”Ã¤Ã³pnâ”œÃ¤Ã”Ã‡Âª pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­ i historiâ”œÃ¤Ã”Ã¤Ã³. Ustawienie jest zachowywane miâ”œÃ¤Ã”Ã¤Ã³dzy sesjami.]]></pl>
-            <es><![CDATA[Pulsa I durante el juego para activar o desactivar el HUD. Muestra ingreso, modo de pago, prâ”œÃ¢â”¬â”‚ximo pago e historial reciente. El ajuste persiste entre sesiones.]]></es>
-            <it><![CDATA[Premi I durante il gioco per attivare o disattivare il HUD. Mostra reddito, modalitâ”œÃ¢â”¬Ã¡ di pagamento, prossimo pagamento e cronologia recente. L'impostazione persiste tra sessioni.]]></it>
-            <cz><![CDATA[Stisknâ”œÃ¤Ã”Ã‡â•‘te I pâ”œÃ Ã”Ã¤Ã³i hâ”œÃ Ã”Ã¤Ã³e pro pâ”œÃ Ã”Ã¤Ã³epnutâ”œÃ¢â”¬Â¡ HUD. Zobrazuje pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem, platebnâ”œÃ¢â”¬Â¡ reâ”œÃ â”¬Â¥im, pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡â”œÃ â”¬Ã­tâ”œÃ¢â”¬Â¡ platbu a historii. Nastavenâ”œÃ¢â”¬Â¡ se uchovâ”œÃ¢â”¬Ã­vâ”œÃ¢â”¬Ã­ mezi sezenâ”œÃ¢â”¬Â¡mi.]]></cz>
-            <br><![CDATA[Pressione I durante o jogo para alternar o HUD. Mostra renda, modo de pagamento, prâ”œÃ¢â”¬â”‚ximo pagamento e histâ”œÃ¢â”¬â”‚rico recente. O ajuste persiste entre sessâ”œÃ¢â”¬Ães.]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† I â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤ â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼ â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©, â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’ â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© HUD. â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤, â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ, â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â”â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦â”¼Â¢ â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¼Â¢. â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–’â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”‚â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Ã‚ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã…â”œÃ‰â”¬â•â”œÃ‰â”¬Â©.]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã I â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã… HUD. â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤, â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡â–‘â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦â”¼Â¢â”œÃ¦â”¼Â¢ â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ¦â”¼Â¢. â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã† â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã…â”œÃ‰â”¬â•â”œÃ‰â”¬Â©.]]></ru>
-            <da><![CDATA[Tryk pâ”œÃ¢â”¬Ã‘ I under spil for at skifte HUD. Viser indkomst, betalingsmâ”œÃ¢â”¬Ã‘de, nâ”œÃ¢â”¬Âªste betaling og nylig historie. Indstillingen bevares mellem sessioner.]]></da>
+            <de><![CDATA[Dr├â┬╝cken Sie I w├â┬ñhrend des Spiels, um das Einkommens-HUD ein- oder auszublenden. Es zeigt Einkommen, Zahlungsmodus, n├â┬ñchste Zahlung und den Verlauf. Die Einstellung bleibt erhalten.]]></de>
+            <fr><![CDATA[Appuyez sur I pendant le jeu pour afficher ou masquer le HUD. Il affiche revenu, mode de paiement, prochain paiement et historique r├â┬®cent. Le r├â┬®glage persiste entre sessions.]]></fr>
+            <pl><![CDATA[Naci├àÔÇ║nij I podczas gry, aby w├àÔÇÜ├äÔÇªczy├äÔÇí lub wy├àÔÇÜ├äÔÇªczy├äÔÇí HUD dochodu. Pokazuje doch├â┬│d, tryb p├àÔÇÜatno├àÔÇ║ci, nast├äÔäópn├äÔÇª p├àÔÇÜatno├àÔÇ║├äÔÇí i histori├äÔäó. Ustawienie jest zachowywane mi├äÔäódzy sesjami.]]></pl>
+            <es><![CDATA[Pulsa I durante el juego para activar o desactivar el HUD. Muestra ingreso, modo de pago, pr├â┬│ximo pago e historial reciente. El ajuste persiste entre sesiones.]]></es>
+            <it><![CDATA[Premi I durante il gioco per attivare o disattivare il HUD. Mostra reddito, modalit├â┬á di pagamento, prossimo pagamento e cronologia recente. L'impostazione persiste tra sessioni.]]></it>
+            <cz><![CDATA[Stiskn├äÔÇ║te I p├àÔäói h├àÔäóe pro p├àÔäóepnut├â┬¡ HUD. Zobrazuje p├àÔäó├â┬¡jem, platebn├â┬¡ re├à┬¥im, p├àÔäó├â┬¡├à┬ít├â┬¡ platbu a historii. Nastaven├â┬¡ se uchov├â┬ív├â┬í mezi sezen├â┬¡mi.]]></cz>
+            <br><![CDATA[Pressione I durante o jogo para alternar o HUD. Mostra renda, modo de pagamento, pr├â┬│ximo pagamento e hist├â┬│rico recente. O ajuste persiste entre sess├â┬Áes.]]></br>
+            <uk><![CDATA[├É┬Ø├É┬░├æÔÇÜ├É┬©├æ┬ü├É┬¢├æÔÇô├æÔÇÜ├æ┼Æ I ├É┬┐├æÔÇô├É┬┤ ├æÔÇí├É┬░├æ┬ü ├É┬│├æÔé¼├É┬©, ├æÔÇ░├É┬¥├É┬▒ ├æãÆ├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© ├É┬░├É┬▒├É┬¥ ├É┬▓├É┬©├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© HUD. ├É┼©├É┬¥├É┬║├É┬░├É┬À├æãÆ├æÔÇØ ├É┬┤├É┬¥├æÔÇª├æÔÇô├É┬┤, ├æÔé¼├É┬Á├É┬Â├É┬©├É┬╝ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ, ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æãÆ├É┬┐├É┬¢├æãÆ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ ├æÔÇÜ├É┬░ ├É┬¢├É┬Á├æÔÇ░├É┬¥├É┬┤├É┬░├É┬▓├É┬¢├æ┼¢ ├æÔÇô├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├æÔÇô├æ┼¢. ├É┬Ø├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å ├É┬À├É┬▒├É┬Á├æÔé¼├æÔÇô├É┬│├É┬░├æÔÇØ├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├É┬╝├æÔÇô├É┬Â ├æ┬ü├É┬Á├æ┬ü├æÔÇô├æ┬Å├É┬╝├É┬©.]]></uk>
+            <ru><![CDATA[├É┬Ø├É┬░├É┬Â├É┬╝├É┬©├æÔÇÜ├É┬Á I ├É┬▓├É┬¥ ├É┬▓├æÔé¼├É┬Á├É┬╝├æ┬Å ├É┬©├É┬│├æÔé¼├æÔÇ╣ ├É┬┤├É┬╗├æ┬Å ├É┬┐├É┬Á├æÔé¼├É┬Á├É┬║├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬¢├É┬©├æ┬Å HUD. ├É┼©├É┬¥├É┬║├É┬░├É┬À├æÔÇ╣├É┬▓├É┬░├É┬Á├æÔÇÜ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤, ├æÔé¼├É┬Á├É┬Â├É┬©├É┬╝ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ, ├æ┬ü├É┬╗├É┬Á├É┬┤├æãÆ├æ┼¢├æÔÇ░├æãÆ├æ┼¢ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ ├É┬© ├É┬¢├É┬Á├É┬┤├É┬░├É┬▓├É┬¢├æ┼¢├æ┼¢ ├É┬©├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├É┬©├æ┼¢. ├É┬Ø├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬░ ├æ┬ü├É┬¥├æÔÇª├æÔé¼├É┬░├É┬¢├æ┬Å├É┬Á├æÔÇÜ├æ┬ü├æ┬Å ├É┬╝├É┬Á├É┬Â├É┬┤├æãÆ ├æ┬ü├É┬Á├æ┬ü├æ┬ü├É┬©├æ┬Å├É┬╝├É┬©.]]></ru>
+            <da><![CDATA[Tryk p├â┬Ñ I under spil for at skifte HUD. Viser indkomst, betalingsm├â┬Ñde, n├â┬ªste betaling og nylig historie. Indstillingen bevares mellem sessioner.]]></da>
         </text>
 
         <text name="im_help_t1_report_title">
-            <en><![CDATA[Income Report â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ U Key]]></en>
-            <de><![CDATA[Einkommensbericht â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Taste U]]></de>
-            <fr><![CDATA[Rapport de revenu â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Touche U]]></fr>
-            <pl><![CDATA[Raport dochodu â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Klawisz U]]></pl>
-            <es><![CDATA[Informe de ingresos â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tecla U]]></es>
-            <it><![CDATA[Rapporto reddito â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tasto U]]></it>
-            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³ehled pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â» â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Klâ”œÃ¢â”¬Ã­vesa U]]></cz>
-            <br><![CDATA[Relatâ”œÃ¢â”¬â”‚rio de renda â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tecla U]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â© â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¼Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘ U]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã”Ã‡Ã¿â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¼Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘ U]]></ru>
-            <da><![CDATA[Indkomstrapport â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tasten U]]></da>
+            <en><![CDATA[Income Report ├óÔé¼ÔÇØ U Key]]></en>
+            <de><![CDATA[Einkommensbericht ├óÔé¼ÔÇØ Taste U]]></de>
+            <fr><![CDATA[Rapport de revenu ├óÔé¼ÔÇØ Touche U]]></fr>
+            <pl><![CDATA[Raport dochodu ├óÔé¼ÔÇØ Klawisz U]]></pl>
+            <es><![CDATA[Informe de ingresos ├óÔé¼ÔÇØ Tecla U]]></es>
+            <it><![CDATA[Rapporto reddito ├óÔé¼ÔÇØ Tasto U]]></it>
+            <cz><![CDATA[P├àÔäóehled p├àÔäó├â┬¡jm├à┬» ├óÔé¼ÔÇØ Kl├â┬ívesa U]]></cz>
+            <br><![CDATA[Relat├â┬│rio de renda ├óÔé¼ÔÇØ Tecla U]]></br>
+            <uk><![CDATA[├ÉÔÇö├É┬▓├æÔÇô├æÔÇÜ ├É┬┐├æÔé¼├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬© ├óÔé¼ÔÇØ ├É┼í├É┬╗├É┬░├É┬▓├æÔÇô├æ╦å├É┬░ U]]></uk>
+            <ru><![CDATA[├É┼¥├æÔÇÜ├æÔÇí├æÔÇÿ├æÔÇÜ ├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░├æÔÇª ├óÔé¼ÔÇØ ├É┼í├É┬╗├É┬░├É┬▓├É┬©├æ╦å├É┬░ U]]></ru>
+            <da><![CDATA[Indkomstrapport ├óÔé¼ÔÇØ Tasten U]]></da>
         </text>
 
         <text name="im_help_t1_report_text">
             <en><![CDATA[Press U to open the Income Report dialog. Shows configuration, total earnings (last 10 payments), average per payment, next scheduled payment, and a full detailed payment history table.]]></en>
-            <de><![CDATA[Drâ”œÃ¢â”¬â•cken Sie U, um den Einkommensbericht zu â”œÃ¢â”¬Ã‚ffnen. Zeigt Konfiguration, Gesamteinnahmen (letzte 10), Durchschnitt, nâ”œÃ¢â”¬Ã±chste Zahlung und detaillierte Verlaufstabelle.]]></de>
-            <fr><![CDATA[Appuyez sur U pour ouvrir le rapport. Affiche configuration, gains totaux (10 derniers), moyenne par paiement, prochain paiement et tableau historique dâ”œÃ¢â”¬Â®taillâ”œÃ¢â”¬Â®.]]></fr>
-            <pl><![CDATA[Naciâ”œÃ Ã”Ã‡â•‘nij U, aby otworzyâ”œÃ¤Ã”Ã‡Ã­ raport dochodu. Pokazuje konfiguracjâ”œÃ¤Ã”Ã¤Ã³, â”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczne zarobki (ostatnie 10), â”œÃ Ã”Ã‡â•‘redniâ”œÃ¤Ã”Ã‡Âª, nastâ”œÃ¤Ã”Ã¤Ã³pnâ”œÃ¤Ã”Ã‡Âª pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­ i szczegâ”œÃ¢â”¬â”‚â”œÃ Ã”Ã‡Ãœowâ”œÃ¤Ã”Ã‡Âª tabelâ”œÃ¤Ã”Ã¤Ã³ historii.]]></pl>
-            <es><![CDATA[Pulsa U para abrir el informe de ingresos. Muestra configuraciâ”œÃ¢â”¬â”‚n, ganancias totales (â”œÃ¢â”¬â•‘ltimos 10), promedio, prâ”œÃ¢â”¬â”‚ximo pago y tabla de historial detallada.]]></es>
+            <de><![CDATA[Dr├â┬╝cken Sie U, um den Einkommensbericht zu ├â┬Âffnen. Zeigt Konfiguration, Gesamteinnahmen (letzte 10), Durchschnitt, n├â┬ñchste Zahlung und detaillierte Verlaufstabelle.]]></de>
+            <fr><![CDATA[Appuyez sur U pour ouvrir le rapport. Affiche configuration, gains totaux (10 derniers), moyenne par paiement, prochain paiement et tableau historique d├â┬®taill├â┬®.]]></fr>
+            <pl><![CDATA[Naci├àÔÇ║nij U, aby otworzy├äÔÇí raport dochodu. Pokazuje konfiguracj├äÔäó, ├àÔÇÜ├äÔÇªczne zarobki (ostatnie 10), ├àÔÇ║redni├äÔÇª, nast├äÔäópn├äÔÇª p├àÔÇÜatno├àÔÇ║├äÔÇí i szczeg├â┬│├àÔÇÜow├äÔÇª tabel├äÔäó historii.]]></pl>
+            <es><![CDATA[Pulsa U para abrir el informe de ingresos. Muestra configuraci├â┬│n, ganancias totales (├â┬║ltimos 10), promedio, pr├â┬│ximo pago y tabla de historial detallada.]]></es>
             <it><![CDATA[Premi U per aprire il rapporto. Mostra configurazione, guadagni totali (ultimi 10), media per pagamento, prossimo pagamento e tabella cronologia dettagliata.]]></it>
-            <cz><![CDATA[Stisknâ”œÃ¤Ã”Ã‡â•‘te U pro otevâ”œÃ Ã”Ã¤Ã³enâ”œÃ¢â”¬Â¡ pâ”œÃ Ã”Ã¤Ã³ehledu pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â». Zobrazuje konfiguraci, celkovâ”œÃ¢â”¬Â® vâ”œÃ¢â”¬Â¢dâ”œÃ¤Ã”Ã‡â•‘lky (poslednâ”œÃ¢â”¬Â¡ch 10), prâ”œÃ â”¬Â»mâ”œÃ¤Ã”Ã‡â•‘r, pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡â”œÃ â”¬Ã­tâ”œÃ¢â”¬Â¡ platbu a podrobnou historii.]]></cz>
-            <br><![CDATA[Pressione U para abrir o relatâ”œÃ¢â”¬â”‚rio de renda. Mostra configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ãºo, ganhos totais (â”œÃ¢â”¬â•‘ltimos 10), mâ”œÃ¢â”¬Â®dia, prâ”œÃ¢â”¬â”‚ximo pagamento e tabela de histâ”œÃ¢â”¬â”‚rico detalhado.]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† U, â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©. â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã—â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”‚â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã¡â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¼Â¢, â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”‚â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘ (â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´ 10), â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã˜, â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â”â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã¡â”œÃ¦â”¼Â¢ â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ã¶.]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã U â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã”Ã‡Ã¿â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª. â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã¡â”œÃ‰â”¬Â©â”œÃ¦â”¼Â¢, â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘ (â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã 10), â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡â–‘â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ‰â”¬Â© â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã¡â”œÃ¦Ã£Ã† â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬Â©.]]></ru>
-            <da><![CDATA[Tryk pâ”œÃ¢â”¬Ã‘ U for at â”œÃ¢â”¬Ã‘bne indkomstrapporten. Viser konfiguration, samlede indtâ”œÃ¢â”¬Âªgter (sidste 10), gennemsnit, nâ”œÃ¢â”¬Âªste betaling og en detaljeret historietabel.]]></da>
+            <cz><![CDATA[Stiskn├äÔÇ║te U pro otev├àÔäóen├â┬¡ p├àÔäóehledu p├àÔäó├â┬¡jm├à┬». Zobrazuje konfiguraci, celkov├â┬® v├â┬¢d├äÔÇ║lky (posledn├â┬¡ch 10), pr├à┬»m├äÔÇ║r, p├àÔäó├â┬¡├à┬ít├â┬¡ platbu a podrobnou historii.]]></cz>
+            <br><![CDATA[Pressione U para abrir o relat├â┬│rio de renda. Mostra configura├â┬º├â┬úo, ganhos totais (├â┬║ltimos 10), m├â┬®dia, pr├â┬│ximo pagamento e tabela de hist├â┬│rico detalhado.]]></br>
+            <uk><![CDATA[├É┬Ø├É┬░├æÔÇÜ├É┬©├æ┬ü├É┬¢├æÔÇô├æÔÇÜ├æ┼Æ U, ├æÔÇ░├É┬¥├É┬▒ ├É┬▓├æÔÇô├É┬┤├É┬║├æÔé¼├É┬©├æÔÇÜ├É┬© ├É┬À├É┬▓├æÔÇô├æÔÇÜ ├É┬┐├æÔé¼├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬©. ├É┼©├É┬¥├É┬║├É┬░├É┬À├æãÆ├æÔÇØ ├É┬║├É┬¥├É┬¢├æÔÇ×├æÔÇô├É┬│├æãÆ├æÔé¼├É┬░├æÔÇá├æÔÇô├æ┼¢, ├É┬À├É┬░├É┬│├É┬░├É┬╗├æ┼Æ├É┬¢├É┬©├É┬╣ ├É┬À├É┬░├æÔé¼├É┬¥├É┬▒├æÔÇô├æÔÇÜ├É┬¥├É┬║ (├É┬¥├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¢├æÔÇô 10), ├æ┬ü├É┬Á├æÔé¼├É┬Á├É┬┤├É┬¢├æÔÇØ, ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æãÆ├É┬┐├É┬¢├æãÆ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ ├æÔÇÜ├É┬░ ├É┬┤├É┬Á├æÔÇÜ├É┬░├É┬╗├æ┼Æ├É┬¢├æãÆ ├æÔÇÜ├É┬░├É┬▒├É┬╗├É┬©├æÔÇá├æ┼¢ ├æÔÇô├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├æÔÇô├æÔÇö.]]></uk>
+            <ru><![CDATA[├É┬Ø├É┬░├É┬Â├É┬╝├É┬©├æÔÇÜ├É┬Á U ├É┬┤├É┬╗├æ┬Å ├É┬¥├æÔÇÜ├É┬║├æÔé¼├æÔÇ╣├æÔÇÜ├É┬©├æ┬Å ├É┬¥├æÔÇÜ├æÔÇí├æÔÇÿ├æÔÇÜ├É┬░ ├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░├æÔÇª. ├É┼©├É┬¥├É┬║├É┬░├É┬À├æÔÇ╣├É┬▓├É┬░├É┬Á├æÔÇÜ ├É┬║├É┬¥├É┬¢├æÔÇ×├É┬©├É┬│├æãÆ├æÔé¼├É┬░├æÔÇá├É┬©├æ┼¢, ├É┬¥├É┬▒├æÔÇ░├É┬©├É┬╣ ├É┬À├É┬░├æÔé¼├É┬░├É┬▒├É┬¥├æÔÇÜ├É┬¥├É┬║ (├É┬┐├É┬¥├æ┬ü├É┬╗├É┬Á├É┬┤├É┬¢├É┬©├É┬Á 10), ├æ┬ü├æÔé¼├É┬Á├É┬┤├É┬¢├É┬Á├É┬Á, ├æ┬ü├É┬╗├É┬Á├É┬┤├æãÆ├æ┼¢├æÔÇ░├æãÆ├æ┼¢ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ ├É┬© ├É┬┐├É┬¥├É┬┤├æÔé¼├É┬¥├É┬▒├É┬¢├æãÆ├æ┼¢ ├æÔÇÜ├É┬░├É┬▒├É┬╗├É┬©├æÔÇá├æãÆ ├É┬©├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├É┬©├É┬©.]]></ru>
+            <da><![CDATA[Tryk p├â┬Ñ U for at ├â┬Ñbne indkomstrapporten. Viser konfiguration, samlede indt├â┬ªgter (sidste 10), gennemsnit, n├â┬ªste betaling og en detaljeret historietabel.]]></da>
         </text>
 
-        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page 7 â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Income Tips â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
+        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page 7 ├óÔé¼ÔÇØ Income Tips ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
         <text name="im_help_t2_season_title">
             <en><![CDATA[Best Season for Income]]></en>
-            <de><![CDATA[Beste Saison fâ”œÃ¢â”¬â•r Einkommen]]></de>
+            <de><![CDATA[Beste Saison f├â┬╝r Einkommen]]></de>
             <fr><![CDATA[Meilleure saison pour les revenus]]></fr>
-            <pl><![CDATA[Najlepsza pora roku na dochâ”œÃ¢â”¬â”‚d]]></pl>
+            <pl><![CDATA[Najlepsza pora roku na doch├â┬│d]]></pl>
             <es><![CDATA[Mejor temporada para ingresos]]></es>
             <it><![CDATA[Stagione migliore per il reddito]]></it>
-            <cz><![CDATA[Nejlepâ”œÃ â”¬Ã­â”œÃ¢â”¬Â¡ sezâ”œÃ¢â”¬â”‚na pro pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem]]></cz>
-            <br><![CDATA[Melhor estaâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ãºo para renda]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
-            <ru><![CDATA[â”œÃ‰Ã”Ã‡â•‘â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã­â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
-            <da><![CDATA[Bedste sâ”œÃ¢â”¬Âªson for indkomst]]></da>
+            <cz><![CDATA[Nejlep├à┬í├â┬¡ sez├â┬│na pro p├àÔäó├â┬¡jem]]></cz>
+            <br><![CDATA[Melhor esta├â┬º├â┬úo para renda]]></br>
+            <uk><![CDATA[├É┬Ø├É┬░├É┬╣├É┬║├æÔé¼├É┬░├æÔÇ░├É┬©├É┬╣ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢ ├É┬┤├É┬╗├æ┬Å ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
+            <ru><![CDATA[├ÉÔÇ║├æãÆ├æÔÇí├æ╦å├É┬©├É┬╣ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢ ├É┬┤├É┬╗├æ┬Å ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
+            <da><![CDATA[Bedste s├â┬ªson for indkomst]]></da>
         </text>
 
         <text name="im_help_t2_season_text">
-            <en><![CDATA[With Seasonal Effects on, Autumn gives 1.2x income â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ the season peak. Winter is lowest at 0.7x. Consider enabling a high multiplier during Autumn for maximum combined income.]]></en>
-            <de><![CDATA[Mit saisonalen Effekten bietet Herbst 1,2x Einkommen â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ der saisonale Hâ”œÃ¢â”¬Ã‚hepunkt. Winter ist mit 0,7x am niedrigsten. Aktivieren Sie einen hohen Multiplikator im Herbst fâ”œÃ¢â”¬â•r maximales Einkommen.]]></de>
-            <fr><![CDATA[Avec les effets saisonniers, l'automne donne 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ le pic saisonnier. L'hiver est le plus bas â”œÃ¢â”¬Ã¡ 0,7x. Envisagez un grand multiplicateur en automne pour un revenu maximum.]]></fr>
-            <pl><![CDATA[Przy efektach sezonowych jesieâ”œÃ Ã”Ã‡Ã— daje 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ sezonowy szczyt. Zima jest najniâ”œÃ â”¬â•sza (0,7x). Rozwaâ”œÃ â”¬â• wysoki mnoâ”œÃ â”¬â•nik jesieniâ”œÃ¤Ã”Ã‡Âª dla maksymalnego â”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczonego dochodu.]]></pl>
-            <es><![CDATA[Con efectos estacionales, el otoâ”œÃ¢â”¬â–’o da 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ el pico estacional. El invierno es el mâ”œÃ¢â”¬Ã­s bajo con 0,7x. Considera usar un multiplicador alto en otoâ”œÃ¢â”¬â–’o para ingreso mâ”œÃ¢â”¬Ã­ximo combinado.]]></es>
-            <it><![CDATA[Con gli effetti stagionali, l'autunno dâ”œÃ¢â”¬Ã¡ 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ il picco stagionale. L'inverno â”œÃ¢â”¬Â¿ il piâ”œÃ¢â”¬â•£ basso con 0,7x. Considera un moltiplicatore alto in autunno per il massimo reddito combinato.]]></it>
-            <cz><![CDATA[Se sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡mi efekty pâ”œÃ Ã”Ã¤Ã³inâ”œÃ¢â”¬Ã­â”œÃ â”¬Ã­â”œÃ¢â”¬Â¡ podzim 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡ vrchol. Zima je nejniâ”œÃ â”¬Â¥â”œÃ â”¬Ã­â”œÃ¢â”¬Â¡ (0,7x). Zvaâ”œÃ â”¬Â¥te vysokâ”œÃ¢â”¬Â¢ multiplikâ”œÃ¢â”¬Ã­tor na podzim pro maximâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡ kombinovanâ”œÃ¢â”¬Â¢ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem.]]></cz>
-            <br><![CDATA[Com efeitos sazonais, o outono dâ”œÃ¢â”¬Ã­ 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ o pico sazonal. O inverno â”œÃ¢â”¬Â® o mais baixo com 0,7x. Considere usar um multiplicador alto no outono para renda mâ”œÃ¢â”¬Ã­xima combinada.]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Âª â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª â”œÃ‰â”¼Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜ 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•‘ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†. â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã‚â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘ â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ 0,7x. â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã€â”œÃ‰â”¬â”‚â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬â•â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â© â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•‘â”œÃ¦Ã£Ã†â”œÃ‰â”¬â”â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†.]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Âª â”œÃ¦â”¬Ã¬â”œÃ¦Ã”Ã‡Ã—â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª â”œÃ‰â”¼Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã¿â”œÃ¦Ã”Ã‡Ãœ 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬â”â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘. â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã… â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ 0,7x. â”œÃ‰â”¬Ã¡â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£ â”œÃ‰â”¬â•â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã† â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ¦Ã£Ã†â”œÃ‰â”¬â”â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘.]]></ru>
-            <da><![CDATA[Med sâ”œÃ¢â”¬Âªsonale effekter giver efterâ”œÃ¢â”¬Ã‘ret 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ sâ”œÃ¢â”¬Âªsonens top. Vinter er lavest pâ”œÃ¢â”¬Ã‘ 0,7x. Overvej at aktivere en hâ”œÃ¢â”¬Â©j multiplikator om efterâ”œÃ¢â”¬Ã‘ret for maksimal kombineret indkomst.]]></da>
+            <en><![CDATA[With Seasonal Effects on, Autumn gives 1.2x income ├óÔé¼ÔÇØ the season peak. Winter is lowest at 0.7x. Consider enabling a high multiplier during Autumn for maximum combined income.]]></en>
+            <de><![CDATA[Mit saisonalen Effekten bietet Herbst 1,2x Einkommen ├óÔé¼ÔÇØ der saisonale H├â┬Âhepunkt. Winter ist mit 0,7x am niedrigsten. Aktivieren Sie einen hohen Multiplikator im Herbst f├â┬╝r maximales Einkommen.]]></de>
+            <fr><![CDATA[Avec les effets saisonniers, l'automne donne 1,2x ├óÔé¼ÔÇØ le pic saisonnier. L'hiver est le plus bas ├â┬á 0,7x. Envisagez un grand multiplicateur en automne pour un revenu maximum.]]></fr>
+            <pl><![CDATA[Przy efektach sezonowych jesie├àÔÇ× daje 1,2x ├óÔé¼ÔÇØ sezonowy szczyt. Zima jest najni├à┬╝sza (0,7x). Rozwa├à┬╝ wysoki mno├à┬╝nik jesieni├äÔÇª dla maksymalnego ├àÔÇÜ├äÔÇªczonego dochodu.]]></pl>
+            <es><![CDATA[Con efectos estacionales, el oto├â┬▒o da 1,2x ├óÔé¼ÔÇØ el pico estacional. El invierno es el m├â┬ís bajo con 0,7x. Considera usar un multiplicador alto en oto├â┬▒o para ingreso m├â┬íximo combinado.]]></es>
+            <it><![CDATA[Con gli effetti stagionali, l'autunno d├â┬á 1,2x ├óÔé¼ÔÇØ il picco stagionale. L'inverno ├â┬¿ il pi├â┬╣ basso con 0,7x. Considera un moltiplicatore alto in autunno per il massimo reddito combinato.]]></it>
+            <cz><![CDATA[Se sez├â┬│nn├â┬¡mi efekty p├àÔäóin├â┬í├à┬í├â┬¡ podzim 1,2x ├óÔé¼ÔÇØ sez├â┬│nn├â┬¡ vrchol. Zima je nejni├à┬¥├à┬í├â┬¡ (0,7x). Zva├à┬¥te vysok├â┬¢ multiplik├â┬ítor na podzim pro maxim├â┬íln├â┬¡ kombinovan├â┬¢ p├àÔäó├â┬¡jem.]]></cz>
+            <br><![CDATA[Com efeitos sazonais, o outono d├â┬í 1,2x ├óÔé¼ÔÇØ o pico sazonal. O inverno ├â┬® o mais baixo com 0,7x. Considere usar um multiplicador alto no outono para renda m├â┬íxima combinada.]]></br>
+            <uk><![CDATA[├É┼©├æÔé¼├É┬© ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬©├æÔÇª ├É┬Á├æÔÇ×├É┬Á├É┬║├æÔÇÜ├É┬░├æÔÇª ├É┼¥├æ┬ü├æÔÇô├É┬¢├æ┼Æ ├É┬┤├É┬░├æÔÇØ 1,2x ├óÔé¼ÔÇØ ├É┬┐├æÔÇô├É┬║ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├æãÆ. ├ÉÔÇö├É┬©├É┬╝├É┬░ ├É┬¢├É┬░├É┬╣├É┬¢├É┬©├É┬Â├æÔÇí├É┬░ ├óÔé¼ÔÇØ 0,7x. ├É┬á├É┬¥├É┬À├É┬│├É┬╗├æ┬Å├É┬¢├æ┼Æ├æÔÇÜ├É┬Á ├É┬▓├É┬Á├É┬╗├É┬©├É┬║├É┬©├É┬╣ ├É┬╝├É┬¢├É┬¥├É┬Â├É┬¢├É┬©├É┬║ ├É┬▓├É┬¥├æ┬ü├É┬Á├É┬¢├É┬© ├É┬┤├É┬╗├æ┬Å ├É┬╝├É┬░├É┬║├æ┬ü├É┬©├É┬╝├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥├É┬│├É┬¥ ├æ┬ü├æãÆ├É┬║├æãÆ├É┬┐├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ.]]></uk>
+            <ru><![CDATA[├É┼©├æÔé¼├É┬© ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├æÔÇ╣├æÔÇª ├æ┬ì├æÔÇ×├æÔÇ×├É┬Á├É┬║├æÔÇÜ├É┬░├æÔÇª ├É┼¥├æ┬ü├É┬Á├É┬¢├æ┼Æ ├É┬┤├É┬░├æÔÇÿ├æÔÇÜ 1,2x ├óÔé¼ÔÇØ ├É┬┐├É┬©├É┬║ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬░. ├ÉÔÇö├É┬©├É┬╝├É┬░ ├É┬¢├É┬░├É┬©├É┬╝├É┬Á├É┬¢├æ┼Æ├æ╦å├É┬░├æ┬Å ├óÔé¼ÔÇØ 0,7x. ├É┬á├É┬░├æ┬ü├æ┬ü├É┬╝├É┬¥├æÔÇÜ├æÔé¼├É┬©├æÔÇÜ├É┬Á ├É┬▒├É┬¥├É┬╗├æ┼Æ├æ╦å├É┬¥├É┬╣ ├É┬╝├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┼Æ ├É┬¥├æ┬ü├É┬Á├É┬¢├æ┼Æ├æ┼¢ ├É┬┤├É┬╗├æ┬Å ├É┬╝├É┬░├É┬║├æ┬ü├É┬©├É┬╝├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥├É┬│├É┬¥ ├æ┬ü├É┬¥├É┬▓├É┬¥├É┬║├æãÆ├É┬┐├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░.]]></ru>
+            <da><![CDATA[Med s├â┬ªsonale effekter giver efter├â┬Ñret 1,2x ├óÔé¼ÔÇØ s├â┬ªsonens top. Vinter er lavest p├â┬Ñ 0,7x. Overvej at aktivere en h├â┬©j multiplikator om efter├â┬Ñret for maksimal kombineret indkomst.]]></da>
         </text>
 
         <text name="im_help_t2_calc_title">
             <en><![CDATA[Income Formula]]></en>
             <de><![CDATA[Einkommensformel]]></de>
             <fr><![CDATA[Formule de revenu]]></fr>
-            <pl><![CDATA[Wzâ”œÃ¢â”¬â”‚r dochodu]]></pl>
-            <es><![CDATA[Fâ”œÃ¢â”¬â”‚rmula de ingresos]]></es>
+            <pl><![CDATA[Wz├â┬│r dochodu]]></pl>
+            <es><![CDATA[F├â┬│rmula de ingresos]]></es>
             <it><![CDATA[Formula del reddito]]></it>
-            <cz><![CDATA[Vzorec pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmu]]></cz>
-            <br><![CDATA[Fâ”œÃ¢â”¬â”‚rmula de renda]]></br>
-            <uk><![CDATA[â”œÃ‰â”¬Ã±â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¬Ã±â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
+            <cz><![CDATA[Vzorec p├àÔäó├â┬¡jmu]]></cz>
+            <br><![CDATA[F├â┬│rmula de renda]]></br>
+            <uk><![CDATA[├É┬ñ├É┬¥├æÔé¼├É┬╝├æãÆ├É┬╗├É┬░ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
+            <ru><![CDATA[├É┬ñ├É┬¥├æÔé¼├É┬╝├æãÆ├É┬╗├É┬░ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
             <da><![CDATA[Indkomstformel]]></da>
         </text>
 
         <text name="im_help_t2_calc_text">
-            <en><![CDATA[Final = Base â”œÃ¢Ã”Ã‡Ã¶ Multiplier â”œÃ¢Ã”Ã‡Ã¶ Seasonal. Example: Hard ($1,100) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Autumn (1.2x) = $13,200 per period. Use the IncomeNext console command to preview your next scheduled payout.]]></en>
-            <de><![CDATA[Endwert = Basis â”œÃ¢Ã”Ã‡Ã¶ Multiplikator â”œÃ¢Ã”Ã‡Ã¶ Saisonfaktor. Beispiel: Schwer (1.100$) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Herbst (1,2x) = 13.200$ pro Zeitraum. IncomeNext in der Konsole zeigt die nâ”œÃ¢â”¬Ã±chste Zahlung.]]></de>
-            <fr><![CDATA[Final = Base â”œÃ¢Ã”Ã‡Ã¶ Multiplicateur â”œÃ¢Ã”Ã‡Ã¶ Saisonnier. Exemple : Difficile (1 100$) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Automne (1,2x) = 13 200$ par pâ”œÃ¢â”¬Â®riode. Utilisez IncomeNext en console pour voir la prochaine â”œÃ¢â”¬Â®châ”œÃ¢â”¬Â®ance.]]></fr>
-            <pl><![CDATA[Koâ”œÃ Ã”Ã‡Ã—cowy = Podstawa â”œÃ¢Ã”Ã‡Ã¶ Mnoâ”œÃ â”¬â•nik â”œÃ¢Ã”Ã‡Ã¶ Sezon. Przykâ”œÃ Ã”Ã‡Ãœad: Trudny (1 100$) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Jesieâ”œÃ Ã”Ã‡Ã— (1,2x) = 13 200$ za okres. Uâ”œÃ â”¬â•yj IncomeNext w konsoli, aby zobaczyâ”œÃ¤Ã”Ã‡Ã­ nastâ”œÃ¤Ã”Ã¤Ã³pnâ”œÃ¤Ã”Ã‡Âª pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­.]]></pl>
-            <es><![CDATA[Final = Base â”œÃ¢Ã”Ã‡Ã¶ Multiplicador â”œÃ¢Ã”Ã‡Ã¶ Estacional. Ejemplo: Difâ”œÃ¢â”¬Â¡cil ($1.100) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Otoâ”œÃ¢â”¬â–’o (1,2x) = $13.200 por perâ”œÃ¢â”¬Â¡odo. Usa IncomeNext en consola para ver el prâ”œÃ¢â”¬â”‚ximo pago programado.]]></es>
-            <it><![CDATA[Finale = Base â”œÃ¢Ã”Ã‡Ã¶ Moltiplicatore â”œÃ¢Ã”Ã‡Ã¶ Stagionale. Esempio: Difficile ($1.100) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Autunno (1,2x) = $13.200 per periodo. Usa IncomeNext in console per il prossimo pagamento.]]></it>
-            <cz><![CDATA[Vâ”œÃ¢â”¬Â¢sledek = Zâ”œÃ¢â”¬Ã­klad â”œÃ¢Ã”Ã‡Ã¶ Multiplikâ”œÃ¢â”¬Ã­tor â”œÃ¢Ã”Ã‡Ã¶ Sezâ”œÃ¢â”¬â”‚na. Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡klad: Tâ”œÃ¤Ã”Ã‡â•‘â”œÃ â”¬Â¥kâ”œÃ¢â”¬Â® (1 100$) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Podzim (1,2x) = 13 200$ za obdobâ”œÃ¢â”¬Â¡. IncomeNext v konzoli ukâ”œÃ¢â”¬Ã­â”œÃ â”¬Â¥e pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡â”œÃ â”¬Ã­tâ”œÃ¢â”¬Â¡ platbu.]]></cz>
-            <br><![CDATA[Final = Base â”œÃ¢Ã”Ã‡Ã¶ Multiplicador â”œÃ¢Ã”Ã‡Ã¶ Sazonal. Exemplo: Difâ”œÃ¢â”¬Â¡cil ($1.100) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Outono (1,2x) = $13.200 por perâ”œÃ¢â”¬Â¡odo. Use IncomeNext no console para ver o prâ”œÃ¢â”¬â”‚ximo pagamento.]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘ = â”œÃ‰Ã”Ã‡Ã¿â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ¢Ã”Ã‡Ã¶ â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘ â”œÃ¢Ã”Ã‡Ã¶ â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤: â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥ ($1 100) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ â”œÃ‰â”¼Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã† (1,2x) = $13 200 â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤. IncomeNext â”œÃ¦Ã£Ã† â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ã â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â”â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†.]]></uk>
-            <ru><![CDATA[â”œÃ‰â•¦Â£â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚ = â”œÃ‰Ã”Ã‡Ã¿â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ¢Ã”Ã‡Ã¶ â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã† â”œÃ¢Ã”Ã‡Ã¶ â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼: â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ ($1 100) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ â”œÃ‰â”¼Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã† (1,2x) = $13 200 â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤. IncomeNext â”œÃ‰â”¬â–“ â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡â–‘â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†.]]></ru>
-            <da><![CDATA[Endelig = Base â”œÃ¢Ã”Ã‡Ã¶ Multiplikator â”œÃ¢Ã”Ã‡Ã¶ Sâ”œÃ¢â”¬Âªson. Eksempel: Svâ”œÃ¢â”¬Âªr ($1.100) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Efterâ”œÃ¢â”¬Ã‘r (1,2x) = $13.200 pr. periode. Brug IncomeNext konsolkommandoen for at forhâ”œÃ¢â”¬Ã‘ndsvise din nâ”œÃ¢â”¬Âªste planlagte udbetaling.]]></da>
+            <en><![CDATA[Final = Base ├âÔÇö Multiplier ├âÔÇö Seasonal. Example: Hard ($1,100) ├âÔÇö 10x ├âÔÇö Autumn (1.2x) = $13,200 per period. Use the IncomeNext console command to preview your next scheduled payout.]]></en>
+            <de><![CDATA[Endwert = Basis ├âÔÇö Multiplikator ├âÔÇö Saisonfaktor. Beispiel: Schwer (1.100$) ├âÔÇö 10x ├âÔÇö Herbst (1,2x) = 13.200$ pro Zeitraum. IncomeNext in der Konsole zeigt die n├â┬ñchste Zahlung.]]></de>
+            <fr><![CDATA[Final = Base ├âÔÇö Multiplicateur ├âÔÇö Saisonnier. Exemple : Difficile (1 100$) ├âÔÇö 10x ├âÔÇö Automne (1,2x) = 13 200$ par p├â┬®riode. Utilisez IncomeNext en console pour voir la prochaine ├â┬®ch├â┬®ance.]]></fr>
+            <pl><![CDATA[Ko├àÔÇ×cowy = Podstawa ├âÔÇö Mno├à┬╝nik ├âÔÇö Sezon. Przyk├àÔÇÜad: Trudny (1 100$) ├âÔÇö 10x ├âÔÇö Jesie├àÔÇ× (1,2x) = 13 200$ za okres. U├à┬╝yj IncomeNext w konsoli, aby zobaczy├äÔÇí nast├äÔäópn├äÔÇª p├àÔÇÜatno├àÔÇ║├äÔÇí.]]></pl>
+            <es><![CDATA[Final = Base ├âÔÇö Multiplicador ├âÔÇö Estacional. Ejemplo: Dif├â┬¡cil ($1.100) ├âÔÇö 10x ├âÔÇö Oto├â┬▒o (1,2x) = $13.200 por per├â┬¡odo. Usa IncomeNext en consola para ver el pr├â┬│ximo pago programado.]]></es>
+            <it><![CDATA[Finale = Base ├âÔÇö Moltiplicatore ├âÔÇö Stagionale. Esempio: Difficile ($1.100) ├âÔÇö 10x ├âÔÇö Autunno (1,2x) = $13.200 per periodo. Usa IncomeNext in console per il prossimo pagamento.]]></it>
+            <cz><![CDATA[V├â┬¢sledek = Z├â┬íklad ├âÔÇö Multiplik├â┬ítor ├âÔÇö Sez├â┬│na. P├àÔäó├â┬¡klad: T├äÔÇ║├à┬¥k├â┬® (1 100$) ├âÔÇö 10x ├âÔÇö Podzim (1,2x) = 13 200$ za obdob├â┬¡. IncomeNext v konzoli uk├â┬í├à┬¥e p├àÔäó├â┬¡├à┬ít├â┬¡ platbu.]]></cz>
+            <br><![CDATA[Final = Base ├âÔÇö Multiplicador ├âÔÇö Sazonal. Exemplo: Dif├â┬¡cil ($1.100) ├âÔÇö 10x ├âÔÇö Outono (1,2x) = $13.200 por per├â┬¡odo. Use IncomeNext no console para ver o pr├â┬│ximo pagamento.]]></br>
+            <uk><![CDATA[├É┼©├æÔÇô├É┬┤├æ┬ü├æãÆ├É┬╝├É┬¥├É┬║ = ├ÉÔÇÿ├É┬░├É┬À├É┬░ ├âÔÇö ├É┼ô├É┬¢├É┬¥├É┬Â├É┬¢├É┬©├É┬║ ├âÔÇö ├É┬í├É┬Á├É┬À├É┬¥├É┬¢. ├É┼©├æÔé¼├É┬©├É┬║├É┬╗├É┬░├É┬┤: ├ÉÔÇÖ├É┬░├É┬Â├É┬║├É┬¥ ($1 100) ├âÔÇö 10x ├âÔÇö ├É┼¥├æ┬ü├æÔÇô├É┬¢├æ┼Æ (1,2x) = $13 200 ├É┬À├É┬░ ├É┬┐├É┬Á├æÔé¼├æÔÇô├É┬¥├É┬┤. IncomeNext ├æãÆ ├É┬║├É┬¥├É┬¢├æ┬ü├É┬¥├É┬╗├æÔÇô ├É┬┐├É┬¥├É┬║├É┬░├É┬Â├É┬Á ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æãÆ├É┬┐├É┬¢├æãÆ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ.]]></uk>
+            <ru><![CDATA[├É╦£├æÔÇÜ├É┬¥├É┬│ = ├ÉÔÇÿ├É┬░├É┬À├É┬░ ├âÔÇö ├É┼ô├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┼Æ ├âÔÇö ├É┬í├É┬Á├É┬À├É┬¥├É┬¢. ├É┼©├æÔé¼├É┬©├É┬╝├É┬Á├æÔé¼: ├É┬í├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥ ($1 100) ├âÔÇö 10x ├âÔÇö ├É┼¥├æ┬ü├É┬Á├É┬¢├æ┼Æ (1,2x) = $13 200 ├É┬À├É┬░ ├É┬┐├É┬Á├æÔé¼├É┬©├É┬¥├É┬┤. IncomeNext ├É┬▓ ├É┬║├É┬¥├É┬¢├æ┬ü├É┬¥├É┬╗├É┬© ├É┬┐├É┬¥├É┬║├É┬░├É┬Â├É┬Á├æÔÇÜ ├æ┬ü├É┬╗├É┬Á├É┬┤├æãÆ├æ┼¢├æÔÇ░├æãÆ├æ┼¢ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ.]]></ru>
+            <da><![CDATA[Endelig = Base ├âÔÇö Multiplikator ├âÔÇö S├â┬ªson. Eksempel: Sv├â┬ªr ($1.100) ├âÔÇö 10x ├âÔÇö Efter├â┬Ñr (1,2x) = $13.200 pr. periode. Brug IncomeNext konsolkommandoen for at forh├â┬Ñndsvise din n├â┬ªste planlagte udbetaling.]]></da>
         </text>
 
-        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page 8 â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ About â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
+        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page 8 ├óÔé¼ÔÇØ About ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
         <text name="im_help_i1_about_title">
             <en><![CDATA[About This Mod]]></en>
-            <de><![CDATA[â”œÃ¢â”¼Ã´ber diesen Mod]]></de>
-            <fr><![CDATA[â”œÃ¢Ã”Ã©Â¼ propos de ce mod]]></fr>
+            <de><![CDATA[├â┼ôber diesen Mod]]></de>
+            <fr><![CDATA[├âÔé¼ propos de ce mod]]></fr>
             <pl><![CDATA[O tym modzie]]></pl>
             <es><![CDATA[Acerca de este mod]]></es>
             <it><![CDATA[Informazioni su questo mod]]></it>
             <cz><![CDATA[O tomto modu]]></cz>
             <br><![CDATA[Sobre este mod]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ â”œÃ¦Ã”Ã‡Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•£ â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’ â”œÃ¦â”¬Ã¬â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â• â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ã]]></ru>
+            <uk><![CDATA[├É┼©├æÔé¼├É┬¥ ├æÔÇá├É┬Á├É┬╣ ├É┬╝├É┬¥├É┬┤]]></uk>
+            <ru><![CDATA[├É┼¥├É┬▒ ├æ┬ì├æÔÇÜ├É┬¥├É┬╝ ├É┬╝├É┬¥├É┬┤├É┬Á]]></ru>
             <da><![CDATA[Om denne mod]]></da>
         </text>
 
         <text name="im_help_i1_about_text">
             <en><![CDATA[Income Mod v2.0 adds a fully configurable passive income system to FS25. All settings persist per savegame. Compatible with multiplayer and other mods.]]></en>
-            <de><![CDATA[Einkommens-Mod v2.0 fâ”œÃ¢â”¬â•gt FS25 ein vollstâ”œÃ¢â”¬Ã±ndig konfigurierbares passives Einkommenssystem hinzu. Alle Einstellungen werden pro Spielstand gespeichert. Multiplayer-kompatibel.]]></de>
-            <fr><![CDATA[Income Mod v2.0 ajoute un systâ”œÃ¢â”¬Â¿me de revenus passifs entiâ”œÃ¢â”¬Â¿rement configurable â”œÃ¢â”¬Ã¡ FS25. Tous les paramâ”œÃ¢â”¬Â¿tres persistent par sauvegarde. Compatible multijoueur et autres mods.]]></fr>
-            <pl><![CDATA[Income Mod v2.0 dodaje do FS25 w peâ”œÃ Ã”Ã‡Ãœni konfigurowalny system pasywnych dochodâ”œÃ¢â”¬â”‚w. Wszystkie ustawienia sâ”œÃ¤Ã”Ã‡Âª zachowywane dla kaâ”œÃ â”¬â•dego zapisu. Kompatybilny z wieloosobowym.]]></pl>
-            <es><![CDATA[Income Mod v2.0 aâ”œÃ¢â”¬â–’ade un sistema de ingresos pasivos totalmente configurable a FS25. Todos los ajustes persisten por guardado. Compatible con multijugador y otros mods.]]></es>
+            <de><![CDATA[Einkommens-Mod v2.0 f├â┬╝gt FS25 ein vollst├â┬ñndig konfigurierbares passives Einkommenssystem hinzu. Alle Einstellungen werden pro Spielstand gespeichert. Multiplayer-kompatibel.]]></de>
+            <fr><![CDATA[Income Mod v2.0 ajoute un syst├â┬¿me de revenus passifs enti├â┬¿rement configurable ├â┬á FS25. Tous les param├â┬¿tres persistent par sauvegarde. Compatible multijoueur et autres mods.]]></fr>
+            <pl><![CDATA[Income Mod v2.0 dodaje do FS25 w pe├àÔÇÜni konfigurowalny system pasywnych dochod├â┬│w. Wszystkie ustawienia s├äÔÇª zachowywane dla ka├à┬╝dego zapisu. Kompatybilny z wieloosobowym.]]></pl>
+            <es><![CDATA[Income Mod v2.0 a├â┬▒ade un sistema de ingresos pasivos totalmente configurable a FS25. Todos los ajustes persisten por guardado. Compatible con multijugador y otros mods.]]></es>
             <it><![CDATA[Income Mod v2.0 aggiunge un sistema di reddito passivo completamente configurabile a FS25. Tutte le impostazioni persistono per salvataggio. Compatibile con multigiocatore e altri mod.]]></it>
-            <cz><![CDATA[Income Mod v2.0 pâ”œÃ Ã”Ã¤Ã³idâ”œÃ¢â”¬Ã­vâ”œÃ¢â”¬Ã­ do FS25 plnâ”œÃ¤Ã”Ã‡â•‘ konfigurovatelnâ”œÃ¢â”¬Â¢ systâ”œÃ¢â”¬Â®m pasivnâ”œÃ¢â”¬Â¡ho pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmu. Vâ”œÃ â”¬Ã­echna nastavenâ”œÃ¢â”¬Â¡ jsou zachovâ”œÃ¢â”¬Ã­na pro kaâ”œÃ â”¬Â¥dâ”œÃ¢â”¬Â¢ uloâ”œÃ â”¬Â¥enâ”œÃ¢â”¬Â¢ stav. Kompatibilnâ”œÃ¢â”¬Â¡ s vâ”œÃ¢â”¬Â¡ce hrâ”œÃ¢â”¬Ã­â”œÃ¤â”¬Ã¬i.]]></cz>
-            <br><![CDATA[O Income Mod v2.0 adiciona um sistema de renda passiva totalmente configurâ”œÃ¢â”¬Ã­vel ao FS25. Todas as configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães persistem por salvamento. Compatâ”œÃ¢â”¬Â¡vel com multiplayer e outros mods.]]></br>
-            <uk><![CDATA[Income Mod v2.0 â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ FS25 â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Â¢ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†. â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–’â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”‚â”œÃ‰â”¬â–‘â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–’â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…. â”œÃ‰â”¬Ã­â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬Ã€ â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•.]]></uk>
-            <ru><![CDATA[Income Mod v2.0 â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â–“ FS25 â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â©â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘. â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ã â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã…. â”œÃ‰â”¬Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ¦â”¬Ã¼ â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•.]]></ru>
-            <da><![CDATA[Income Mod v2.0 tilfâ”œÃ¢â”¬Â©jer et fuldt konfigurerbart passivt indkomstsystem til FS25. Alle indstillinger bevares pr. gemt spil. Kompatibel med multiplayer og andre mods.]]></da>
+            <cz><![CDATA[Income Mod v2.0 p├àÔäóid├â┬ív├â┬í do FS25 pln├äÔÇ║ konfigurovateln├â┬¢ syst├â┬®m pasivn├â┬¡ho p├àÔäó├â┬¡jmu. V├à┬íechna nastaven├â┬¡ jsou zachov├â┬ína pro ka├à┬¥d├â┬¢ ulo├à┬¥en├â┬¢ stav. Kompatibiln├â┬¡ s v├â┬¡ce hr├â┬í├ä┬ìi.]]></cz>
+            <br><![CDATA[O Income Mod v2.0 adiciona um sistema de renda passiva totalmente configur├â┬ível ao FS25. Todas as configura├â┬º├â┬Áes persistem por salvamento. Compat├â┬¡vel com multiplayer e outros mods.]]></br>
+            <uk><![CDATA[Income Mod v2.0 ├É┬┤├É┬¥├É┬┤├É┬░├æÔÇØ ├É┬┤├É┬¥ FS25 ├É┬┐├É┬¥├É┬▓├É┬¢├æÔÇô├æ┬ü├æÔÇÜ├æ┼¢ ├É┬¢├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├É┬¥├É┬▓├æãÆ├É┬▓├É┬░├É┬¢├æãÆ ├æ┬ü├É┬©├æ┬ü├æÔÇÜ├É┬Á├É┬╝├æãÆ ├É┬┐├É┬░├æ┬ü├É┬©├É┬▓├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ. ├ÉÔÇÖ├æ┬ü├æÔÇô ├É┬¢├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å ├É┬À├É┬▒├É┬Á├æÔé¼├æÔÇô├É┬│├É┬░├æ┼¢├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├É┬┤├É┬╗├æ┬Å ├É┬║├É┬¥├É┬Â├É┬¢├É┬¥├É┬│├É┬¥ ├É┬À├É┬▒├É┬Á├æÔé¼├É┬Á├É┬Â├É┬Á├É┬¢├É┬¢├æ┬Å. ├É┬í├æãÆ├É┬╝├æÔÇô├æ┬ü├É┬¢├É┬©├É┬╣ ├É┬À ├É┬╝├æãÆ├É┬╗├æ┼Æ├æÔÇÜ├É┬©├É┬┐├É┬╗├É┬Á├æÔÇØ├æÔé¼├É┬¥├É┬╝.]]></uk>
+            <ru><![CDATA[Income Mod v2.0 ├É┬┤├É┬¥├É┬▒├É┬░├É┬▓├É┬╗├æ┬Å├É┬Á├æÔÇÜ ├É┬▓ FS25 ├É┬┐├É┬¥├É┬╗├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æ┼Æ├æ┼¢ ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬░├É┬©├É┬▓├É┬░├É┬Á├É┬╝├æãÆ├æ┼¢ ├æ┬ü├É┬©├æ┬ü├æÔÇÜ├É┬Á├É┬╝├æãÆ ├É┬┐├É┬░├æ┬ü├æ┬ü├É┬©├É┬▓├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░. ├ÉÔÇÖ├æ┬ü├É┬Á ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬© ├æ┬ü├É┬¥├æÔÇª├æÔé¼├É┬░├É┬¢├æ┬Å├æ┼¢├æÔÇÜ├æ┬ü├æ┬Å ├É┬┤├É┬╗├æ┬Å ├É┬║├É┬░├É┬Â├É┬┤├É┬¥├É┬│├É┬¥ ├æ┬ü├É┬¥├æÔÇª├æÔé¼├É┬░├É┬¢├É┬Á├É┬¢├É┬©├æ┬Å. ├É┬í├É┬¥├É┬▓├É┬╝├É┬Á├æ┬ü├æÔÇÜ├É┬©├É┬╝ ├æ┬ü ├É┬╝├æãÆ├É┬╗├æ┼Æ├æÔÇÜ├É┬©├É┬┐├É┬╗├É┬Á├É┬Á├æÔé¼├É┬¥├É┬╝.]]></ru>
+            <da><![CDATA[Income Mod v2.0 tilf├â┬©jer et fuldt konfigurerbart passivt indkomstsystem til FS25. Alle indstillinger bevares pr. gemt spil. Kompatibel med multiplayer og andre mods.]]></da>
         </text>
 
         <text name="im_help_i1_cmd_title">
@@ -1432,25 +1432,25 @@
             <pl><![CDATA[Komendy konsoli]]></pl>
             <es><![CDATA[Comandos de consola]]></es>
             <it><![CDATA[Comandi console]]></it>
-            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡kazy konzole]]></cz>
+            <cz><![CDATA[P├àÔäó├â┬¡kazy konzole]]></cz>
             <br><![CDATA[Comandos do console]]></br>
-            <uk><![CDATA[â”œÃ‰â”¼Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬Ã â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡â•£]]></ru>
+            <uk><![CDATA[├É┼í├É┬¥├É┬¢├æ┬ü├É┬¥├É┬╗├æ┼Æ├É┬¢├æÔÇô ├É┬║├É┬¥├É┬╝├É┬░├É┬¢├É┬┤├É┬©]]></uk>
+            <ru><![CDATA[├É┼í├É┬¥├É┬¢├æ┬ü├É┬¥├É┬╗├æ┼Æ├É┬¢├æÔÇ╣├É┬Á ├É┬║├É┬¥├É┬╝├É┬░├É┬¢├É┬┤├æÔÇ╣]]></ru>
             <da><![CDATA[Konsolkommandoer]]></da>
         </text>
 
         <text name="im_help_i1_cmd_text">
             <en><![CDATA[Open the developer console (~) and type 'income' for the full list. Key commands: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></en>
-            <de><![CDATA[Entwicklerkonsole (~) â”œÃ¢â”¬Ã‚ffnen und 'income' eingeben. Wichtige Befehle: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></de>
-            <fr><![CDATA[Ouvrez la console (~) et tapez 'income' pour la liste. Commandes clâ”œÃ¢â”¬Â®s : IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></fr>
-            <pl><![CDATA[Otwâ”œÃ¢â”¬â”‚rz konsolâ”œÃ¤Ã”Ã¤Ã³ (~) i wpisz 'income'. Kluczowe: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></pl>
+            <de><![CDATA[Entwicklerkonsole (~) ├â┬Âffnen und 'income' eingeben. Wichtige Befehle: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></de>
+            <fr><![CDATA[Ouvrez la console (~) et tapez 'income' pour la liste. Commandes cl├â┬®s : IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></fr>
+            <pl><![CDATA[Otw├â┬│rz konsol├äÔäó (~) i wpisz 'income'. Kluczowe: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></pl>
             <es><![CDATA[Abre la consola (~) y escribe 'income'. Comandos clave: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></es>
             <it><![CDATA[Apri la console (~) e digita 'income'. Comandi chiave: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></it>
-            <cz><![CDATA[Otevâ”œÃ Ã”Ã¤Ã³ete konzoli (~) a zadejte 'income'. Klâ”œÃ¢â”¬Â¡â”œÃ¤â”¬Ã¬ovâ”œÃ¢â”¬Â®: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></cz>
+            <cz><![CDATA[Otev├àÔäóete konzoli (~) a zadejte 'income'. Kl├â┬¡├ä┬ìov├â┬®: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></cz>
             <br><![CDATA[Abra o console (~) e digite 'income'. Principais: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></br>
-            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã† (~) â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬â–“â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† 'income'. â”œÃ‰â”¼Ã­â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></uk>
-            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã† (~) â”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã 'income'. â”œÃ‰â”¼Ã­â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬Ã: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></ru>
-            <da><![CDATA[â”œÃ¢Ã”Ã‡Âªbn udviklerkonsollen (~) og skriv 'income' for den fulde liste. Nâ”œÃ¢â”¬Â©glekommandoer: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></da>
+            <uk><![CDATA[├ÉÔÇÖ├æÔÇô├É┬┤├É┬║├æÔé¼├É┬©├É┬╣├æÔÇÜ├É┬Á ├É┬║├É┬¥├É┬¢├æ┬ü├É┬¥├É┬╗├æ┼Æ (~) ├æÔÇô ├É┬▓├É┬▓├É┬Á├É┬┤├æÔÇô├æÔÇÜ├æ┼Æ 'income'. ├É┼í├É┬╗├æ┼¢├æÔÇí├É┬¥├É┬▓├æÔÇô: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></uk>
+            <ru><![CDATA[├É┼¥├æÔÇÜ├É┬║├æÔé¼├É┬¥├É┬╣├æÔÇÜ├É┬Á ├É┬║├É┬¥├É┬¢├æ┬ü├É┬¥├É┬╗├æ┼Æ (~) ├É┬© ├É┬▓├É┬▓├É┬Á├É┬┤├É┬©├æÔÇÜ├É┬Á 'income'. ├É┼í├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬▓├æÔÇ╣├É┬Á: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></ru>
+            <da><![CDATA[├âÔÇªbn udviklerkonsollen (~) og skriv 'income' for den fulde liste. N├â┬©glekommandoer: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></da>
         </text>
     
 
@@ -2088,12 +2088,12 @@
     </l10n>
 
     <!--
-        Help pages accessible in-game via: Pause Menu â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Help.
+        Help pages accessible in-game via: Pause Menu ├óÔÇáÔÇÖ Help.
         Four categories: Overview, Settings, Tips & Tricks, About.
     -->
     <helpLines>
 
-        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Category 1: Overview â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
+        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Category 1: Overview ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
         <category title="$l10n_im_help_cat_overview">
 
             <page title="$l10n_im_help_p1_title" iconSliceId="icon_info">
@@ -2120,7 +2120,7 @@
 
         </category>
 
-        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Category 2: Settings â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
+        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Category 2: Settings ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
         <category title="$l10n_im_help_cat_settings">
 
             <page title="$l10n_im_help_s1_title" iconSliceId="icon_info">
@@ -2170,7 +2170,7 @@
 
         </category>
 
-        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Category 3: Tips & Tricks â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
+        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Category 3: Tips & Tricks ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
         <category title="$l10n_im_help_cat_tips">
 
             <page title="$l10n_im_help_t1_title" iconSliceId="icon_info">
@@ -2197,7 +2197,7 @@
 
         </category>
 
-        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Category 4: About â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
+        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Category 4: About ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
         <category title="$l10n_im_help_cat_info">
 
             <page title="$l10n_im_help_i1_title" iconSliceId="icon_info">

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="92">
     <author>TisonK</author>
-    <version>2.1.7.31</version>
+    <version>2.1.7.32</version>
     <modName>FS25_IncomeMod</modName>
     <title>
         <en><![CDATA[Income Mod]]></en>
         <de><![CDATA[Realistisches Ernten]]></de>
-        <fr><![CDATA[R├â┬®colte R├â┬®aliste]]></fr>
-        <pl><![CDATA[Realistyczne ├à┬╗niwa]]></pl>
+        <fr><![CDATA[Râ”œÃ¢â”¬Â®colte Râ”œÃ¢â”¬Â®aliste]]></fr>
+        <pl><![CDATA[Realistyczne â”œÃ â”¬â•—niwa]]></pl>
         <es><![CDATA[Cosecha Realista]]></es>
         <it><![CDATA[Raccolta Realistica]]></it>
-        <cz><![CDATA[Realistick├â┬í Sklize├à╦å]]></cz>
+        <cz><![CDATA[Realistickâ”œÃ¢â”¬Ã­ Sklizeâ”œÃ â•¦Ã¥]]></cz>
         <br><![CDATA[Colheita Realista]]></br>
-        <uk><![CDATA[├É┬á├É┬Á├É┬░├É┬╗├æÔÇô├æ┬ü├æÔÇÜ├É┬©├æÔÇí├É┬¢├É┬©├É┬╣ ├É┬À├É┬▒├æÔÇô├æÔé¼ ├É┬▓├æÔé¼├É┬¥├É┬Â├É┬░├æ┼¢]]></uk>
-        <ru><![CDATA[├É┬á├É┬Á├É┬░├É┬╗├É┬©├æ┬ü├æÔÇÜ├É┬©├æÔÇí├É┬¢├æÔÇ╣├É┬╣ ├æ┬ü├É┬▒├É┬¥├æÔé¼ ├æãÆ├æÔé¼├É┬¥├É┬Â├É┬░├æ┬Å]]></ru>
+        <uk><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã©Â¼ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â–‘â”œÃ¦â”¼Â¢]]></uk>
+        <ru><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼ â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã…]]></ru>
         <da><![CDATA[Indkomst Mod]]></da>
     </title>
     <description>
         <en><![CDATA[Adds hourly / daily income system with difficulty tiers, seasonal modifiers, and multiplayer per-farm support.]]></en>
-        <de><![CDATA[F├â┬╝gt ein st├â┬╝ndliches / t├â┬ñgliches Einkommenssystem mit Schwierigkeitsstufen, saisonalen Modifikatoren und Mehrspielersupport hinzu.]]></de>
-        <fr><![CDATA[Ajoute un syst├â┬¿me de revenus horaires / quotidiens avec niveaux de difficult├â┬®, modificateurs saisonniers et support multijoueur.]]></fr>
-        <pl><![CDATA[Dodaje system dochod├â┬│w godzinowych / dziennych z poziomami trudno├àÔÇ║ci, modyfikatorami sezonowymi i wsparciem wieloosobowym.]]></pl>
-        <es><![CDATA[A├â┬▒ade sistema de ingresos horarios / diarios con niveles de dificultad, modificadores estacionales y soporte multijugador.]]></es>
-        <it><![CDATA[Aggiunge un sistema di reddito orario / giornaliero con livelli di difficolt├â┬á, modificatori stagionali e supporto multigiocatore.]]></it>
-        <cz><![CDATA[P├àÔäóid├â┬ív├â┬í hodinov├â┬¢ / denn├â┬¡ p├àÔäó├â┬¡jmov├â┬¢ syst├â┬®m s obt├â┬¡├à┬¥nost├â┬¡, sez├â┬│nn├â┬¡mi modifik├â┬ítory a podporou v├â┬¡ce hr├â┬í├ä┬ì├à┬».]]></cz>
-        <br><![CDATA[Adiciona sistema de renda hor├â┬íria / di├â┬íria com n├â┬¡veis de dificuldade, modificadores sazonais e suporte multiplayer.]]></br>
-        <uk><![CDATA[├ÉÔÇØ├É┬¥├É┬┤├É┬░├æÔÇØ ├æ┬ü├É┬©├æ┬ü├æÔÇÜ├É┬Á├É┬╝├æãÆ ├É┬┐├É┬¥├É┬│├É┬¥├É┬┤├É┬©├É┬¢├É┬¢├É┬¥├É┬│├É┬¥ / ├æÔÇ░├É┬¥├É┬┤├É┬Á├É┬¢├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ ├É┬À ├æÔé¼├æÔÇô├É┬▓├É┬¢├æ┬Å├É┬╝├É┬© ├æ┬ü├É┬║├É┬╗├É┬░├É┬┤├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æÔÇô, ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬©├É┬╝├É┬© ├É┬╝├É┬¥├É┬┤├É┬©├æÔÇ×├æÔÇô├É┬║├É┬░├æÔÇÜ├É┬¥├æÔé¼├É┬░├É┬╝├É┬© ├æÔÇÜ├É┬░ ├É┬┐├æÔÇô├É┬┤├æÔÇÜ├æÔé¼├É┬©├É┬╝├É┬║├É┬¥├æ┼¢ ├É┬╝├æãÆ├É┬╗├æ┼Æ├æÔÇÜ├É┬©├É┬┐├É┬╗├É┬Á├æÔÇØ├æÔé¼├É┬░.]]></uk>
-        <ru><![CDATA[├ÉÔÇØ├É┬¥├É┬▒├É┬░├É┬▓├É┬╗├æ┬Å├É┬Á├æÔÇÜ ├æ┬ü├É┬©├æ┬ü├æÔÇÜ├É┬Á├É┬╝├æãÆ ├É┬┐├É┬¥├æÔÇí├É┬░├æ┬ü├É┬¥├É┬▓├É┬¥├É┬│├É┬¥ / ├É┬Á├É┬Â├É┬Á├É┬┤├É┬¢├É┬Á├É┬▓├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░ ├æ┬ü ├æãÆ├æÔé¼├É┬¥├É┬▓├É┬¢├æ┬Å├É┬╝├É┬© ├æ┬ü├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├É┬©, ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├æÔÇ╣├É┬╝├É┬© ├É┬╝├É┬¥├É┬┤├É┬©├æÔÇ×├É┬©├É┬║├É┬░├æÔÇÜ├É┬¥├æÔé¼├É┬░├É┬╝├É┬© ├É┬© ├É┬┐├É┬¥├É┬┤├É┬┤├É┬Á├æÔé¼├É┬Â├É┬║├É┬¥├É┬╣ ├É┬╝├æãÆ├É┬╗├æ┼Æ├æÔÇÜ├É┬©├É┬┐├É┬╗├É┬Á├É┬Á├æÔé¼├É┬░.]]></ru>
-        <da><![CDATA[Tilf├â┬©jer et timeligt / dagligt inkomstsystem med sv├â┬ªrhedsniveauer, s├â┬ªsonelle modificer og multiplayer support.]]></da>
+        <de><![CDATA[Fâ”œÃ¢â”¬â•gt ein stâ”œÃ¢â”¬â•ndliches / tâ”œÃ¢â”¬Ã±gliches Einkommenssystem mit Schwierigkeitsstufen, saisonalen Modifikatoren und Mehrspielersupport hinzu.]]></de>
+        <fr><![CDATA[Ajoute un systâ”œÃ¢â”¬Â¿me de revenus horaires / quotidiens avec niveaux de difficultâ”œÃ¢â”¬Â®, modificateurs saisonniers et support multijoueur.]]></fr>
+        <pl><![CDATA[Dodaje system dochodâ”œÃ¢â”¬â”‚w godzinowych / dziennych z poziomami trudnoâ”œÃ Ã”Ã‡â•‘ci, modyfikatorami sezonowymi i wsparciem wieloosobowym.]]></pl>
+        <es><![CDATA[Aâ”œÃ¢â”¬â–’ade sistema de ingresos horarios / diarios con niveles de dificultad, modificadores estacionales y soporte multijugador.]]></es>
+        <it><![CDATA[Aggiunge un sistema di reddito orario / giornaliero con livelli di difficoltâ”œÃ¢â”¬Ã¡, modificatori stagionali e supporto multigiocatore.]]></it>
+        <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³idâ”œÃ¢â”¬Ã­vâ”œÃ¢â”¬Ã­ hodinovâ”œÃ¢â”¬Â¢ / dennâ”œÃ¢â”¬Â¡ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ systâ”œÃ¢â”¬Â®m s obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nostâ”œÃ¢â”¬Â¡, sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡mi modifikâ”œÃ¢â”¬Ã­tory a podporou vâ”œÃ¢â”¬Â¡ce hrâ”œÃ¢â”¬Ã­â”œÃ¤â”¬Ã¬â”œÃ â”¬Â».]]></cz>
+        <br><![CDATA[Adiciona sistema de renda horâ”œÃ¢â”¬Ã­ria / diâ”œÃ¢â”¬Ã­ria com nâ”œÃ¢â”¬Â¡veis de dificuldade, modificadores sazonais e suporte multiplayer.]]></br>
+        <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã˜â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ / â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã† â”œÃ‰â”¬Ã€ â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã´, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã—â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘.]]></uk>
+        <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã˜â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ / â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼ â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ‰â”¬Â© â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£ â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘.]]></ru>
+        <da><![CDATA[Tilfâ”œÃ¢â”¬Â©jer et timeligt / dagligt inkomstsystem med svâ”œÃ¢â”¬Âªrhedsniveauer, sâ”œÃ¢â”¬Âªsonelle modificer og multiplayer support.]]></da>
     </description>
     <iconFilename>icon.dds</iconFilename>
 
@@ -46,10 +46,10 @@
             <pl><![CDATA[Mod Dochodu]]></pl>
             <es><![CDATA[Mod de Ingresos]]></es>
             <it><![CDATA[Mod Reddito]]></it>
-            <cz><![CDATA[P├àÔäó├â┬¡jmov├â┬¢ Mod]]></cz>
+            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ Mod]]></cz>
             <br><![CDATA[Mod de Renda]]></br>
-            <uk><![CDATA[├É┼ô├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
-            <ru><![CDATA[├É┼ô├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
             <da><![CDATA[inkomst Mod]]></da>
         </text>
 
@@ -58,27 +58,27 @@
             <en><![CDATA[Enable Mod]]></en>
             <de><![CDATA[Mod aktivieren]]></de>
             <fr><![CDATA[Activer le mod]]></fr>
-            <pl><![CDATA[W├àÔÇÜ├äÔÇªcz mod]]></pl>
+            <pl><![CDATA[Wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz mod]]></pl>
             <es><![CDATA[Activar mod]]></es>
             <it><![CDATA[Attiva mod]]></it>
             <cz><![CDATA[Povolit mod]]></cz>
             <br><![CDATA[Ativar mod]]></br>
-            <uk><![CDATA[├É┬ú├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© ├É┬╝├É┬¥├É┬┤]]></uk>
-            <ru><![CDATA[├ÉÔÇÖ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ ├É┬╝├É┬¥├É┬┤]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤]]></ru>
             <da><![CDATA[Aktiver mod]]></da>
         </text>
 
         <text name="im_enabled_long">
             <en><![CDATA[Enable or disable the income mod]]></en>
             <de><![CDATA[Einkommens-Mod aktivieren oder deaktivieren]]></de>
-            <fr><![CDATA[Activer ou d├â┬®sactiver le module de revenu]]></fr>
-            <pl><![CDATA[W├àÔÇÜ├äÔÇªcz lub wy├àÔÇÜ├äÔÇªcz mod dochod├â┬│w]]></pl>
-            <es><![CDATA[Activar o desactivar el m├â┬│dulo de ingresos]]></es>
+            <fr><![CDATA[Activer ou dâ”œÃ¢â”¬Â®sactiver le module de revenu]]></fr>
+            <pl><![CDATA[Wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz lub wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz mod dochodâ”œÃ¢â”¬â”‚w]]></pl>
+            <es><![CDATA[Activar o desactivar el mâ”œÃ¢â”¬â”‚dulo de ingresos]]></es>
             <it><![CDATA[Attiva o disattiva il modulo di reddito]]></it>
-            <cz><![CDATA[Povolit nebo zak├â┬ízat p├àÔäó├â┬¡jmov├â┬¢ mod]]></cz>
+            <cz><![CDATA[Povolit nebo zakâ”œÃ¢â”¬Ã­zat pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ mod]]></cz>
             <br><![CDATA[Ativar ou desativar o mod de renda]]></br>
-            <uk><![CDATA[├É┬ú├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© ├É┬░├É┬▒├É┬¥ ├É┬▓├É┬©├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© ├É┬╝├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
-            <ru><![CDATA[├ÉÔÇÖ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ ├É┬©├É┬╗├É┬© ├É┬▓├æÔÇ╣├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ ├É┬╝├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
             <da><![CDATA[Aktiver eller deaktiver inkomst mod]]></da>
         </text>
 
@@ -89,25 +89,25 @@
             <fr><![CDATA[Mode DEBUG]]></fr>
             <pl><![CDATA[Tryb DEBUG]]></pl>
             <es><![CDATA[Modo DEBUG]]></es>
-            <it><![CDATA[Modalit├â┬á DEBUG]]></it>
-            <cz><![CDATA[DEBUG re├à┬¥im]]></cz>
+            <it><![CDATA[Modalitâ”œÃ¢â”¬Ã¡ DEBUG]]></it>
+            <cz><![CDATA[DEBUG reâ”œÃ â”¬Â¥im]]></cz>
             <br><![CDATA[Modo DEBUG]]></br>
-            <uk><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝ DEBUG]]></uk>
-            <ru><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝ DEBUG]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• DEBUG]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• DEBUG]]></ru>
             <da><![CDATA[DEBUG Mode]]></da>
         </text>
 
         <text name="im_debug_long">
             <en><![CDATA[Enable / disable debug mode (extra logging)]]></en>
-            <de><![CDATA[DEBUG-Modus ein- / ausschalten (zus├â┬ñtzliche Protokollierung)]]></de>
-            <fr><![CDATA[Activer / d├â┬®sactiver le mode DEBUG (journalisation suppl├â┬®mentaire)]]></fr>
-            <pl><![CDATA[W├àÔÇÜ├äÔÇªcz / wy├àÔÇÜ├äÔÇªcz tryb DEBUG (dodatkowe logowanie)]]></pl>
+            <de><![CDATA[DEBUG-Modus ein- / ausschalten (zusâ”œÃ¢â”¬Ã±tzliche Protokollierung)]]></de>
+            <fr><![CDATA[Activer / dâ”œÃ¢â”¬Â®sactiver le mode DEBUG (journalisation supplâ”œÃ¢â”¬Â®mentaire)]]></fr>
+            <pl><![CDATA[Wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz / wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz tryb DEBUG (dodatkowe logowanie)]]></pl>
             <es><![CDATA[Activar / desactivar modo DEBUG (registro adicional)]]></es>
-            <it><![CDATA[Attiva / disattiva modalit├â┬á DEBUG (registrazione aggiuntiva)]]></it>
-            <cz><![CDATA[Povolit / zak├â┬ízat DEBUG re├à┬¥im (dodate├ä┬ìn├â┬® logov├â┬ín├â┬¡)]]></cz>
+            <it><![CDATA[Attiva / disattiva modalitâ”œÃ¢â”¬Ã¡ DEBUG (registrazione aggiuntiva)]]></it>
+            <cz><![CDATA[Povolit / zakâ”œÃ¢â”¬Ã­zat DEBUG reâ”œÃ â”¬Â¥im (dodateâ”œÃ¤â”¬Ã¬nâ”œÃ¢â”¬Â® logovâ”œÃ¢â”¬Ã­nâ”œÃ¢â”¬Â¡)]]></cz>
             <br><![CDATA[Ativar / desativar modo DEBUG (registro adicional)]]></br>
-            <uk><![CDATA[├É┬ú├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© / ├É┬▓├É┬©├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© ├æÔé¼├É┬Á├É┬Â├É┬©├É┬╝ DEBUG (├É┬┤├É┬¥├É┬┤├É┬░├æÔÇÜ├É┬║├É┬¥├É┬▓├É┬Á ├É┬╗├É┬¥├É┬│├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å)]]></uk>
-            <ru><![CDATA[├ÉÔÇÖ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ / ├É┬▓├æÔÇ╣├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ ├æÔé¼├É┬Á├É┬Â├É┬©├É┬╝ DEBUG (├É┬┤├É┬¥├É┬┐├É┬¥├É┬╗├É┬¢├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┼Æ├É┬¢├É┬¥├É┬Á ├É┬╗├É┬¥├É┬│├É┬©├æÔé¼├É┬¥├É┬▓├É┬░├É┬¢├É┬©├É┬Á)]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© / â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• DEBUG (â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Ã â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…)]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† / â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• DEBUG (â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã)]]></ru>
             <da><![CDATA[Aktiver / deaktiver debug mode (ekstra logning)]]></da>
         </text>
 
@@ -116,55 +116,55 @@
             <en><![CDATA[Pay Mode]]></en>
             <de><![CDATA[Zahlungsmodus]]></de>
             <fr><![CDATA[Mode de paiement]]></fr>
-            <pl><![CDATA[Tryb p├àÔÇÜatno├àÔÇ║ci]]></pl>
+            <pl><![CDATA[Tryb pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci]]></pl>
             <es><![CDATA[Modo de pago]]></es>
-            <it><![CDATA[Modalit├â┬á pagamento]]></it>
-            <cz><![CDATA[Platebn├â┬¡ re├à┬¥im]]></cz>
+            <it><![CDATA[Modalitâ”œÃ¢â”¬Ã¡ pagamento]]></it>
+            <cz><![CDATA[Platebnâ”œÃ¢â”¬Â¡ reâ”œÃ â”¬Â¥im]]></cz>
             <br><![CDATA[Modo de pagamento]]></br>
-            <uk><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ]]></uk>
-            <ru><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ]]></ru>
             <da><![CDATA[Betalingstype]]></da>
         </text>
 
         <text name="im_paymode_long">
             <en><![CDATA[Choose payment frequency: hourly or daily]]></en>
-            <de><![CDATA[W├â┬ñhlen Sie die Zahlungsh├â┬ñufigkeit: st├â┬╝ndlich oder t├â┬ñglich]]></de>
-            <fr><![CDATA[Choisissez la fr├â┬®quence de paiement : horaire ou quotidienne]]></fr>
-            <pl><![CDATA[Wybierz cz├äÔäóstotliwo├àÔÇ║├äÔÇí p├àÔÇÜatno├àÔÇ║ci: godzinowa lub dzienna]]></pl>
+            <de><![CDATA[Wâ”œÃ¢â”¬Ã±hlen Sie die Zahlungshâ”œÃ¢â”¬Ã±ufigkeit: stâ”œÃ¢â”¬â•ndlich oder tâ”œÃ¢â”¬Ã±glich]]></de>
+            <fr><![CDATA[Choisissez la frâ”œÃ¢â”¬Â®quence de paiement : horaire ou quotidienne]]></fr>
+            <pl><![CDATA[Wybierz czâ”œÃ¤Ã”Ã¤Ã³stotliwoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­ pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci: godzinowa lub dzienna]]></pl>
             <es><![CDATA[Elegir frecuencia de pago: horaria o diaria]]></es>
             <it><![CDATA[Scegli frequenza pagamento: oraria o giornaliera]]></it>
-            <cz><![CDATA[Vyberte frekvenci plateb: hodinovou nebo denn├â┬¡]]></cz>
-            <br><![CDATA[Escolher frequ├â┬¬ncia de pagamento: hor├â┬íria ou di├â┬íria]]></br>
-            <uk><![CDATA[├ÉÔÇÖ├É┬©├É┬▒├É┬Á├æÔé¼├æÔÇô├æÔÇÜ├æ┼Æ ├æÔÇí├É┬░├æ┬ü├æÔÇÜ├É┬¥├æÔÇÜ├æãÆ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ: ├É┬┐├É┬¥├É┬│├É┬¥├É┬┤├É┬©├É┬¢├É┬¢├É┬¥ ├É┬░├É┬▒├É┬¥ ├æÔÇ░├É┬¥├É┬┤├É┬Á├É┬¢├É┬¢├É┬¥]]></uk>
-            <ru><![CDATA[├ÉÔÇÖ├æÔÇ╣├É┬▒├æÔé¼├É┬░├æÔÇÜ├æ┼Æ ├æÔÇí├É┬░├æ┬ü├æÔÇÜ├É┬¥├æÔÇÜ├æãÆ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ: ├É┬┐├É┬¥├æÔÇí├É┬░├æ┬ü├É┬¥├É┬▓├æãÆ├æ┼¢ ├É┬©├É┬╗├É┬© ├É┬Á├É┬Â├É┬Á├É┬┤├É┬¢├É┬Á├É┬▓├É┬¢├æãÆ├æ┼¢]]></ru>
-            <da><![CDATA[V├â┬ªlg betalingsfrekvens: time for time eller dagligt]]></da>
+            <cz><![CDATA[Vyberte frekvenci plateb: hodinovou nebo dennâ”œÃ¢â”¬Â¡]]></cz>
+            <br><![CDATA[Escolher frequâ”œÃ¢â”¬Â¬ncia de pagamento: horâ”œÃ¢â”¬Ã­ria ou diâ”œÃ¢â”¬Ã­ria]]></br>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Â©â”œÃ‰â”¬â–’â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ: â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ: â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢]]></ru>
+            <da><![CDATA[Vâ”œÃ¢â”¬Âªlg betalingsfrekvens: time for time eller dagligt]]></da>
         </text>
 
         <text name="im_paymode_1">
             <en><![CDATA[Hourly]]></en>
-            <de><![CDATA[St├â┬╝ndlich]]></de>
+            <de><![CDATA[Stâ”œÃ¢â”¬â•ndlich]]></de>
             <fr><![CDATA[Horaire]]></fr>
             <pl><![CDATA[Godzinowa]]></pl>
             <es><![CDATA[Horaria]]></es>
             <it><![CDATA[Oraria]]></it>
-            <cz><![CDATA[Hodinov├â┬í]]></cz>
-            <br><![CDATA[Hor├â┬íria]]></br>
-            <uk><![CDATA[├É┼©├É┬¥├É┬│├É┬¥├É┬┤├É┬©├É┬¢├É┬¢├É┬¥]]></uk>
-            <ru><![CDATA[├É┼©├É┬¥├æÔÇí├É┬░├æ┬ü├É┬¥├É┬▓├É┬¥]]></ru>
+            <cz><![CDATA[Hodinovâ”œÃ¢â”¬Ã­]]></cz>
+            <br><![CDATA[Horâ”œÃ¢â”¬Ã­ria]]></br>
+            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥]]></ru>
             <da><![CDATA[Time for time]]></da>
         </text>
 
         <text name="im_paymode_2">
             <en><![CDATA[Daily]]></en>
-            <de><![CDATA[T├â┬ñglich]]></de>
+            <de><![CDATA[Tâ”œÃ¢â”¬Ã±glich]]></de>
             <fr><![CDATA[Quotidienne]]></fr>
             <pl><![CDATA[Dzienna]]></pl>
             <es><![CDATA[Diaria]]></es>
             <it><![CDATA[Giornaliera]]></it>
-            <cz><![CDATA[Denn├â┬¡]]></cz>
-            <br><![CDATA[Di├â┬íria]]></br>
-            <uk><![CDATA[├É┬®├É┬¥├É┬┤├É┬Á├É┬¢├É┬¢├É┬¥]]></uk>
-            <ru><![CDATA[├ÉÔÇó├É┬Â├É┬Á├É┬┤├É┬¢├É┬Á├É┬▓├É┬¢├É┬¥]]></ru>
+            <cz><![CDATA[Dennâ”œÃ¢â”¬Â¡]]></cz>
+            <br><![CDATA[Diâ”œÃ¢â”¬Ã­ria]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Â®â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã³â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></ru>
             <da><![CDATA[Dagligt]]></da>
         </text>
 
@@ -172,42 +172,42 @@
         <text name="im_difficulty_short">
             <en><![CDATA[Difficulty]]></en>
             <de><![CDATA[Schwierigkeit]]></de>
-            <fr><![CDATA[Difficult├â┬®]]></fr>
-            <pl><![CDATA[Trudno├àÔÇ║├äÔÇí]]></pl>
+            <fr><![CDATA[Difficultâ”œÃ¢â”¬Â®]]></fr>
+            <pl><![CDATA[Trudnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­]]></pl>
             <es><![CDATA[Dificultad]]></es>
-            <it><![CDATA[Difficolt├â┬á]]></it>
-            <cz><![CDATA[Obt├â┬¡├à┬¥nost]]></cz>
+            <it><![CDATA[Difficoltâ”œÃ¢â”¬Ã¡]]></it>
+            <cz><![CDATA[Obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nost]]></cz>
             <br><![CDATA[Dificuldade]]></br>
-            <uk><![CDATA[├É┬í├É┬║├É┬╗├É┬░├É┬┤├É┬¢├æÔÇô├æ┬ü├æÔÇÜ├æ┼Æ]]></uk>
-            <ru><![CDATA[├É┬í├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æ┼Æ]]></ru>
-            <da><![CDATA[Sv├â┬ªrhedsgrad]]></da>
+            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†]]></ru>
+            <da><![CDATA[Svâ”œÃ¢â”¬Âªrhedsgrad]]></da>
         </text>
 
         <text name="im_difficulty_long">
             <en><![CDATA[Set income amount: Easy=$5000, Normal=$2400, Hard=$1100]]></en>
             <de><![CDATA[Einkommensbetrag festlegen: Einfach=5000$, Normal=2400$, Schwer=1100$]]></de>
-            <fr><![CDATA[D├â┬®finir le montant du revenu : Facile=5000$, Normal=2400$, Difficile=1100$]]></fr>
-            <pl><![CDATA[Ustaw kwot├äÔäó dochodu: ├à┬üatwy=5000$, Normalny=2400$, Trudny=1100$]]></pl>
-            <es><![CDATA[Establecer monto de ingreso: F├â┬ícil=5000$, Normal=2400$, Dif├â┬¡cil=1100$]]></es>
+            <fr><![CDATA[Dâ”œÃ¢â”¬Â®finir le montant du revenu : Facile=5000$, Normal=2400$, Difficile=1100$]]></fr>
+            <pl><![CDATA[Ustaw kwotâ”œÃ¤Ã”Ã¤Ã³ dochodu: â”œÃ â”¬Ã¼atwy=5000$, Normalny=2400$, Trudny=1100$]]></pl>
+            <es><![CDATA[Establecer monto de ingreso: Fâ”œÃ¢â”¬Ã­cil=5000$, Normal=2400$, Difâ”œÃ¢â”¬Â¡cil=1100$]]></es>
             <it><![CDATA[Imposta importo reddito: Facile=5000$, Normale=2400$, Difficile=1100$]]></it>
-            <cz><![CDATA[Nastavit v├â┬¢├à┬íi p├àÔäó├â┬¡jmu: Snadn├â┬®=5000$, Norm├â┬íln├â┬¡=2400$, T├äÔÇ║├à┬¥k├â┬®=1100$]]></cz>
-            <br><![CDATA[Definir valor da renda: F├â┬ícil=5000$, Normal=2400$, Dif├â┬¡cil=1100$]]></br>
-            <uk><![CDATA[├ÉÔÇÖ├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¥├É┬▓├É┬©├æÔÇÜ├É┬© ├æ┬ü├æãÆ├É┬╝├æãÆ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ: ├ÉÔÇ║├É┬Á├É┬│├É┬║├É┬¥=5000$, ├É┬Ø├É┬¥├æÔé¼├É┬╝├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥=2400$, ├ÉÔÇÖ├É┬░├É┬Â├É┬║├É┬¥=1100$]]></uk>
-            <ru><![CDATA[├É┬ú├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¥├É┬▓├É┬©├æÔÇÜ├æ┼Æ ├æ┬ü├æãÆ├É┬╝├É┬╝├æãÆ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░: ├ÉÔÇ║├É┬Á├É┬│├É┬║├É┬¥=5000$, ├É┼¥├É┬▒├æÔÇ╣├æÔÇí├É┬¢├É┬¥=2400$, ├É┬í├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥=1100$]]></ru>
-            <da><![CDATA[Indstil inkomstbel├â┬©b: Let=$5000, Normal=$2400, Sv├â┬ªr=$1100]]></da>
+            <cz><![CDATA[Nastavit vâ”œÃ¢â”¬Â¢â”œÃ â”¬Ã­i pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmu: Snadnâ”œÃ¢â”¬Â®=5000$, Normâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡=2400$, Tâ”œÃ¤Ã”Ã‡â•‘â”œÃ â”¬Â¥kâ”œÃ¢â”¬Â®=1100$]]></cz>
+            <br><![CDATA[Definir valor da renda: Fâ”œÃ¢â”¬Ã­cil=5000$, Normal=2400$, Difâ”œÃ¢â”¬Â¡cil=1100$]]></br>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†: â”œÃ‰Ã”Ã‡â•‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥=5000$, â”œÃ‰â”¬Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥=2400$, â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥=1100$]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘: â”œÃ‰Ã”Ã‡â•‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥=5000$, â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥=2400$, â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥=1100$]]></ru>
+            <da><![CDATA[Indstil inkomstbelâ”œÃ¢â”¬Â©b: Let=$5000, Normal=$2400, Svâ”œÃ¢â”¬Âªr=$1100]]></da>
         </text>
 
         <text name="im_diff_1">
             <en><![CDATA[Easy ($5000)]]></en>
             <de><![CDATA[Einfach (5000$)]]></de>
             <fr><![CDATA[Facile (5000$)]]></fr>
-            <pl><![CDATA[├à┬üatwy (5000$)]]></pl>
-            <es><![CDATA[F├â┬ícil (5000$)]]></es>
+            <pl><![CDATA[â”œÃ â”¬Ã¼atwy (5000$)]]></pl>
+            <es><![CDATA[Fâ”œÃ¢â”¬Ã­cil (5000$)]]></es>
             <it><![CDATA[Facile (5000$)]]></it>
-            <cz><![CDATA[Snadn├â┬® (5000$)]]></cz>
-            <br><![CDATA[F├â┬ícil (5000$)]]></br>
-            <uk><![CDATA[├ÉÔÇ║├É┬Á├É┬│├É┬║├É┬¥ (5000$)]]></uk>
-            <ru><![CDATA[├ÉÔÇ║├É┬Á├É┬│├É┬║├É┬¥ (5000$)]]></ru>
+            <cz><![CDATA[Snadnâ”œÃ¢â”¬Â® (5000$)]]></cz>
+            <br><![CDATA[Fâ”œÃ¢â”¬Ã­cil (5000$)]]></br>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡â•‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥ (5000$)]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡â•‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥ (5000$)]]></ru>
             <da><![CDATA[Let ($5000)]]></da>
         </text>
 
@@ -218,10 +218,10 @@
             <pl><![CDATA[Normalny (2400$)]]></pl>
             <es><![CDATA[Normal (2400$)]]></es>
             <it><![CDATA[Normale (2400$)]]></it>
-            <cz><![CDATA[Norm├â┬íln├â┬¡ (2400$)]]></cz>
+            <cz><![CDATA[Normâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡ (2400$)]]></cz>
             <br><![CDATA[Normal (2400$)]]></br>
-            <uk><![CDATA[├É┬Ø├É┬¥├æÔé¼├É┬╝├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥ (2400$)]]></uk>
-            <ru><![CDATA[├É┼¥├É┬▒├æÔÇ╣├æÔÇí├É┬¢├É┬¥ (2400$)]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ (2400$)]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ (2400$)]]></ru>
             <da><![CDATA[Normal ($2400)]]></da>
         </text>
 
@@ -230,13 +230,13 @@
             <de><![CDATA[Schwer (1100$)]]></de>
             <fr><![CDATA[Difficile (1100$)]]></fr>
             <pl><![CDATA[Trudny (1100$)]]></pl>
-            <es><![CDATA[Dif├â┬¡cil (1100$)]]></es>
+            <es><![CDATA[Difâ”œÃ¢â”¬Â¡cil (1100$)]]></es>
             <it><![CDATA[Difficile (1100$)]]></it>
-            <cz><![CDATA[T├äÔÇ║├à┬¥k├â┬® (1100$)]]></cz>
-            <br><![CDATA[Dif├â┬¡cil (1100$)]]></br>
-            <uk><![CDATA[├ÉÔÇÖ├É┬░├É┬Â├É┬║├É┬¥ (1100$)]]></uk>
-            <ru><![CDATA[├É┬í├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥ (1100$)]]></ru>
-            <da><![CDATA[Sv├â┬ªr ($1100)]]></da>
+            <cz><![CDATA[Tâ”œÃ¤Ã”Ã‡â•‘â”œÃ â”¬Â¥kâ”œÃ¢â”¬Â® (1100$)]]></cz>
+            <br><![CDATA[Difâ”œÃ¢â”¬Â¡cil (1100$)]]></br>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥ (1100$)]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ (1100$)]]></ru>
+            <da><![CDATA[Svâ”œÃ¢â”¬Âªr ($1100)]]></da>
         </text>
 
         <!-- Notifications -->
@@ -247,24 +247,24 @@
             <pl><![CDATA[Powiadomienia]]></pl>
             <es><![CDATA[Notificaciones]]></es>
             <it><![CDATA[Notifiche]]></it>
-            <cz><![CDATA[Upozorn├äÔÇ║n├â┬¡]]></cz>
-            <br><![CDATA[Notifica├â┬º├â┬Áes]]></br>
-            <uk><![CDATA[├É┬í├É┬┐├É┬¥├É┬▓├æÔÇô├æÔÇ░├É┬Á├É┬¢├É┬¢├æ┬Å]]></uk>
-            <ru><![CDATA[├É┬ú├É┬▓├É┬Á├É┬┤├É┬¥├É┬╝├É┬╗├É┬Á├É┬¢├É┬©├æ┬Å]]></ru>
+            <cz><![CDATA[Upozornâ”œÃ¤Ã”Ã‡â•‘nâ”œÃ¢â”¬Â¡]]></cz>
+            <br><![CDATA[Notificaâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã…]]></ru>
             <da><![CDATA[Notifikationer]]></da>
         </text>
 
         <text name="im_notifications_long">
             <en><![CDATA[Enable/disable payment notifications]]></en>
             <de><![CDATA[Zahlungsbenachrichtigungen ein-/ausschalten]]></de>
-            <fr><![CDATA[Activer/d├â┬®sactiver les notifications de paiement]]></fr>
-            <pl><![CDATA[W├àÔÇÜ├äÔÇªcz/wy├àÔÇÜ├äÔÇªcz powiadomienia o p├àÔÇÜatno├àÔÇ║ciach]]></pl>
+            <fr><![CDATA[Activer/dâ”œÃ¢â”¬Â®sactiver les notifications de paiement]]></fr>
+            <pl><![CDATA[Wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz/wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz powiadomienia o pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ciach]]></pl>
             <es><![CDATA[Activar/desactivar notificaciones de pago]]></es>
             <it><![CDATA[Attiva/disattiva notifiche pagamento]]></it>
-            <cz><![CDATA[Povolit/zak├â┬ízat upozorn├äÔÇ║n├â┬¡ na platby]]></cz>
-            <br><![CDATA[Ativar/desativar notifica├â┬º├â┬Áes de pagamento]]></br>
-            <uk><![CDATA[├É┬ú├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬©/├É┬▓├É┬©├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© ├æ┬ü├É┬┐├É┬¥├É┬▓├æÔÇô├æÔÇ░├É┬Á├É┬¢├É┬¢├æ┬Å ├É┬┐├æÔé¼├É┬¥ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬©]]></uk>
-            <ru><![CDATA[├ÉÔÇÖ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ/├É┬▓├æÔÇ╣├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ ├æãÆ├É┬▓├É┬Á├É┬┤├É┬¥├É┬╝├É┬╗├É┬Á├É┬¢├É┬©├æ┬Å ├É┬¥ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░├æÔÇª]]></ru>
+            <cz><![CDATA[Povolit/zakâ”œÃ¢â”¬Ã­zat upozornâ”œÃ¤Ã”Ã‡â•‘nâ”œÃ¢â”¬Â¡ na platby]]></cz>
+            <br><![CDATA[Ativar/desativar notificaâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães de pagamento]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©/â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†/â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª]]></ru>
             <da><![CDATA[Aktiver/deaktiver betalingsnotifikationer]]></da>
         </text>
 
@@ -272,29 +272,29 @@
         <text name="im_customamount_short">
             <en><![CDATA[Custom Amount]]></en>
             <de><![CDATA[Benutzerdefinierter Betrag]]></de>
-            <fr><![CDATA[Montant personnalis├â┬®]]></fr>
+            <fr><![CDATA[Montant personnalisâ”œÃ¢â”¬Â®]]></fr>
             <pl><![CDATA[Niestandardowa kwota]]></pl>
             <es><![CDATA[Cantidad personalizada]]></es>
             <it><![CDATA[Importo personalizzato]]></it>
-            <cz><![CDATA[Vlastn├â┬¡ ├ä┬ì├â┬ístka]]></cz>
+            <cz><![CDATA[Vlastnâ”œÃ¢â”¬Â¡ â”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­stka]]></cz>
             <br><![CDATA[Valor personalizado]]></br>
-            <uk><![CDATA[├ÉÔÇÖ├É┬╗├É┬░├æ┬ü├É┬¢├É┬░ ├æ┬ü├æãÆ├É┬╝├É┬░]]></uk>
-            <ru><![CDATA[├É┼©├É┬¥├É┬╗├æ┼Æ├É┬À├É┬¥├É┬▓├É┬░├æÔÇÜ├É┬Á├É┬╗├æ┼Æ├æ┬ü├É┬║├É┬░├æ┬Å ├æ┬ü├æãÆ├É┬╝├É┬╝├É┬░]]></ru>
-            <da><![CDATA[Brugerdefineret bel├â┬©b]]></da>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘]]></ru>
+            <da><![CDATA[Brugerdefineret belâ”œÃ¢â”¬Â©b]]></da>
         </text>
 
         <text name="im_customamount_long">
             <en><![CDATA[Set custom payment amount (0 = use difficulty setting)]]></en>
             <de><![CDATA[Benutzerdefinierten Zahlungsbetrag festlegen (0 = Schwierigkeitsstufe verwenden)]]></de>
-            <fr><![CDATA[D├â┬®finir le montant de paiement personnalis├â┬® (0 = utiliser le r├â┬®glage de difficult├â┬®)]]></fr>
-            <pl><![CDATA[Ustaw niestandardow├äÔÇª kwot├äÔäó p├àÔÇÜatno├àÔÇ║ci (0 = u├à┬╝yj ustawienia trudno├àÔÇ║ci)]]></pl>
-            <es><![CDATA[Establecer monto de pago personalizado (0 = usar configuraci├â┬│n de dificultad)]]></es>
-            <it><![CDATA[Imposta importo pagamento personalizzato (0 = usa impostazione difficolt├â┬á)]]></it>
-            <cz><![CDATA[Nastavit vlastn├â┬¡ ├ä┬ì├â┬ístku platby (0 = pou├à┬¥├â┬¡t nastaven├â┬¡ obt├â┬¡├à┬¥nosti)]]></cz>
-            <br><![CDATA[Definir valor de pagamento personalizado (0 = usar configura├â┬º├â┬úo de dificuldade)]]></br>
-            <uk><![CDATA[├ÉÔÇÖ├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¥├É┬▓├É┬©├æÔÇÜ├É┬© ├É┬▓├É┬╗├É┬░├æ┬ü├É┬¢├æãÆ ├æ┬ü├æãÆ├É┬╝├æãÆ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬© (0 = ├É┬▓├É┬©├É┬║├É┬¥├æÔé¼├É┬©├æ┬ü├æÔÇÜ├É┬¥├É┬▓├æãÆ├É┬▓├É┬░├æÔÇÜ├É┬© ├É┬¢├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å ├æ┬ü├É┬║├É┬╗├É┬░├É┬┤├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æÔÇô)]]></uk>
-            <ru><![CDATA[├É┬ú├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¥├É┬▓├É┬©├æÔÇÜ├æ┼Æ ├É┬┐├É┬¥├É┬╗├æ┼Æ├É┬À├É┬¥├É┬▓├É┬░├æÔÇÜ├É┬Á├É┬╗├æ┼Æ├æ┬ü├É┬║├æãÆ├æ┼¢ ├æ┬ü├æãÆ├É┬╝├É┬╝├æãÆ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣ (0 = ├É┬©├æ┬ü├É┬┐├É┬¥├É┬╗├æ┼Æ├É┬À├É┬¥├É┬▓├É┬░├æÔÇÜ├æ┼Æ ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├æãÆ ├æ┬ü├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├É┬©)]]></ru>
-            <da><![CDATA[Indstil brugerdefineret betalingsbel├â┬©b (0 = brug sv├â┬ªrhedsgrad)]]></da>
+            <fr><![CDATA[Dâ”œÃ¢â”¬Â®finir le montant de paiement personnalisâ”œÃ¢â”¬Â® (0 = utiliser le râ”œÃ¢â”¬Â®glage de difficultâ”œÃ¢â”¬Â®)]]></fr>
+            <pl><![CDATA[Ustaw niestandardowâ”œÃ¤Ã”Ã‡Âª kwotâ”œÃ¤Ã”Ã¤Ã³ pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci (0 = uâ”œÃ â”¬â•yj ustawienia trudnoâ”œÃ Ã”Ã‡â•‘ci)]]></pl>
+            <es><![CDATA[Establecer monto de pago personalizado (0 = usar configuraciâ”œÃ¢â”¬â”‚n de dificultad)]]></es>
+            <it><![CDATA[Imposta importo pagamento personalizzato (0 = usa impostazione difficoltâ”œÃ¢â”¬Ã¡)]]></it>
+            <cz><![CDATA[Nastavit vlastnâ”œÃ¢â”¬Â¡ â”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­stku platby (0 = pouâ”œÃ â”¬Â¥â”œÃ¢â”¬Â¡t nastavenâ”œÃ¢â”¬Â¡ obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nosti)]]></cz>
+            <br><![CDATA[Definir valor de pagamento personalizado (0 = usar configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ãºo de dificuldade)]]></br>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© (0 = â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã´)]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£ (0 = â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ¦Ã£Ã† â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©)]]></ru>
+            <da><![CDATA[Indstil brugerdefineret betalingsbelâ”œÃ¢â”¬Â©b (0 = brug svâ”œÃ¢â”¬Âªrhedsgrad)]]></da>
         </text>
 
         <!-- Income Multiplier (NEW in 2.0) -->
@@ -302,13 +302,13 @@
             <en><![CDATA[Income Multiplier]]></en>
             <de><![CDATA[Einkommensmultiplikator]]></de>
             <fr><![CDATA[Multiplicateur de revenu]]></fr>
-            <pl><![CDATA[Mno├à┬╝nik dochodu]]></pl>
+            <pl><![CDATA[Mnoâ”œÃ â”¬â•nik dochodu]]></pl>
             <es><![CDATA[Multiplicador de ingresos]]></es>
             <it><![CDATA[Moltiplicatore reddito]]></it>
-            <cz><![CDATA[P├àÔäó├â┬¡jmov├â┬¢ multiplik├â┬ítor]]></cz>
+            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ multiplikâ”œÃ¢â”¬Ã­tor]]></cz>
             <br><![CDATA[Multiplicador de renda]]></br>
-            <uk><![CDATA[├É┼ô├É┬¢├É┬¥├É┬Â├É┬¢├É┬©├É┬║ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
-            <ru><![CDATA[├É┼ô├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┼Æ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
             <da><![CDATA[Inkomstmultiplikator]]></da>
         </text>
 
@@ -316,14 +316,14 @@
             <en><![CDATA[Multiply the base payment: 1x, 2x, 5x, or 10x]]></en>
             <de><![CDATA[Basisbetrag multiplizieren: 1x, 2x, 5x oder 10x]]></de>
             <fr><![CDATA[Multiplier le paiement de base : 1x, 2x, 5x ou 10x]]></fr>
-            <pl><![CDATA[Pomn├â┬│├à┬╝ podstawow├äÔÇª p├àÔÇÜatno├àÔÇ║├äÔÇí: 1x, 2x, 5x lub 10x]]></pl>
+            <pl><![CDATA[Pomnâ”œÃ¢â”¬â”‚â”œÃ â”¬â• podstawowâ”œÃ¤Ã”Ã‡Âª pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­: 1x, 2x, 5x lub 10x]]></pl>
             <es><![CDATA[Multiplicar el pago base: 1x, 2x, 5x o 10x]]></es>
             <it><![CDATA[Moltiplica il pagamento base: 1x, 2x, 5x o 10x]]></it>
-            <cz><![CDATA[Zn├â┬ísobit z├â┬íkladn├â┬¡ platbu: 1x, 2x, 5x nebo 10x]]></cz>
+            <cz><![CDATA[Znâ”œÃ¢â”¬Ã­sobit zâ”œÃ¢â”¬Ã­kladnâ”œÃ¢â”¬Â¡ platbu: 1x, 2x, 5x nebo 10x]]></cz>
             <br><![CDATA[Multiplicar o pagamento base: 1x, 2x, 5x ou 10x]]></br>
-            <uk><![CDATA[├É┼©├É┬¥├É┬╝├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬© ├É┬▒├É┬░├É┬À├É┬¥├É┬▓├æãÆ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ: 1x, 2x, 5x ├É┬░├É┬▒├É┬¥ 10x]]></uk>
-            <ru><![CDATA[├É┬ú├É┬╝├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├æ┼Æ ├É┬▒├É┬░├É┬À├É┬¥├É┬▓├æãÆ├æ┼¢ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ: 1x, 2x, 5x ├É┬©├É┬╗├É┬© 10x]]></ru>
-            <da><![CDATA[Multiplik├â┬®r basishonoraret: 1x, 2x, 5x eller 10x]]></da>
+            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†: 1x, 2x, 5x â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ 10x]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â•â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†: 1x, 2x, 5x â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© 10x]]></ru>
+            <da><![CDATA[Multiplikâ”œÃ¢â”¬Â®r basishonoraret: 1x, 2x, 5x eller 10x]]></da>
         </text>
 
         <text name="im_mult_1">
@@ -333,10 +333,10 @@
             <pl><![CDATA[1x (Normalny)]]></pl>
             <es><![CDATA[1x (Normal)]]></es>
             <it><![CDATA[1x (Normale)]]></it>
-            <cz><![CDATA[1x (Norm├â┬íln├â┬¡)]]></cz>
+            <cz><![CDATA[1x (Normâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡)]]></cz>
             <br><![CDATA[1x (Normal)]]></br>
-            <uk><![CDATA[1x (├É┬Ø├É┬¥├æÔé¼├É┬╝├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥)]]></uk>
-            <ru><![CDATA[1x (├É┼¥├É┬▒├æÔÇ╣├æÔÇí├É┬¢├É┬¥)]]></ru>
+            <uk><![CDATA[1x (â”œÃ‰â”¬Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥)]]></uk>
+            <ru><![CDATA[1x (â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥)]]></ru>
             <da><![CDATA[1x (Normal)]]></da>
         </text>
 
@@ -390,25 +390,25 @@
             <pl><![CDATA[Efekty sezonowe]]></pl>
             <es><![CDATA[Efectos estacionales]]></es>
             <it><![CDATA[Effetti stagionali]]></it>
-            <cz><![CDATA[Sez├â┬│nn├â┬¡ efekty]]></cz>
+            <cz><![CDATA[Sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡ efekty]]></cz>
             <br><![CDATA[Efeitos sazonais]]></br>
-            <uk><![CDATA[├É┬í├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├æÔÇô ├É┬Á├æÔÇ×├É┬Á├É┬║├æÔÇÜ├É┬©]]></uk>
-            <ru><![CDATA[├É┬í├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├æÔÇ╣├É┬Á ├æ┬ì├æÔÇ×├æÔÇ×├É┬Á├É┬║├æÔÇÜ├æÔÇ╣]]></ru>
-            <da><![CDATA[s├â┬ªsonale effekter]]></da>
+            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬Ã â”œÃ¦â”¬Ã¬â”œÃ¦Ã”Ã‡Ã—â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£]]></ru>
+            <da><![CDATA[sâ”œÃ¢â”¬Âªsonale effekter]]></da>
         </text>
 
         <text name="im_seasonal_long">
             <en><![CDATA[Income varies by season: Spring 0.8x, Summer 1.0x, Autumn 1.2x, Winter 0.7x]]></en>
-            <de><![CDATA[Einkommen variiert je nach Jahreszeit: Fr├â┬╝hling 0,8x, Sommer 1,0x, Herbst 1,2x, Winter 0,7x]]></de>
-            <fr><![CDATA[Le revenu varie selon la saison : Printemps 0,8x, ├âÔÇ░t├â┬® 1,0x, Automne 1,2x, Hiver 0,7x]]></fr>
-            <pl><![CDATA[Doch├â┬│d zmienia si├äÔäó w zale├à┬╝no├àÔÇ║ci od sezonu: Wiosna 0,8x, Lato 1,0x, Jesie├àÔÇ× 1,2x, Zima 0,7x]]></pl>
-            <es><![CDATA[Los ingresos var├â┬¡an por temporada: Primavera 0,8x, Verano 1,0x, Oto├â┬▒o 1,2x, Invierno 0,7x]]></es>
+            <de><![CDATA[Einkommen variiert je nach Jahreszeit: Frâ”œÃ¢â”¬â•hling 0,8x, Sommer 1,0x, Herbst 1,2x, Winter 0,7x]]></de>
+            <fr><![CDATA[Le revenu varie selon la saison : Printemps 0,8x, â”œÃ¢Ã”Ã‡â–‘tâ”œÃ¢â”¬Â® 1,0x, Automne 1,2x, Hiver 0,7x]]></fr>
+            <pl><![CDATA[Dochâ”œÃ¢â”¬â”‚d zmienia siâ”œÃ¤Ã”Ã¤Ã³ w zaleâ”œÃ â”¬â•noâ”œÃ Ã”Ã‡â•‘ci od sezonu: Wiosna 0,8x, Lato 1,0x, Jesieâ”œÃ Ã”Ã‡Ã— 1,2x, Zima 0,7x]]></pl>
+            <es><![CDATA[Los ingresos varâ”œÃ¢â”¬Â¡an por temporada: Primavera 0,8x, Verano 1,0x, Otoâ”œÃ¢â”¬â–’o 1,2x, Invierno 0,7x]]></es>
             <it><![CDATA[Il reddito varia per stagione: Primavera 0,8x, Estate 1,0x, Autunno 1,2x, Inverno 0,7x]]></it>
-            <cz><![CDATA[P├àÔäó├â┬¡jem se m├äÔÇ║n├â┬¡ podle ro├ä┬ìn├â┬¡ho obdob├â┬¡: Jaro 0,8x, L├â┬®to 1,0x, Podzim 1,2x, Zima 0,7x]]></cz>
-            <br><![CDATA[A renda varia por esta├â┬º├â┬úo: Primavera 0,8x, Ver├â┬úo 1,0x, Outono 1,2x, Inverno 0,7x]]></br>
-            <uk><![CDATA[├ÉÔÇØ├É┬¥├æÔÇª├æÔÇô├É┬┤ ├É┬À├É┬╝├æÔÇô├É┬¢├æ┼¢├æÔÇØ├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├É┬À├É┬░ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¥├É┬╝: ├ÉÔÇÖ├É┬Á├æ┬ü├É┬¢├É┬░ 0,8x, ├ÉÔÇ║├æÔÇô├æÔÇÜ├É┬¥ 1,0x, ├É┼¥├æ┬ü├æÔÇô├É┬¢├æ┼Æ 1,2x, ├ÉÔÇö├É┬©├É┬╝├É┬░ 0,7x]]></uk>
-            <ru><![CDATA[├ÉÔÇØ├É┬¥├æÔÇª├É┬¥├É┬┤ ├É┬╝├É┬Á├É┬¢├æ┬Å├É┬Á├æÔÇÜ├æ┬ü├æ┬Å ├É┬┐├É┬¥ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬░├É┬╝: ├ÉÔÇÖ├É┬Á├æ┬ü├É┬¢├É┬░ 0,8x, ├ÉÔÇ║├É┬Á├æÔÇÜ├É┬¥ 1,0x, ├É┼¥├æ┬ü├É┬Á├É┬¢├æ┼Æ 1,2x, ├ÉÔÇö├É┬©├É┬╝├É┬░ 0,7x]]></ru>
-            <da><![CDATA[Inkomst varierer efter s├â┬ªson: For├â┬Ñr 0,8x, Sommer 1,0x, Efter├â┬Ñr 1,2x, Vinter 0,7x]]></da>
+            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem se mâ”œÃ¤Ã”Ã‡â•‘nâ”œÃ¢â”¬Â¡ podle roâ”œÃ¤â”¬Ã¬nâ”œÃ¢â”¬Â¡ho obdobâ”œÃ¢â”¬Â¡: Jaro 0,8x, Lâ”œÃ¢â”¬Â®to 1,0x, Podzim 1,2x, Zima 0,7x]]></cz>
+            <br><![CDATA[A renda varia por estaâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ãºo: Primavera 0,8x, Verâ”œÃ¢â”¬Ãºo 1,0x, Outono 1,2x, Inverno 0,7x]]></br>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â•â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¢â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•: â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ 0,8x, â”œÃ‰Ã”Ã‡â•‘â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥ 1,0x, â”œÃ‰â”¼Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã† 1,2x, â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ 0,7x]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•: â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ 0,8x, â”œÃ‰Ã”Ã‡â•‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥ 1,0x, â”œÃ‰â”¼Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã† 1,2x, â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ 0,7x]]></ru>
+            <da><![CDATA[Inkomst varierer efter sâ”œÃ¢â”¬Âªson: Forâ”œÃ¢â”¬Ã‘r 0,8x, Sommer 1,0x, Efterâ”œÃ¢â”¬Ã‘r 1,2x, Vinter 0,7x]]></da>
         </text>
 
         <!-- Show HUD -->
@@ -416,13 +416,13 @@
             <en><![CDATA[Show Income HUD]]></en>
             <de><![CDATA[Einkommens-HUD anzeigen]]></de>
             <fr><![CDATA[Afficher l'HUD de revenu]]></fr>
-            <pl><![CDATA[Poka├à┬╝ HUD dochodu]]></pl>
+            <pl><![CDATA[Pokaâ”œÃ â”¬â• HUD dochodu]]></pl>
             <es><![CDATA[Mostrar HUD de ingresos]]></es>
             <it><![CDATA[Mostra HUD reddito]]></it>
-            <cz><![CDATA[Zobrazit HUD p├àÔäó├â┬¡jm├à┬»]]></cz>
+            <cz><![CDATA[Zobrazit HUD pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â»]]></cz>
             <br><![CDATA[Mostrar HUD de renda]]></br>
-            <uk><![CDATA[├É┼©├É┬¥├É┬║├É┬░├É┬À├É┬░├æÔÇÜ├É┬© HUD ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
-            <ru><![CDATA[├É┼©├É┬¥├É┬║├É┬░├É┬À├É┬░├æÔÇÜ├æ┼Æ HUD ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© HUD â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† HUD â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
             <da><![CDATA[Vis inkomst-HUD]]></da>
         </text>
 
@@ -430,14 +430,14 @@
             <en><![CDATA[Show the income HUD overlay with current income, payment method, and history (toggle with I key)]]></en>
             <de><![CDATA[Einkommens-HUD mit Einkommen, Zahlungsart und Verlauf anzeigen (mit Taste I umschalten)]]></de>
             <fr><![CDATA[Afficher l'HUD avec les revenus actuels, le mode de paiement et l'historique (touche I)]]></fr>
-            <pl><![CDATA[Poka├à┬╝ nak├àÔÇÜadk├äÔäó HUD z bie├à┬╝├äÔÇªcym dochodem, trybem p├àÔÇÜatno├àÔÇ║ci i histori├äÔÇª (klawisz I)]]></pl>
-            <es><![CDATA[Mostrar HUD con ingresos actuales, m├â┬®todo de pago e historial (tecla I)]]></es>
+            <pl><![CDATA[Pokaâ”œÃ â”¬â• nakâ”œÃ Ã”Ã‡Ãœadkâ”œÃ¤Ã”Ã¤Ã³ HUD z bieâ”œÃ â”¬â•â”œÃ¤Ã”Ã‡Âªcym dochodem, trybem pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci i historiâ”œÃ¤Ã”Ã‡Âª (klawisz I)]]></pl>
+            <es><![CDATA[Mostrar HUD con ingresos actuales, mâ”œÃ¢â”¬Â®todo de pago e historial (tecla I)]]></es>
             <it><![CDATA[Mostra l'HUD con reddito corrente, metodo di pagamento e cronologia (tasto I)]]></it>
-            <cz><![CDATA[Zobrazit HUD s aktu├â┬íln├â┬¡mi p├àÔäó├â┬¡jmy, zp├à┬»sobem platby a histori├â┬¡ (kl├â┬ívesa I)]]></cz>
-            <br><![CDATA[Mostrar HUD com renda atual, m├â┬®todo de pagamento e hist├â┬│rico (tecla I)]]></br>
-            <da><![CDATA[Vis inkomst-HUD med nuv├â┬ªrende inkomst, betalingsmetode og historik (skift med tasten I)]]></da>
-            <uk><![CDATA[├É┼©├É┬¥├É┬║├É┬░├É┬À├É┬░├æÔÇÜ├É┬© HUD ├É┬À ├É┬┐├É┬¥├æÔÇÜ├É┬¥├æÔÇí├É┬¢├É┬©├É┬╝ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬¥├É┬╝, ├É┬╝├É┬Á├æÔÇÜ├É┬¥├É┬┤├É┬¥├É┬╝ ├É┬¥├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬© ├æÔÇÜ├É┬░ ├æÔÇô├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├æÔÇô├æÔÇØ├æ┼¢ (├É┬║├É┬╗├É┬░├É┬▓├æÔÇô├æ╦å├É┬░ I)]]></uk>
-            <ru><![CDATA[├É┼©├É┬¥├É┬║├É┬░├É┬À├É┬░├æÔÇÜ├æ┼Æ HUD ├æ┬ü ├æÔÇÜ├É┬Á├É┬║├æãÆ├æÔÇ░├É┬©├É┬╝ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬¥├É┬╝, ├æ┬ü├É┬┐├É┬¥├æ┬ü├É┬¥├É┬▒├É┬¥├É┬╝ ├É┬¥├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣ ├É┬© ├É┬©├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├É┬©├É┬Á├É┬╣ (├É┬║├É┬╗├É┬░├É┬▓├É┬©├æ╦å├É┬░ I)]]></ru>
+            <cz><![CDATA[Zobrazit HUD s aktuâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡mi pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmy, zpâ”œÃ â”¬Â»sobem platby a historiâ”œÃ¢â”¬Â¡ (klâ”œÃ¢â”¬Ã­vesa I)]]></cz>
+            <br><![CDATA[Mostrar HUD com renda atual, mâ”œÃ¢â”¬Â®todo de pagamento e histâ”œÃ¢â”¬â”‚rico (tecla I)]]></br>
+            <da><![CDATA[Vis inkomst-HUD med nuvâ”œÃ¢â”¬Âªrende inkomst, betalingsmetode og historik (skift med tasten I)]]></da>
+            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© HUD â”œÃ‰â”¬Ã€ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•, â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â• â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦â”¼Â¢ (â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘ I)]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† HUD â”œÃ¦â”¬Ã¼ â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ‰â”¬â• â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬Â© â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•£ (â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘ I)]]></ru>
         </text>
 
         <!-- HUD toggle key binding display name -->
@@ -445,29 +445,29 @@
             <en><![CDATA[Toggle Income HUD]]></en>
             <de><![CDATA[Einkommens-HUD umschalten]]></de>
             <fr><![CDATA[Basculer l'HUD de revenu]]></fr>
-            <pl><![CDATA[Prze├àÔÇÜ├äÔÇªcz HUD dochodu]]></pl>
+            <pl><![CDATA[Przeâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz HUD dochodu]]></pl>
             <es><![CDATA[Alternar HUD de ingresos]]></es>
             <it><![CDATA[Attiva/disattiva HUD reddito]]></it>
-            <cz><![CDATA[P├àÔäóepnout HUD p├àÔäó├â┬¡jm├à┬»]]></cz>
+            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³epnout HUD pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â»]]></cz>
             <br><![CDATA[Alternar HUD de renda]]></br>
-            <uk><![CDATA[├É┼©├É┬Á├æÔé¼├É┬Á├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© HUD ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
-            <ru><![CDATA[├É┼©├É┬Á├æÔé¼├É┬Á├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ HUD ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© HUD â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† HUD â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
             <da><![CDATA[Skift inkomst-HUD]]></da>
         </text>
 
         <!-- Income Report Dialog: key binding display name -->
         <text name="input_IM_INCOME_REPORT">
             <en><![CDATA[Open Income Report]]></en>
-            <de><![CDATA[Einkommensbericht ├â┬Âffnen]]></de>
+            <de><![CDATA[Einkommensbericht â”œÃ¢â”¬Ã‚ffnen]]></de>
             <fr><![CDATA[Ouvrir le rapport de revenu]]></fr>
-            <pl><![CDATA[Otw├â┬│rz raport dochodu]]></pl>
+            <pl><![CDATA[Otwâ”œÃ¢â”¬â”‚rz raport dochodu]]></pl>
             <es><![CDATA[Abrir informe de ingresos]]></es>
             <it><![CDATA[Apri rapporto reddito]]></it>
-            <cz><![CDATA[Otev├àÔäó├â┬¡t p├àÔäóehled p├àÔäó├â┬¡jm├à┬»]]></cz>
-            <br><![CDATA[Abrir relat├â┬│rio de renda]]></br>
-            <uk><![CDATA[├ÉÔÇÖ├æÔÇô├É┬┤├É┬║├æÔé¼├É┬©├æÔÇÜ├É┬© ├É┬À├É┬▓├æÔÇô├æÔÇÜ ├É┬┐├æÔé¼├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬©]]></uk>
-            <ru><![CDATA[├É┼¥├æÔÇÜ├É┬║├æÔé¼├æÔÇ╣├æÔÇÜ├æ┼Æ ├É┬¥├æÔÇÜ├æÔÇí├æÔÇÿ├æÔÇÜ ├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░├æÔÇª]]></ru>
-            <da><![CDATA[├âÔÇªbn inkomstrapport]]></da>
+            <cz><![CDATA[Otevâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡t pâ”œÃ Ã”Ã¤Ã³ehled pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â»]]></cz>
+            <br><![CDATA[Abrir relatâ”œÃ¢â”¬â”‚rio de renda]]></br>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã”Ã‡Ã¿â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª]]></ru>
+            <da><![CDATA[â”œÃ¢Ã”Ã‡Âªbn inkomstrapport]]></da>
         </text>
 
         <!-- Income Report Dialog: dialog title -->
@@ -478,10 +478,10 @@
             <pl><![CDATA[Raport dochodu]]></pl>
             <es><![CDATA[Informe de ingresos]]></es>
             <it><![CDATA[Rapporto reddito]]></it>
-            <cz><![CDATA[P├àÔäóehled p├àÔäó├â┬¡jm├à┬»]]></cz>
-            <br><![CDATA[Relat├â┬│rio de renda]]></br>
-            <uk><![CDATA[├ÉÔÇö├É┬▓├æÔÇô├æÔÇÜ ├É┬┐├æÔé¼├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬©]]></uk>
-            <ru><![CDATA[├É┼¥├æÔÇÜ├æÔÇí├æÔÇÿ├æÔÇÜ ├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░├æÔÇª]]></ru>
+            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³ehled pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â»]]></cz>
+            <br><![CDATA[Relatâ”œÃ¢â”¬â”‚rio de renda]]></br>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã”Ã‡Ã¿â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª]]></ru>
             <da><![CDATA[Inkomstrapport]]></da>
         </text>
 
@@ -495,8 +495,8 @@
             <it><![CDATA[Stato]]></it>
             <cz><![CDATA[Stav]]></cz>
             <br><![CDATA[Status]]></br>
-            <uk><![CDATA[├É┬í├æÔÇÜ├É┬░├É┬¢]]></uk>
-            <ru><![CDATA[├É┬í├æÔÇÜ├É┬░├æÔÇÜ├æãÆ├æ┬ü]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ¦â”¬Ã¼]]></ru>
             <da><![CDATA[Status]]></da>
         </text>
 
@@ -506,39 +506,39 @@
             <fr><![CDATA[Mode]]></fr>
             <pl><![CDATA[Tryb]]></pl>
             <es><![CDATA[Modo]]></es>
-            <it><![CDATA[Modalit├â┬á]]></it>
-            <cz><![CDATA[Re├à┬¥im]]></cz>
+            <it><![CDATA[Modalitâ”œÃ¢â”¬Ã¡]]></it>
+            <cz><![CDATA[Reâ”œÃ â”¬Â¥im]]></cz>
             <br><![CDATA[Modo]]></br>
-            <uk><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝]]></uk>
-            <ru><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â•]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â•]]></ru>
             <da><![CDATA[Modus]]></da>
         </text>
 
         <text name="im_report_difficulty_label">
             <en><![CDATA[Difficulty]]></en>
             <de><![CDATA[Schwierigkeit]]></de>
-            <fr><![CDATA[Difficult├â┬®]]></fr>
-            <pl><![CDATA[Trudno├àÔÇ║├äÔÇí]]></pl>
+            <fr><![CDATA[Difficultâ”œÃ¢â”¬Â®]]></fr>
+            <pl><![CDATA[Trudnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­]]></pl>
             <es><![CDATA[Dificultad]]></es>
-            <it><![CDATA[Difficolt├â┬á]]></it>
-            <cz><![CDATA[Obt├â┬¡├à┬¥nost]]></cz>
+            <it><![CDATA[Difficoltâ”œÃ¢â”¬Ã¡]]></it>
+            <cz><![CDATA[Obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nost]]></cz>
             <br><![CDATA[Dificuldade]]></br>
-            <uk><![CDATA[├É┬í├É┬║├É┬╗├É┬░├É┬┤├É┬¢├æÔÇô├æ┬ü├æÔÇÜ├æ┼Æ]]></uk>
-            <ru><![CDATA[├É┬í├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æ┼Æ]]></ru>
-            <da><![CDATA[Sv├â┬ªrhedsgr├â┬ªd]]></da>
+            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†]]></ru>
+            <da><![CDATA[Svâ”œÃ¢â”¬Âªrhedsgrâ”œÃ¢â”¬Âªd]]></da>
         </text>
 
         <text name="im_report_amount_label">
             <en><![CDATA[Payment]]></en>
             <de><![CDATA[Zahlung]]></de>
             <fr><![CDATA[Paiement]]></fr>
-            <pl><![CDATA[P├àÔÇÜatno├àÔÇ║├äÔÇí]]></pl>
+            <pl><![CDATA[Pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­]]></pl>
             <es><![CDATA[Pago]]></es>
             <it><![CDATA[Pagamento]]></it>
             <cz><![CDATA[Platba]]></cz>
             <br><![CDATA[Pagamento]]></br>
-            <uk><![CDATA[├ÉÔÇÖ├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░]]></uk>
-            <ru><![CDATA[├ÉÔÇÖ├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░]]></ru>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘]]></ru>
             <da><![CDATA[Betaling]]></da>
         </text>
 
@@ -546,13 +546,13 @@
             <en><![CDATA[Multiplier]]></en>
             <de><![CDATA[Multiplikator]]></de>
             <fr><![CDATA[Multiplicateur]]></fr>
-            <pl><![CDATA[Mno├à┬╝nik]]></pl>
+            <pl><![CDATA[Mnoâ”œÃ â”¬â•nik]]></pl>
             <es><![CDATA[Multiplicador]]></es>
             <it><![CDATA[Moltiplicatore]]></it>
-            <cz><![CDATA[Multiplik├â┬ítor]]></cz>
+            <cz><![CDATA[Multiplikâ”œÃ¢â”¬Ã­tor]]></cz>
             <br><![CDATA[Multiplicador]]></br>
-            <uk><![CDATA[├É┼ô├É┬¢├É┬¥├É┬Â├É┬¢├É┬©├É┬║]]></uk>
-            <ru><![CDATA[├É┼ô├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┼Æ]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†]]></ru>
             <da><![CDATA[Multiplikator]]></da>
         </text>
 
@@ -563,54 +563,54 @@
             <pl><![CDATA[Sezonowe]]></pl>
             <es><![CDATA[Estacional]]></es>
             <it><![CDATA[Stagionale]]></it>
-            <cz><![CDATA[Sez├â┬│nn├â┬¡]]></cz>
+            <cz><![CDATA[Sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡]]></cz>
             <br><![CDATA[Sazonal]]></br>
-            <uk><![CDATA[├É┬í├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬Á]]></uk>
-            <ru><![CDATA[├É┬í├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬¥├É┬Á]]></ru>
-            <da><![CDATA[S├â┬ªsonal]]></da>
+            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ã]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã]]></ru>
+            <da><![CDATA[Sâ”œÃ¢â”¬Âªsonal]]></da>
         </text>
 
         <!-- Income Report Dialog: stats labels -->
         <text name="im_report_total_label">
             <en><![CDATA[Total Earned]]></en>
             <de><![CDATA[Gesamtverdienst]]></de>
-            <fr><![CDATA[Total gagn├â┬®]]></fr>
-            <pl><![CDATA[├à┬ü├äÔÇªcznie zarobiono]]></pl>
+            <fr><![CDATA[Total gagnâ”œÃ¢â”¬Â®]]></fr>
+            <pl><![CDATA[â”œÃ â”¬Ã¼â”œÃ¤Ã”Ã‡Âªcznie zarobiono]]></pl>
             <es><![CDATA[Total ganado]]></es>
             <it><![CDATA[Totale guadagnato]]></it>
-            <cz><![CDATA[Celkem vyd├äÔÇ║l├â┬íno]]></cz>
+            <cz><![CDATA[Celkem vydâ”œÃ¤Ã”Ã‡â•‘lâ”œÃ¢â”¬Ã­no]]></cz>
             <br><![CDATA[Total ganho]]></br>
-            <uk><![CDATA[├ÉÔÇÖ├æ┬ü├æ┼Æ├É┬¥├É┬│├É┬¥ ├É┬À├É┬░├æÔé¼├É┬¥├É┬▒├É┬╗├É┬Á├É┬¢├É┬¥]]></uk>
-            <ru><![CDATA[├ÉÔÇÖ├æ┬ü├É┬Á├É┬│├É┬¥ ├É┬À├É┬░├æÔé¼├É┬░├É┬▒├É┬¥├æÔÇÜ├É┬░├É┬¢├É┬¥]]></ru>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></ru>
             <da><![CDATA[Totalt tjent]]></da>
         </text>
 
         <text name="im_report_avg_label">
             <en><![CDATA[Avg/Payment]]></en>
-            <de><![CDATA[├â╦£/Zahlung]]></de>
+            <de><![CDATA[â”œÃ¢â•¦Â£/Zahlung]]></de>
             <fr><![CDATA[Moy./Paiement]]></fr>
-            <pl><![CDATA[├à┼íred./P├àÔÇÜatno├àÔÇ║├äÔÇí]]></pl>
+            <pl><![CDATA[â”œÃ â”¼Ã­red./Pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­]]></pl>
             <es><![CDATA[Prom./Pago]]></es>
             <it><![CDATA[Media/Pag.]]></it>
-            <cz><![CDATA[Pr├à┬»m├äÔÇ║r/Platba]]></cz>
-            <br><![CDATA[M├â┬®dia/Pagto]]></br>
-            <uk><![CDATA[├É┬í├É┬Á├æÔé¼├É┬Á├É┬┤./├ÉÔÇÖ├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░]]></uk>
-            <ru><![CDATA[├É┬í├æÔé¼./├ÉÔÇÖ├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░]]></ru>
+            <cz><![CDATA[Prâ”œÃ â”¬Â»mâ”œÃ¤Ã”Ã‡â•‘r/Platba]]></cz>
+            <br><![CDATA[Mâ”œÃ¢â”¬Â®dia/Pagto]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤./â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ¦Ã”Ã©Â¼./â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘]]></ru>
             <da><![CDATA[Gennemsnitligt tjent]]></da>
         </text>
 
         <text name="im_report_next_label">
             <en><![CDATA[Next Payment]]></en>
-            <de><![CDATA[N├â┬ñchste Zahlung]]></de>
+            <de><![CDATA[Nâ”œÃ¢â”¬Ã±chste Zahlung]]></de>
             <fr><![CDATA[Prochain paiement]]></fr>
-            <pl><![CDATA[Nast├äÔäópna p├àÔÇÜatno├àÔÇ║├äÔÇí]]></pl>
-            <es><![CDATA[Pr├â┬│ximo pago]]></es>
+            <pl><![CDATA[Nastâ”œÃ¤Ã”Ã¤Ã³pna pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­]]></pl>
+            <es><![CDATA[Prâ”œÃ¢â”¬â”‚ximo pago]]></es>
             <it><![CDATA[Prossimo pagamento]]></it>
-            <cz><![CDATA[P├àÔäó├â┬¡├à┬ít├â┬¡ platba]]></cz>
-            <br><![CDATA[Pr├â┬│ximo pagamento]]></br>
-            <uk><![CDATA[├É┬Ø├É┬░├æ┬ü├æÔÇÜ├æãÆ├É┬┐├É┬¢├É┬░ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░]]></uk>
-            <ru><![CDATA[├É┬í├É┬╗├É┬Á├É┬┤├æãÆ├æ┼¢├æÔÇ░├É┬░├æ┬Å ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░]]></ru>
-            <da><![CDATA[N├â┬ªste betaling]]></da>
+            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡â”œÃ â”¬Ã­tâ”œÃ¢â”¬Â¡ platba]]></cz>
+            <br><![CDATA[Prâ”œÃ¢â”¬â”‚ximo pagamento]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â”â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã… â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘]]></ru>
+            <da><![CDATA[Nâ”œÃ¢â”¬Âªste betaling]]></da>
         </text>
 
         <!-- Income Report Dialog: table column headers -->
@@ -618,13 +618,13 @@
             <en><![CDATA[Day]]></en>
             <de><![CDATA[Tag]]></de>
             <fr><![CDATA[Jour]]></fr>
-            <pl><![CDATA[Dzie├àÔÇ×]]></pl>
-            <es><![CDATA[D├â┬¡a]]></es>
+            <pl><![CDATA[Dzieâ”œÃ Ã”Ã‡Ã—]]></pl>
+            <es><![CDATA[Dâ”œÃ¢â”¬Â¡a]]></es>
             <it><![CDATA[Giorno]]></it>
             <cz><![CDATA[Den]]></cz>
             <br><![CDATA[Dia]]></br>
-            <uk><![CDATA[├ÉÔÇØ├É┬Á├É┬¢├æ┼Æ]]></uk>
-            <ru><![CDATA[├ÉÔÇØ├É┬Á├É┬¢├æ┼Æ]]></ru>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã˜â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã˜â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†]]></ru>
             <da><![CDATA[Dag]]></da>
         </text>
 
@@ -635,10 +635,10 @@
             <pl><![CDATA[Godzina]]></pl>
             <es><![CDATA[Hora]]></es>
             <it><![CDATA[Ora]]></it>
-            <cz><![CDATA[├ä┼Æas]]></cz>
+            <cz><![CDATA[â”œÃ¤â”¼Ã†as]]></cz>
             <br><![CDATA[Hora]]></br>
-            <uk><![CDATA[├É┬º├É┬░├æ┬ü]]></uk>
-            <ru><![CDATA[├ÉÔÇÖ├æÔé¼├É┬Á├É┬╝├æ┬Å]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¬Âºâ”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ¦â”¬Ã…]]></ru>
             <da><![CDATA[Tid]]></da>
         </text>
 
@@ -651,8 +651,8 @@
             <it><![CDATA[Tipo]]></it>
             <cz><![CDATA[Typ]]></cz>
             <br><![CDATA[Tipo]]></br>
-            <uk><![CDATA[├É┬ó├É┬©├É┬┐]]></uk>
-            <ru><![CDATA[├É┬ó├É┬©├É┬┐]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¬Ã³â”œÃ‰â”¬Â©â”œÃ‰â”¬â”]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã³â”œÃ‰â”¬Â©â”œÃ‰â”¬â”]]></ru>
             <da><![CDATA[Type]]></da>
         </text>
 
@@ -663,11 +663,11 @@
             <pl><![CDATA[Kwota]]></pl>
             <es><![CDATA[Monto]]></es>
             <it><![CDATA[Importo]]></it>
-            <cz><![CDATA[├ä┼Æ├â┬ístka]]></cz>
+            <cz><![CDATA[â”œÃ¤â”¼Ã†â”œÃ¢â”¬Ã­stka]]></cz>
             <br><![CDATA[Valor]]></br>
-            <uk><![CDATA[├É┬í├æãÆ├É┬╝├É┬░]]></uk>
-            <ru><![CDATA[├É┬í├æãÆ├É┬╝├É┬╝├É┬░]]></ru>
-            <da><![CDATA[Bel├â┬©b]]></da>
+            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘]]></ru>
+            <da><![CDATA[Belâ”œÃ¢â”¬Â©b]]></da>
         </text>
 
         <text name="im_report_col_seasonal">
@@ -677,141 +677,141 @@
             <pl><![CDATA[Sezonowe]]></pl>
             <es><![CDATA[Estacional]]></es>
             <it><![CDATA[Stagionale]]></it>
-            <cz><![CDATA[Sez├â┬│nn├â┬¡]]></cz>
+            <cz><![CDATA[Sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡]]></cz>
             <br><![CDATA[Sazonal]]></br>
-            <uk><![CDATA[├É┬í├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬Á]]></uk>
-            <ru><![CDATA[├É┬í├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬¥├É┬Á]]></ru>
-            <da><![CDATA[S├â┬ªsonal]]></da>
+            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ã]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã]]></ru>
+            <da><![CDATA[Sâ”œÃ¢â”¬Âªsonal]]></da>
         </text>
 
         <!-- Income Report Dialog: no history message -->
         <text name="im_report_no_history">
             <en><![CDATA[No payment history yet. Income will be recorded after the first payment.]]></en>
             <de><![CDATA[Noch kein Zahlungsverlauf. Einkommen wird nach der ersten Zahlung aufgezeichnet.]]></de>
-            <fr><![CDATA[Pas encore d'historique de paiement. Les revenus seront enregistr├â┬®s apr├â┬¿s le premier paiement.]]></fr>
-            <pl><![CDATA[Brak historii p├àÔÇÜatno├àÔÇ║ci. Doch├â┬│d zostanie zarejestrowany po pierwszej p├àÔÇÜatno├àÔÇ║ci.]]></pl>
-            <es><![CDATA[A├â┬║n no hay historial de pagos. Los ingresos se registrar├â┬ín despu├â┬®s del primer pago.]]></es>
+            <fr><![CDATA[Pas encore d'historique de paiement. Les revenus seront enregistrâ”œÃ¢â”¬Â®s aprâ”œÃ¢â”¬Â¿s le premier paiement.]]></fr>
+            <pl><![CDATA[Brak historii pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci. Dochâ”œÃ¢â”¬â”‚d zostanie zarejestrowany po pierwszej pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci.]]></pl>
+            <es><![CDATA[Aâ”œÃ¢â”¬â•‘n no hay historial de pagos. Los ingresos se registrarâ”œÃ¢â”¬Ã­n despuâ”œÃ¢â”¬Â®s del primer pago.]]></es>
             <it><![CDATA[Nessuna cronologia pagamenti. I ricavi verranno registrati dopo il primo pagamento.]]></it>
-            <cz><![CDATA[Zat├â┬¡m ├à┬¥├â┬ídn├â┬í historie plateb. P├àÔäó├â┬¡jem bude zaznamen├â┬ín po prvn├â┬¡ platb├äÔÇ║.]]></cz>
-            <br><![CDATA[Sem hist├â┬│rico de pagamentos. A renda ser├â┬í registrada ap├â┬│s o primeiro pagamento.]]></br>
-            <uk><![CDATA[├É┬®├É┬Á ├É┬¢├É┬Á├É┬╝├É┬░├æÔÇØ ├æÔÇô├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├æÔÇô├æÔÇö ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ. ├ÉÔÇØ├É┬¥├æÔÇª├æÔÇô├É┬┤ ├É┬▒├æãÆ├É┬┤├É┬Á ├É┬À├É┬░├É┬┐├É┬©├æ┬ü├É┬░├É┬¢├É┬¥ ├É┬┐├æÔÇô├æ┬ü├É┬╗├æ┬Å ├É┬┐├É┬Á├æÔé¼├æ╦å├É┬¥├æÔÇö ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬©.]]></uk>
-            <ru><![CDATA[├É╦£├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├É┬©├É┬© ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ ├É┬┐├É┬¥├É┬║├É┬░ ├É┬¢├É┬Á├æÔÇÜ. ├ÉÔÇØ├É┬¥├æÔÇª├É┬¥├É┬┤ ├É┬▒├æãÆ├É┬┤├É┬Á├æÔÇÜ ├É┬À├É┬░├É┬┐├É┬©├æ┬ü├É┬░├É┬¢ ├É┬┐├É┬¥├æ┬ü├É┬╗├É┬Á ├É┬┐├É┬Á├æÔé¼├É┬▓├É┬¥├É┬╣ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣.]]></ru>
-            <da><![CDATA[Ingen betalingshistorik endnu. Indkomst vil blive registreret efter den f├â┬©rste betaling.]]></da>
+            <cz><![CDATA[Zatâ”œÃ¢â”¬Â¡m â”œÃ â”¬Â¥â”œÃ¢â”¬Ã­dnâ”œÃ¢â”¬Ã­ historie plateb. Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem bude zaznamenâ”œÃ¢â”¬Ã­n po prvnâ”œÃ¢â”¬Â¡ platbâ”œÃ¤Ã”Ã‡â•‘.]]></cz>
+            <br><![CDATA[Sem histâ”œÃ¢â”¬â”‚rico de pagamentos. A renda serâ”œÃ¢â”¬Ã­ registrada apâ”œÃ¢â”¬â”‚s o primeiro pagamento.]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Â®â”œÃ‰â”¬Ã â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜ â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ã¶ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ. â”œÃ‰Ã”Ã‡Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â–’â”œÃ¦Ã£Ã†â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ã â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã¶ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©.]]></uk>
+            <ru><![CDATA[â”œÃ‰â•¦Â£â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ. â”œÃ‰Ã”Ã‡Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â–’â”œÃ¦Ã£Ã†â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ã â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£.]]></ru>
+            <da><![CDATA[Ingen betalingshistorik endnu. Indkomst vil blive registreret efter den fâ”œÃ¢â”¬Â©rste betaling.]]></da>
         </text>
 
         <!-- Income Report Dialog: enabled/disabled status values -->
         <text name="im_report_enabled">
             <en><![CDATA[Enabled]]></en>
             <de><![CDATA[Aktiviert]]></de>
-            <fr><![CDATA[Activ├â┬®]]></fr>
-            <pl><![CDATA[W├àÔÇÜ├äÔÇªczone]]></pl>
+            <fr><![CDATA[Activâ”œÃ¢â”¬Â®]]></fr>
+            <pl><![CDATA[Wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczone]]></pl>
             <es><![CDATA[Activado]]></es>
             <it><![CDATA[Attivato]]></it>
             <cz><![CDATA[Povoleno]]></cz>
             <br><![CDATA[Ativado]]></br>
-            <uk><![CDATA[├É┬ú├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├É┬Á├É┬¢├É┬¥]]></uk>
-            <ru><![CDATA[├ÉÔÇÖ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬¢├É┬¥]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></ru>
             <da><![CDATA[Aktiveret]]></da>
         </text>
 
         <text name="im_report_disabled">
             <en><![CDATA[Disabled]]></en>
             <de><![CDATA[Deaktiviert]]></de>
-            <fr><![CDATA[D├â┬®sactiv├â┬®]]></fr>
-            <pl><![CDATA[Wy├àÔÇÜ├äÔÇªczone]]></pl>
+            <fr><![CDATA[Dâ”œÃ¢â”¬Â®sactivâ”œÃ¢â”¬Â®]]></fr>
+            <pl><![CDATA[Wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczone]]></pl>
             <es><![CDATA[Desactivado]]></es>
             <it><![CDATA[Disattivato]]></it>
-            <cz><![CDATA[Zak├â┬íz├â┬íno]]></cz>
+            <cz><![CDATA[Zakâ”œÃ¢â”¬Ã­zâ”œÃ¢â”¬Ã­no]]></cz>
             <br><![CDATA[Desativado]]></br>
-            <uk><![CDATA[├ÉÔÇÖ├É┬©├É┬╝├É┬║├É┬¢├É┬Á├É┬¢├É┬¥]]></uk>
-            <ru><![CDATA[├ÉÔÇÖ├æÔÇ╣├É┬║├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬¢├É┬¥]]></ru>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥]]></ru>
             <da><![CDATA[Deaktiveret]]></da>
         </text>
 
         <!-- Reset -->
         <text name="im_reset">
             <en><![CDATA[Reset Income Settings]]></en>
-            <de><![CDATA[Einkommenseinstellungen zur├â┬╝cksetzen]]></de>
-            <fr><![CDATA[R├â┬®initialiser les param├â┬¿tres de revenu]]></fr>
+            <de><![CDATA[Einkommenseinstellungen zurâ”œÃ¢â”¬â•cksetzen]]></de>
+            <fr><![CDATA[Râ”œÃ¢â”¬Â®initialiser les paramâ”œÃ¢â”¬Â¿tres de revenu]]></fr>
             <pl><![CDATA[Resetuj ustawienia dochodu]]></pl>
             <es><![CDATA[Restablecer config. ingresos]]></es>
             <it><![CDATA[Ripristina impostazioni reddito]]></it>
-            <cz><![CDATA[Resetovat nastaven├â┬¡ p├àÔäó├â┬¡jmu]]></cz>
-            <br><![CDATA[Restaurar configura├â┬º├â┬Áes de renda]]></br>
-            <uk><![CDATA[├É┬í├É┬║├É┬©├É┬¢├æãÆ├æÔÇÜ├É┬© ├É┬¢├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
-            <ru><![CDATA[├É┬í├É┬▒├æÔé¼├É┬¥├æ┬ü├É┬©├æÔÇÜ├æ┼Æ ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬© ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
+            <cz><![CDATA[Resetovat nastavenâ”œÃ¢â”¬Â¡ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmu]]></cz>
+            <br><![CDATA[Restaurar configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães de renda]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
             <da><![CDATA[Reset indkomstindstillinger]]></da>
         </text>
 
-        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Category titles ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
+        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Category titles â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
         <text name="im_help_cat_overview">
-            <en><![CDATA[Income Mod ├óÔé¼ÔÇØ Overview]]></en>
-            <de><![CDATA[Einkommens-Mod ├óÔé¼ÔÇØ ├â┼ôbersicht]]></de>
-            <fr><![CDATA[Mod de revenu ├óÔé¼ÔÇØ Vue d'ensemble]]></fr>
-            <pl><![CDATA[Mod dochod├â┬│w ├óÔé¼ÔÇØ Przegl├äÔÇªd]]></pl>
-            <es><![CDATA[Mod de ingresos ├óÔé¼ÔÇØ Resumen]]></es>
-            <it><![CDATA[Mod reddito ├óÔé¼ÔÇØ Panoramica]]></it>
-            <cz><![CDATA[P├àÔäó├â┬¡jmov├â┬¢ mod ├óÔé¼ÔÇØ P├àÔäóehled]]></cz>
-            <br><![CDATA[Mod de renda ├óÔé¼ÔÇØ Vis├â┬úo geral]]></br>
-            <uk><![CDATA[├É┼ô├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ ├óÔé¼ÔÇØ ├É┼¥├É┬│├É┬╗├æ┬Å├É┬┤]]></uk>
-            <ru><![CDATA[├É┼ô├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░ ├óÔé¼ÔÇØ ├É┼¥├É┬▒├É┬À├É┬¥├æÔé¼]]></ru>
-            <da><![CDATA[Income Mod ├óÔé¼ÔÇØ Oversigt]]></da>
+            <en><![CDATA[Income Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Overview]]></en>
+            <de><![CDATA[Einkommens-Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ¢â”¼Ã´bersicht]]></de>
+            <fr><![CDATA[Mod de revenu â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Vue d'ensemble]]></fr>
+            <pl><![CDATA[Mod dochodâ”œÃ¢â”¬â”‚w â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Przeglâ”œÃ¤Ã”Ã‡Âªd]]></pl>
+            <es><![CDATA[Mod de ingresos â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Resumen]]></es>
+            <it><![CDATA[Mod reddito â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Panoramica]]></it>
+            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Pâ”œÃ Ã”Ã¤Ã³ehled]]></cz>
+            <br><![CDATA[Mod de renda â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Visâ”œÃ¢â”¬Ãºo geral]]></br>
+            <uk><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã† â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¼Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ‰â”¬â”¤]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼]]></ru>
+            <da><![CDATA[Income Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Oversigt]]></da>
         </text>
 
         <text name="im_help_cat_settings">
-            <en><![CDATA[Income Mod ├óÔé¼ÔÇØ Settings]]></en>
-            <de><![CDATA[Einkommens-Mod ├óÔé¼ÔÇØ Einstellungen]]></de>
-            <fr><![CDATA[Mod de revenu ├óÔé¼ÔÇØ Param├â┬¿tres]]></fr>
-            <pl><![CDATA[Mod dochod├â┬│w ├óÔé¼ÔÇØ Ustawienia]]></pl>
-            <es><![CDATA[Mod de ingresos ├óÔé¼ÔÇØ Ajustes]]></es>
-            <it><![CDATA[Mod reddito ├óÔé¼ÔÇØ Impostazioni]]></it>
-            <cz><![CDATA[P├àÔäó├â┬¡jmov├â┬¢ mod ├óÔé¼ÔÇØ Nastaven├â┬¡]]></cz>
-            <br><![CDATA[Mod de renda ├óÔé¼ÔÇØ Configura├â┬º├â┬Áes]]></br>
-            <uk><![CDATA[├É┼ô├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ ├óÔé¼ÔÇØ ├É┬Ø├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å]]></uk>
-            <ru><![CDATA[├É┼ô├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░ ├óÔé¼ÔÇØ ├É┬Ø├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬©]]></ru>
-            <da><![CDATA[Inkomst Mod ├óÔé¼ÔÇØ Indstillinger]]></da>
+            <en><![CDATA[Income Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Settings]]></en>
+            <de><![CDATA[Einkommens-Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Einstellungen]]></de>
+            <fr><![CDATA[Mod de revenu â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Paramâ”œÃ¢â”¬Â¿tres]]></fr>
+            <pl><![CDATA[Mod dochodâ”œÃ¢â”¬â”‚w â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Ustawienia]]></pl>
+            <es><![CDATA[Mod de ingresos â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Ajustes]]></es>
+            <it><![CDATA[Mod reddito â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Impostazioni]]></it>
+            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Nastavenâ”œÃ¢â”¬Â¡]]></cz>
+            <br><![CDATA[Mod de renda â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães]]></br>
+            <uk><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã† â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©]]></ru>
+            <da><![CDATA[Inkomst Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Indstillinger]]></da>
         </text>
 
         <text name="im_help_cat_tips">
-            <en><![CDATA[Income Mod ├óÔé¼ÔÇØ Tips & Tricks]]></en>
-            <de><![CDATA[Einkommens-Mod ├óÔé¼ÔÇØ Tipps & Tricks]]></de>
-            <fr><![CDATA[Mod de revenu ├óÔé¼ÔÇØ Astuces]]></fr>
-            <pl><![CDATA[Mod dochod├â┬│w ├óÔé¼ÔÇØ Porady i sztuczki]]></pl>
-            <es><![CDATA[Mod de ingresos ├óÔé¼ÔÇØ Consejos]]></es>
-            <it><![CDATA[Mod reddito ├óÔé¼ÔÇØ Consigli]]></it>
-            <cz><![CDATA[P├àÔäó├â┬¡jmov├â┬¢ mod ├óÔé¼ÔÇØ Tipy a triky]]></cz>
-            <br><![CDATA[Mod de renda ├óÔé¼ÔÇØ Dicas e truques]]></br>
-            <uk><![CDATA[├É┼ô├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ ├óÔé¼ÔÇØ ├É┼©├É┬¥├æÔé¼├É┬░├É┬┤├É┬©]]></uk>
-            <ru><![CDATA[├É┼ô├É┬¥├É┬┤ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░ ├óÔé¼ÔÇØ ├É┬í├É┬¥├É┬▓├É┬Á├æÔÇÜ├æÔÇ╣]]></ru>
-            <da><![CDATA[Inkomst Mod ├óÔé¼ÔÇØ Tips & Tricks]]></da>
+            <en><![CDATA[Income Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tips & Tricks]]></en>
+            <de><![CDATA[Einkommens-Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tipps & Tricks]]></de>
+            <fr><![CDATA[Mod de revenu â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Astuces]]></fr>
+            <pl><![CDATA[Mod dochodâ”œÃ¢â”¬â”‚w â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Porady i sztuczki]]></pl>
+            <es><![CDATA[Mod de ingresos â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Consejos]]></es>
+            <it><![CDATA[Mod reddito â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Consigli]]></it>
+            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tipy a triky]]></cz>
+            <br><![CDATA[Mod de renda â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Dicas e truques]]></br>
+            <uk><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã† â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£]]></ru>
+            <da><![CDATA[Inkomst Mod â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tips & Tricks]]></da>
         </text>
 
         <text name="im_help_cat_info">
             <en><![CDATA[About Income Mod]]></en>
-            <de><![CDATA[├â┼ôber Einkommens-Mod]]></de>
-            <fr><![CDATA[├âÔé¼ propos d'Income Mod]]></fr>
+            <de><![CDATA[â”œÃ¢â”¼Ã´ber Einkommens-Mod]]></de>
+            <fr><![CDATA[â”œÃ¢Ã”Ã©Â¼ propos d'Income Mod]]></fr>
             <pl><![CDATA[O Income Mod]]></pl>
             <es><![CDATA[Acerca de Income Mod]]></es>
             <it><![CDATA[Informazioni su Income Mod]]></it>
             <cz><![CDATA[O Income Modu]]></cz>
             <br><![CDATA[Sobre o Income Mod]]></br>
-            <uk><![CDATA[├É┼©├æÔé¼├É┬¥ Income Mod]]></uk>
-            <ru><![CDATA[├É┼¥├É┬▒ Income Mod]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ Income Mod]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’ Income Mod]]></ru>
             <da><![CDATA[Om Inkomst Mod]]></da>
         </text>
 
-        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page titles ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
+        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page titles â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
         <text name="im_help_p1_title">
             <en><![CDATA[Introduction]]></en>
-            <de><![CDATA[Einf├â┬╝hrung]]></de>
+            <de><![CDATA[Einfâ”œÃ¢â”¬â•hrung]]></de>
             <fr><![CDATA[Introduction]]></fr>
             <pl><![CDATA[Wprowadzenie]]></pl>
-            <es><![CDATA[Introducci├â┬│n]]></es>
+            <es><![CDATA[Introducciâ”œÃ¢â”¬â”‚n]]></es>
             <it><![CDATA[Introduzione]]></it>
-            <cz><![CDATA[├â┼ívod]]></cz>
-            <br><![CDATA[Introdu├â┬º├â┬úo]]></br>
-            <uk><![CDATA[├ÉÔÇÖ├æ┬ü├æÔÇÜ├æãÆ├É┬┐]]></uk>
-            <ru><![CDATA[├ÉÔÇÖ├É┬▓├É┬Á├É┬┤├É┬Á├É┬¢├É┬©├É┬Á]]></ru>
+            <cz><![CDATA[â”œÃ¢â”¼Ã­vod]]></cz>
+            <br><![CDATA[Introduâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ãºo]]></br>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â”]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã]]></ru>
             <da><![CDATA[Introduktion]]></da>
         </text>
 
@@ -819,55 +819,55 @@
             <en><![CDATA[How Payments Work]]></en>
             <de><![CDATA[Wie Zahlungen funktionieren]]></de>
             <fr><![CDATA[Fonctionnement des paiements]]></fr>
-            <pl><![CDATA[Jak dzia├àÔÇÜaj├äÔÇª p├àÔÇÜatno├àÔÇ║ci]]></pl>
-            <es><![CDATA[C├â┬│mo funcionan los pagos]]></es>
+            <pl><![CDATA[Jak dziaâ”œÃ Ã”Ã‡Ãœajâ”œÃ¤Ã”Ã‡Âª pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci]]></pl>
+            <es><![CDATA[Câ”œÃ¢â”¬â”‚mo funcionan los pagos]]></es>
             <it><![CDATA[Come funzionano i pagamenti]]></it>
-            <cz><![CDATA[Jak funguj├â┬¡ platby]]></cz>
+            <cz><![CDATA[Jak fungujâ”œÃ¢â”¬Â¡ platby]]></cz>
             <br><![CDATA[Como os pagamentos funcionam]]></br>
-            <uk><![CDATA[├É┬»├É┬║ ├É┬┐├æÔé¼├É┬░├æÔÇá├æ┼¢├æ┼¢├æÔÇÜ├æ┼Æ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬©]]></uk>
-            <ru><![CDATA[├É┼í├É┬░├É┬║ ├æÔé¼├É┬░├É┬▒├É┬¥├æÔÇÜ├É┬░├æ┼¢├æÔÇÜ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣]]></ru>
-            <da><![CDATA[S├â┬Ñdan fungerer betalinger]]></da>
+            <uk><![CDATA[â”œÃ‰â”¬Â»â”œÃ‰â”¬â•‘ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã¡â”œÃ¦â”¼Â¢â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Ã­â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•‘ â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£]]></ru>
+            <da><![CDATA[Sâ”œÃ¢â”¬Ã‘dan fungerer betalinger]]></da>
         </text>
 
         <text name="im_help_s1_title">
             <en><![CDATA[Income Settings]]></en>
             <de><![CDATA[Einkommenseinstellungen]]></de>
-            <fr><![CDATA[Param├â┬¿tres de revenu]]></fr>
+            <fr><![CDATA[Paramâ”œÃ¢â”¬Â¿tres de revenu]]></fr>
             <pl><![CDATA[Ustawienia dochodu]]></pl>
             <es><![CDATA[Ajustes de ingresos]]></es>
             <it><![CDATA[Impostazioni reddito]]></it>
-            <cz><![CDATA[Nastaven├â┬¡ p├àÔäó├â┬¡jmu]]></cz>
-            <br><![CDATA[Configura├â┬º├â┬Áes de renda]]></br>
-            <uk><![CDATA[├É┬Ø├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
-            <ru><![CDATA[├É┬Ø├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬© ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
+            <cz><![CDATA[Nastavenâ”œÃ¢â”¬Â¡ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmu]]></cz>
+            <br><![CDATA[Configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães de renda]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
             <da><![CDATA[Inkomstindstillinger]]></da>
         </text>
 
         <text name="im_help_s2_title">
             <en><![CDATA[Advanced Settings]]></en>
             <de><![CDATA[Erweiterte Einstellungen]]></de>
-            <fr><![CDATA[Param├â┬¿tres avanc├â┬®s]]></fr>
+            <fr><![CDATA[Paramâ”œÃ¢â”¬Â¿tres avancâ”œÃ¢â”¬Â®s]]></fr>
             <pl><![CDATA[Ustawienia zaawansowane]]></pl>
             <es><![CDATA[Ajustes avanzados]]></es>
             <it><![CDATA[Impostazioni avanzate]]></it>
-            <cz><![CDATA[Roz├à┬í├â┬¡├àÔäóen├â┬í nastaven├â┬¡]]></cz>
-            <br><![CDATA[Configura├â┬º├â┬Áes avan├â┬ºadas]]></br>
-            <uk><![CDATA[├É┬á├É┬¥├É┬À├æ╦å├É┬©├æÔé¼├É┬Á├É┬¢├æÔÇô ├É┬¢├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å]]></uk>
-            <ru><![CDATA[├É┬á├É┬░├æ┬ü├æ╦å├É┬©├æÔé¼├É┬Á├É┬¢├É┬¢├æÔÇ╣├É┬Á ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬©]]></ru>
+            <cz><![CDATA[Rozâ”œÃ â”¬Ã­â”œÃ¢â”¬Â¡â”œÃ Ã”Ã¤Ã³enâ”œÃ¢â”¬Ã­ nastavenâ”œÃ¢â”¬Â¡]]></cz>
+            <br><![CDATA[Configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães avanâ”œÃ¢â”¬Âºadas]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã€â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬Ã â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©]]></ru>
             <da><![CDATA[Avancerede indstillinger]]></da>
         </text>
 
         <text name="im_help_s3_title">
             <en><![CDATA[Display & Reset]]></en>
-            <de><![CDATA[Anzeige & Zur├â┬╝cksetzen]]></de>
-            <fr><![CDATA[Affichage & R├â┬®initialisation]]></fr>
-            <pl><![CDATA[Wy├àÔÇ║wietlanie i reset]]></pl>
+            <de><![CDATA[Anzeige & Zurâ”œÃ¢â”¬â•cksetzen]]></de>
+            <fr><![CDATA[Affichage & Râ”œÃ¢â”¬Â®initialisation]]></fr>
+            <pl><![CDATA[Wyâ”œÃ Ã”Ã‡â•‘wietlanie i reset]]></pl>
             <es><![CDATA[Pantalla y restablecer]]></es>
             <it><![CDATA[Visualizzazione e reset]]></it>
-            <cz><![CDATA[Zobrazen├â┬¡ a reset]]></cz>
-            <br><![CDATA[Exibi├â┬º├â┬úo e redefini├â┬º├â┬úo]]></br>
-            <uk><![CDATA[├ÉÔÇÖ├æÔÇô├É┬┤├É┬¥├É┬▒├æÔé¼├É┬░├É┬Â├É┬Á├É┬¢├É┬¢├æ┬Å ├æÔÇÜ├É┬░ ├æ┬ü├É┬║├É┬©├É┬┤├É┬░├É┬¢├É┬¢├æ┬Å]]></uk>
-            <ru><![CDATA[├É┼¥├æÔÇÜ├É┬¥├É┬▒├æÔé¼├É┬░├É┬Â├É┬Á├É┬¢├É┬©├É┬Á ├É┬© ├æ┬ü├É┬▒├æÔé¼├É┬¥├æ┬ü]]></ru>
+            <cz><![CDATA[Zobrazenâ”œÃ¢â”¬Â¡ a reset]]></cz>
+            <br><![CDATA[Exibiâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ãºo e redefiniâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ãºo]]></br>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼]]></ru>
             <da><![CDATA[Visning og nulstilling]]></da>
         </text>
 
@@ -878,10 +878,10 @@
             <pl><![CDATA[HUD i raport dochodu]]></pl>
             <es><![CDATA[HUD e informe de ingresos]]></es>
             <it><![CDATA[HUD e rapporto reddito]]></it>
-            <cz><![CDATA[HUD a p├àÔäóehled p├àÔäó├â┬¡jm├à┬»]]></cz>
-            <br><![CDATA[HUD e relat├â┬│rio de renda]]></br>
-            <uk><![CDATA[HUD ├æÔÇÜ├É┬░ ├É┬À├É┬▓├æÔÇô├æÔÇÜ ├É┬┐├æÔé¼├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬©]]></uk>
-            <ru><![CDATA[HUD ├É┬© ├É┬¥├æÔÇÜ├æÔÇí├æÔÇÿ├æÔÇÜ ├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░├æÔÇª]]></ru>
+            <cz><![CDATA[HUD a pâ”œÃ Ã”Ã¤Ã³ehled pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â»]]></cz>
+            <br><![CDATA[HUD e relatâ”œÃ¢â”¬â”‚rio de renda]]></br>
+            <uk><![CDATA[HUD â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©]]></uk>
+            <ru><![CDATA[HUD â”œÃ‰â”¬Â© â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã”Ã‡Ã¿â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª]]></ru>
             <da><![CDATA[HUD og inkomstrapport]]></da>
         </text>
 
@@ -889,57 +889,57 @@
             <en><![CDATA[Income Tips]]></en>
             <de><![CDATA[Einkommenstipps]]></de>
             <fr><![CDATA[Conseils sur les revenus]]></fr>
-            <pl><![CDATA[Porady dotycz├äÔÇªce dochodu]]></pl>
+            <pl><![CDATA[Porady dotyczâ”œÃ¤Ã”Ã‡Âªce dochodu]]></pl>
             <es><![CDATA[Consejos de ingresos]]></es>
             <it><![CDATA[Consigli sul reddito]]></it>
-            <cz><![CDATA[Tipy pro p├àÔäó├â┬¡jem]]></cz>
+            <cz><![CDATA[Tipy pro pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem]]></cz>
             <br><![CDATA[Dicas de renda]]></br>
-            <uk><![CDATA[├É┼©├É┬¥├æÔé¼├É┬░├É┬┤├É┬© ├æÔÇ░├É┬¥├É┬┤├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
-            <ru><![CDATA[├É┬í├É┬¥├É┬▓├É┬Á├æÔÇÜ├æÔÇ╣ ├É┬┐├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â© â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></ru>
             <da><![CDATA[Inkomst tips]]></da>
         </text>
 
         <text name="im_help_i1_title">
             <en><![CDATA[About Income Mod]]></en>
-            <de><![CDATA[├â┼ôber Einkommens-Mod]]></de>
-            <fr><![CDATA[├âÔé¼ propos d'Income Mod]]></fr>
+            <de><![CDATA[â”œÃ¢â”¼Ã´ber Einkommens-Mod]]></de>
+            <fr><![CDATA[â”œÃ¢Ã”Ã©Â¼ propos d'Income Mod]]></fr>
             <pl><![CDATA[O Income Mod]]></pl>
             <es><![CDATA[Acerca de Income Mod]]></es>
             <it><![CDATA[Informazioni su Income Mod]]></it>
             <cz><![CDATA[O Income Modu]]></cz>
             <br><![CDATA[Sobre o Income Mod]]></br>
-            <uk><![CDATA[├É┼©├æÔé¼├É┬¥ Income Mod]]></uk>
-            <ru><![CDATA[├É┼¥├É┬▒ Income Mod]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ Income Mod]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’ Income Mod]]></ru>
             <da><![CDATA[Om Inkomst Mod]]></da>
         </text>
 
-        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page 1 ├óÔé¼ÔÇØ Introduction ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
+        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page 1 â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Introduction â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
         <text name="im_help_p1_what_title">
             <en><![CDATA[What Is Income Mod?]]></en>
             <de><![CDATA[Was ist der Einkommens-Mod?]]></de>
             <fr><![CDATA[Qu'est-ce qu'Income Mod ?]]></fr>
             <pl><![CDATA[Czym jest Income Mod?]]></pl>
-            <es><![CDATA[├é┬┐Qu├â┬® es Income Mod?]]></es>
-            <it><![CDATA[Cos'├â┬¿ Income Mod?]]></it>
+            <es><![CDATA[â”œÃ©â”¬â”Quâ”œÃ¢â”¬Â® es Income Mod?]]></es>
+            <it><![CDATA[Cos'â”œÃ¢â”¬Â¿ Income Mod?]]></it>
             <cz><![CDATA[Co je Income Mod?]]></cz>
-            <br><![CDATA[O que ├â┬® o Income Mod?]]></br>
-            <uk><![CDATA[├É┬®├É┬¥ ├æÔÇÜ├É┬░├É┬║├É┬Á Income Mod?]]></uk>
-            <ru><![CDATA[├É┬º├æÔÇÜ├É┬¥ ├æÔÇÜ├É┬░├É┬║├É┬¥├É┬Á Income Mod?]]></ru>
+            <br><![CDATA[O que â”œÃ¢â”¬Â® o Income Mod?]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Â®â”œÃ‰â”¬Â¥ â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•‘â”œÃ‰â”¬Ã Income Mod?]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Âºâ”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥ â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã Income Mod?]]></ru>
             <da><![CDATA[ hvad er Inkomst Mod? ]]></da>
         </text>
 
         <text name="im_help_p1_what_text">
             <en><![CDATA[Income Mod adds a passive income system to your farm. Your farm automatically earns money each in-game hour or day. Perfect for early-game cash flow or a relaxed playthrough.]]></en>
-            <de><![CDATA[Der Einkommens-Mod f├â┬╝gt Ihrem Betrieb ein passives Einkommenssystem hinzu. Ihr Betrieb verdient automatisch Geld jede Spielstunde oder jeden Tag. Ideal f├â┬╝r den fr├â┬╝hen Spielstart oder entspanntes Spielen.]]></de>
-            <fr><![CDATA[Income Mod ajoute des revenus passifs ├â┬á votre ferme. Votre ferme gagne automatiquement de l'argent chaque heure ou jour de jeu. Id├â┬®al pour le d├â┬®but de partie ou une session d├â┬®tendue.]]></fr>
-            <pl><![CDATA[Income Mod dodaje pasywny system dochod├â┬│w do Twojego gospodarstwa. Farma automatycznie zarabia pieni├äÔÇªdze co godzin├äÔäó lub dzie├àÔÇ× gry. Idealne na pocz├äÔÇªtku rozgrywki lub do relaksuj├äÔÇªcej zabawy.]]></pl>
-            <es><![CDATA[Income Mod a├â┬▒ade ingresos pasivos a tu granja. Tu granja gana dinero autom├â┬íticamente cada hora o d├â┬¡a de juego. Perfecto para el flujo de caja inicial o una partida relajada.]]></es>
+            <de><![CDATA[Der Einkommens-Mod fâ”œÃ¢â”¬â•gt Ihrem Betrieb ein passives Einkommenssystem hinzu. Ihr Betrieb verdient automatisch Geld jede Spielstunde oder jeden Tag. Ideal fâ”œÃ¢â”¬â•r den frâ”œÃ¢â”¬â•hen Spielstart oder entspanntes Spielen.]]></de>
+            <fr><![CDATA[Income Mod ajoute des revenus passifs â”œÃ¢â”¬Ã¡ votre ferme. Votre ferme gagne automatiquement de l'argent chaque heure ou jour de jeu. Idâ”œÃ¢â”¬Â®al pour le dâ”œÃ¢â”¬Â®but de partie ou une session dâ”œÃ¢â”¬Â®tendue.]]></fr>
+            <pl><![CDATA[Income Mod dodaje pasywny system dochodâ”œÃ¢â”¬â”‚w do Twojego gospodarstwa. Farma automatycznie zarabia pieniâ”œÃ¤Ã”Ã‡Âªdze co godzinâ”œÃ¤Ã”Ã¤Ã³ lub dzieâ”œÃ Ã”Ã‡Ã— gry. Idealne na poczâ”œÃ¤Ã”Ã‡Âªtku rozgrywki lub do relaksujâ”œÃ¤Ã”Ã‡Âªcej zabawy.]]></pl>
+            <es><![CDATA[Income Mod aâ”œÃ¢â”¬â–’ade ingresos pasivos a tu granja. Tu granja gana dinero automâ”œÃ¢â”¬Ã­ticamente cada hora o dâ”œÃ¢â”¬Â¡a de juego. Perfecto para el flujo de caja inicial o una partida relajada.]]></es>
             <it><![CDATA[Income Mod aggiunge un reddito passivo alla tua fattoria. La fattoria guadagna denaro automaticamente ogni ora o giorno di gioco. Perfetto per supporto iniziale o gameplay rilassato.]]></it>
-            <cz><![CDATA[Income Mod p├àÔäóid├â┬ív├â┬í pasivn├â┬¡ p├àÔäó├â┬¡jmov├â┬¢ syst├â┬®m na va├à┬íi farmu. Farma automaticky vyd├äÔÇ║l├â┬ív├â┬í pen├â┬¡ze ka├à┬¥dou hern├â┬¡ hodinu nebo den. Ide├â┬íln├â┬¡ pro po├ä┬ì├â┬íte├ä┬ìn├â┬¡ podporu nebo uvoln├äÔÇ║nou hru.]]></cz>
-            <br><![CDATA[O Income Mod adiciona renda passiva ├â┬á sua fazenda. Sua fazenda ganha dinheiro automaticamente a cada hora ou dia de jogo. Perfeito para suporte inicial ou partida relaxada.]]></br>
-            <uk><![CDATA[Income Mod ├É┬┤├É┬¥├É┬┤├É┬░├æÔÇØ ├É┬┐├É┬░├æ┬ü├É┬©├É┬▓├É┬¢├É┬©├É┬╣ ├É┬┤├É┬¥├æÔÇª├æÔÇô├É┬┤ ├É┬┤├É┬¥ ├É┬▓├É┬░├æ╦å├É┬¥├æÔÇö ├æÔÇ×├É┬Á├æÔé¼├É┬╝├É┬©. ├É┬ñ├É┬Á├æÔé¼├É┬╝├É┬░ ├É┬░├É┬▓├æÔÇÜ├É┬¥├É┬╝├É┬░├æÔÇÜ├É┬©├æÔÇí├É┬¢├É┬¥ ├É┬À├É┬░├æÔé¼├É┬¥├É┬▒├É┬╗├æ┬Å├æÔÇØ ├É┬│├æÔé¼├É┬¥├æ╦å├æÔÇô ├É┬║├É┬¥├É┬Â├É┬¢├æãÆ ├æÔÇô├É┬│├æÔé¼├É┬¥├É┬▓├æãÆ ├É┬│├É┬¥├É┬┤├É┬©├É┬¢├æãÆ ├É┬░├É┬▒├É┬¥ ├É┬┤├É┬Á├É┬¢├æ┼Æ. ├ÉÔÇá├É┬┤├É┬Á├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥ ├É┬┤├É┬╗├æ┬Å ├É┬┐├æÔÇô├É┬┤├æÔÇÜ├æÔé¼├É┬©├É┬╝├É┬║├É┬© ├É┬¢├É┬░ ├É┬┐├É┬¥├æÔÇí├É┬░├æÔÇÜ├É┬║├æãÆ ├É┬░├É┬▒├É┬¥ ├æ┬ü├É┬┐├É┬¥├É┬║├æÔÇô├É┬╣├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┐├æÔé¼├É┬¥├æÔÇª├É┬¥├É┬┤├É┬Â├É┬Á├É┬¢├É┬¢├æ┬Å.]]></uk>
-            <ru><![CDATA[Income Mod ├É┬┤├É┬¥├É┬▒├É┬░├É┬▓├É┬╗├æ┬Å├É┬Á├æÔÇÜ ├É┬┐├É┬░├æ┬ü├æ┬ü├É┬©├É┬▓├É┬¢├æÔÇ╣├É┬╣ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤ ├É┬¢├É┬░ ├É┬▓├É┬░├æ╦å├æãÆ ├æÔÇ×├É┬Á├æÔé¼├É┬╝├æãÆ. ├É┬ñ├É┬Á├æÔé¼├É┬╝├É┬░ ├É┬░├É┬▓├æÔÇÜ├É┬¥├É┬╝├É┬░├æÔÇÜ├É┬©├æÔÇí├É┬Á├æ┬ü├É┬║├É┬© ├É┬À├É┬░├æÔé¼├É┬░├É┬▒├É┬░├æÔÇÜ├æÔÇ╣├É┬▓├É┬░├É┬Á├æÔÇÜ ├É┬┤├É┬Á├É┬¢├æ┼Æ├É┬│├É┬© ├É┬║├É┬░├É┬Â├É┬┤├æÔÇ╣├É┬╣ ├É┬©├É┬│├æÔé¼├É┬¥├É┬▓├É┬¥├É┬╣ ├æÔÇí├É┬░├æ┬ü ├É┬©├É┬╗├É┬© ├É┬┤├É┬Á├É┬¢├æ┼Æ. ├É╦£├É┬┤├É┬Á├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥ ├É┬┤├É┬╗├æ┬Å ├É┬¢├É┬░├æÔÇí├É┬░├É┬╗├É┬░ ├É┬©├É┬│├æÔé¼├æÔÇ╣ ├É┬©├É┬╗├É┬© ├æ┬ü├É┬┐├É┬¥├É┬║├É┬¥├É┬╣├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┐├æÔé¼├É┬¥├æÔÇª├É┬¥├É┬Â├É┬┤├É┬Á├É┬¢├É┬©├æ┬Å.]]></ru>
-            <da><![CDATA[Indkomst mod tilf├â┬©jer et passivt indkomstsystem til din g├â┬Ñrd. Din g├â┬Ñrd tjener automatisk penge hver time eller dag i spillet. Perfekt til tidligt spil eller en afslappet gennemspilning.]]></da>
+            <cz><![CDATA[Income Mod pâ”œÃ Ã”Ã¤Ã³idâ”œÃ¢â”¬Ã­vâ”œÃ¢â”¬Ã­ pasivnâ”œÃ¢â”¬Â¡ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ systâ”œÃ¢â”¬Â®m na vaâ”œÃ â”¬Ã­i farmu. Farma automaticky vydâ”œÃ¤Ã”Ã‡â•‘lâ”œÃ¢â”¬Ã­vâ”œÃ¢â”¬Ã­ penâ”œÃ¢â”¬Â¡ze kaâ”œÃ â”¬Â¥dou hernâ”œÃ¢â”¬Â¡ hodinu nebo den. Ideâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡ pro poâ”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­teâ”œÃ¤â”¬Ã¬nâ”œÃ¢â”¬Â¡ podporu nebo uvolnâ”œÃ¤Ã”Ã‡â•‘nou hru.]]></cz>
+            <br><![CDATA[O Income Mod adiciona renda passiva â”œÃ¢â”¬Ã¡ sua fazenda. Sua fazenda ganha dinheiro automaticamente a cada hora ou dia de jogo. Perfeito para suporte inicial ou partida relaxada.]]></br>
+            <uk><![CDATA[Income Mod â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â”â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã¶ â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬Â©. â”œÃ‰â”¬Ã±â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†. â”œÃ‰Ã”Ã‡Ã¡â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã….]]></uk>
+            <ru><![CDATA[Income Mod â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã£Ã† â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†. â”œÃ‰â”¬Ã±â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â© â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£ â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼ â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†. â”œÃ‰â•¦Â£â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã….]]></ru>
+            <da><![CDATA[Indkomst mod tilfâ”œÃ¢â”¬Â©jer et passivt indkomstsystem til din gâ”œÃ¢â”¬Ã‘rd. Din gâ”œÃ¢â”¬Ã‘rd tjener automatisk penge hver time eller dag i spillet. Perfekt til tidligt spil eller en afslappet gennemspilning.]]></da>
         </text>
 
         <text name="im_help_p1_mp_title">
@@ -949,196 +949,196 @@
             <pl><![CDATA[Wsparcie wieloosobowe]]></pl>
             <es><![CDATA[Soporte multijugador]]></es>
             <it><![CDATA[Supporto multigiocatore]]></it>
-            <cz><![CDATA[Podpora v├â┬¡ce hr├â┬í├ä┬ì├à┬»]]></cz>
+            <cz><![CDATA[Podpora vâ”œÃ¢â”¬Â¡ce hrâ”œÃ¢â”¬Ã­â”œÃ¤â”¬Ã¬â”œÃ â”¬Â»]]></cz>
             <br><![CDATA[Suporte multiplayer]]></br>
-            <uk><![CDATA[├É┼©├æÔÇô├É┬┤├æÔÇÜ├æÔé¼├É┬©├É┬╝├É┬║├É┬░ ├É┬╝├æãÆ├É┬╗├æ┼Æ├æÔÇÜ├É┬©├É┬┐├É┬╗├É┬Á├æÔÇØ├æÔé¼├É┬░]]></uk>
-            <ru><![CDATA[├É┼©├É┬¥├É┬┤├É┬┤├É┬Á├æÔé¼├É┬Â├É┬║├É┬░ ├É┬╝├æãÆ├É┬╗├æ┼Æ├æÔÇÜ├É┬©├É┬┐├É┬╗├É┬Á├É┬Á├æÔé¼├É┬░]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘]]></ru>
             <da><![CDATA[Multiplayer Support]]></da>
         </text>
 
         <text name="im_help_p1_mp_text">
-            <en><![CDATA[Fully compatible with multiplayer. Only the server processes payments ├óÔé¼ÔÇØ income is never duplicated. Each active farm gets its own income, automatically synced to all clients.]]></en>
-            <de><![CDATA[Vollst├â┬ñndig multiplayer-kompatibel. Nur der Server verarbeitet Zahlungen ├óÔé¼ÔÇØ Einkommen wird nie dupliziert. Jeder aktive Betrieb erh├â┬ñlt sein eigenes Einkommen, automatisch an alle Clients synchronisiert.]]></de>
-            <fr><![CDATA[Enti├â┬¿rement compatible multijoueur. Seul le serveur traite les paiements ├óÔé¼ÔÇØ les revenus ne sont jamais dupliqu├â┬®s. Chaque ferme active re├â┬ºoit ses propres revenus, synchronis├â┬®s automatiquement.]]></fr>
-            <pl><![CDATA[W pe├àÔÇÜni kompatybilny z wieloosobowym. Tylko serwer przetwarza p├àÔÇÜatno├àÔÇ║ci ├óÔé¼ÔÇØ doch├â┬│d nigdy nie jest powielony. Ka├à┬╝de gospodarstwo otrzymuje w├àÔÇÜasny doch├â┬│d, synchronizowany ze wszystkimi klientami.]]></pl>
-            <es><![CDATA[Totalmente compatible con multijugador. Solo el servidor procesa los pagos ├óÔé¼ÔÇØ los ingresos nunca se duplican. Cada granja activa recibe sus propios ingresos, sincronizados autom├â┬íticamente.]]></es>
-            <it><![CDATA[Completamente compatibile con il multigiocatore. Solo il server elabora i pagamenti ├óÔé¼ÔÇØ il reddito non viene mai duplicato. Ogni fattoria attiva riceve il proprio reddito, sincronizzato automaticamente.]]></it>
-            <cz><![CDATA[Pln├äÔÇ║ kompatibiln├â┬¡ s v├â┬¡ce hr├â┬í├ä┬ìi. Pouze server zpracov├â┬ív├â┬í platby ├óÔé¼ÔÇØ p├àÔäó├â┬¡jem nen├â┬¡ nikdy zdvojen. Ka├à┬¥d├â┬í aktivn├â┬¡ farma obdr├à┬¥├â┬¡ vlastn├â┬¡ p├àÔäó├â┬¡jem, automaticky synchronizovan├â┬¢ se v├à┬íemi klienty.]]></cz>
-            <br><![CDATA[Totalmente compat├â┬¡vel com multiplayer. Apenas o servidor processa os pagamentos ├óÔé¼ÔÇØ a renda nunca ├â┬® duplicada. Cada fazenda ativa recebe sua pr├â┬│pria renda, sincronizada automaticamente.]]></br>
-            <uk><![CDATA[├É┼©├É┬¥├É┬▓├É┬¢├æÔÇô├æ┬ü├æÔÇÜ├æ┼¢ ├æ┬ü├æãÆ├É┬╝├æÔÇô├æ┬ü├É┬¢├É┬©├É┬╣ ├É┬À ├É┬╝├æãÆ├É┬╗├æ┼Æ├æÔÇÜ├É┬©├É┬┐├É┬╗├É┬Á├æÔÇØ├æÔé¼├É┬¥├É┬╝. ├É┬ó├æÔÇô├É┬╗├æ┼Æ├É┬║├É┬© ├æ┬ü├É┬Á├æÔé¼├É┬▓├É┬Á├æÔé¼ ├É┬¥├É┬▒├æÔé¼├É┬¥├É┬▒├É┬╗├æ┬Å├æÔÇØ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬© ├óÔé¼ÔÇØ ├É┬┤├É┬¥├æÔÇª├æÔÇô├É┬┤ ├É┬¢├æÔÇô├É┬║├É┬¥├É┬╗├É┬© ├É┬¢├É┬Á ├É┬┤├æãÆ├É┬▒├É┬╗├æ┼¢├æÔÇØ├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å. ├É┼í├É┬¥├É┬Â├É┬¢├É┬░ ├æÔÇ×├É┬Á├æÔé¼├É┬╝├É┬░ ├É┬¥├æÔÇÜ├æÔé¼├É┬©├É┬╝├æãÆ├æÔÇØ ├É┬▓├É┬╗├É┬░├æ┬ü├É┬¢├É┬©├É┬╣ ├É┬┤├É┬¥├æÔÇª├æÔÇô├É┬┤, ├É┬░├É┬▓├æÔÇÜ├É┬¥├É┬╝├É┬░├æÔÇÜ├É┬©├æÔÇí├É┬¢├É┬¥ ├æ┬ü├É┬©├É┬¢├æÔÇª├æÔé¼├É┬¥├É┬¢├æÔÇô├É┬À├É┬¥├É┬▓├É┬░├É┬¢├É┬©├É┬╣ ├É┬À ├æãÆ├æ┬ü├æÔÇô├É┬╝├É┬░ ├É┬║├É┬╗├æÔÇô├æÔÇØ├É┬¢├æÔÇÜ├É┬░├É┬╝├É┬©.]]></uk>
-            <ru><![CDATA[├É┼©├É┬¥├É┬╗├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æ┼Æ├æ┼¢ ├æ┬ü├É┬¥├É┬▓├É┬╝├É┬Á├æ┬ü├æÔÇÜ├É┬©├É┬╝ ├æ┬ü ├É┬╝├æãÆ├É┬╗├æ┼Æ├æÔÇÜ├É┬©├É┬┐├É┬╗├É┬Á├É┬Á├æÔé¼├É┬¥├É┬╝. ├É┬ó├É┬¥├É┬╗├æ┼Æ├É┬║├É┬¥ ├æ┬ü├É┬Á├æÔé¼├É┬▓├É┬Á├æÔé¼ ├É┬¥├É┬▒├æÔé¼├É┬░├É┬▒├É┬░├æÔÇÜ├æÔÇ╣├É┬▓├É┬░├É┬Á├æÔÇÜ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣ ├óÔé¼ÔÇØ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤ ├É┬¢├É┬©├É┬║├É┬¥├É┬│├É┬┤├É┬░ ├É┬¢├É┬Á ├É┬┤├æãÆ├É┬▒├É┬╗├É┬©├æÔé¼├æãÆ├É┬Á├æÔÇÜ├æ┬ü├æ┬Å. ├É┼í├É┬░├É┬Â├É┬┤├É┬░├æ┬Å ├æÔÇ×├É┬Á├æÔé¼├É┬╝├É┬░ ├É┬┐├É┬¥├É┬╗├æãÆ├æÔÇí├É┬░├É┬Á├æÔÇÜ ├æ┬ü├É┬▓├É┬¥├É┬╣ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤, ├É┬░├É┬▓├æÔÇÜ├É┬¥├É┬╝├É┬░├æÔÇÜ├É┬©├æÔÇí├É┬Á├æ┬ü├É┬║├É┬© ├æ┬ü├É┬©├É┬¢├æÔÇª├æÔé¼├É┬¥├É┬¢├É┬©├É┬À├É┬©├æÔé¼├É┬¥├É┬▓├É┬░├É┬¢├É┬¢├æÔÇ╣├É┬╣ ├æ┬ü├É┬¥ ├É┬▓├æ┬ü├É┬Á├É┬╝├É┬© ├É┬║├É┬╗├É┬©├É┬Á├É┬¢├æÔÇÜ├É┬░├É┬╝├É┬©.]]></ru>
-            <da><![CDATA[Fuldt kompatibel med multiplayer. Kun serveren behandler betalinger ├óÔé¼ÔÇØ indkomst bliver aldrig duplikeret. Hver aktiv farm f├â┬Ñr sin egen indkomst, automatisk synkroniseret til alle klienter.]]></da>
+            <en><![CDATA[Fully compatible with multiplayer. Only the server processes payments â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ income is never duplicated. Each active farm gets its own income, automatically synced to all clients.]]></en>
+            <de><![CDATA[Vollstâ”œÃ¢â”¬Ã±ndig multiplayer-kompatibel. Nur der Server verarbeitet Zahlungen â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Einkommen wird nie dupliziert. Jeder aktive Betrieb erhâ”œÃ¢â”¬Ã±lt sein eigenes Einkommen, automatisch an alle Clients synchronisiert.]]></de>
+            <fr><![CDATA[Entiâ”œÃ¢â”¬Â¿rement compatible multijoueur. Seul le serveur traite les paiements â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ les revenus ne sont jamais dupliquâ”œÃ¢â”¬Â®s. Chaque ferme active reâ”œÃ¢â”¬Âºoit ses propres revenus, synchronisâ”œÃ¢â”¬Â®s automatiquement.]]></fr>
+            <pl><![CDATA[W peâ”œÃ Ã”Ã‡Ãœni kompatybilny z wieloosobowym. Tylko serwer przetwarza pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ dochâ”œÃ¢â”¬â”‚d nigdy nie jest powielony. Kaâ”œÃ â”¬â•de gospodarstwo otrzymuje wâ”œÃ Ã”Ã‡Ãœasny dochâ”œÃ¢â”¬â”‚d, synchronizowany ze wszystkimi klientami.]]></pl>
+            <es><![CDATA[Totalmente compatible con multijugador. Solo el servidor procesa los pagos â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ los ingresos nunca se duplican. Cada granja activa recibe sus propios ingresos, sincronizados automâ”œÃ¢â”¬Ã­ticamente.]]></es>
+            <it><![CDATA[Completamente compatibile con il multigiocatore. Solo il server elabora i pagamenti â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ il reddito non viene mai duplicato. Ogni fattoria attiva riceve il proprio reddito, sincronizzato automaticamente.]]></it>
+            <cz><![CDATA[Plnâ”œÃ¤Ã”Ã‡â•‘ kompatibilnâ”œÃ¢â”¬Â¡ s vâ”œÃ¢â”¬Â¡ce hrâ”œÃ¢â”¬Ã­â”œÃ¤â”¬Ã¬i. Pouze server zpracovâ”œÃ¢â”¬Ã­vâ”œÃ¢â”¬Ã­ platby â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem nenâ”œÃ¢â”¬Â¡ nikdy zdvojen. Kaâ”œÃ â”¬Â¥dâ”œÃ¢â”¬Ã­ aktivnâ”œÃ¢â”¬Â¡ farma obdrâ”œÃ â”¬Â¥â”œÃ¢â”¬Â¡ vlastnâ”œÃ¢â”¬Â¡ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem, automaticky synchronizovanâ”œÃ¢â”¬Â¢ se vâ”œÃ â”¬Ã­emi klienty.]]></cz>
+            <br><![CDATA[Totalmente compatâ”œÃ¢â”¬Â¡vel com multiplayer. Apenas o servidor processa os pagamentos â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ a renda nunca â”œÃ¢â”¬Â® duplicada. Cada fazenda ativa recebe sua prâ”œÃ¢â”¬â”‚pria renda, sincronizada automaticamente.]]></br>
+            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Â¢ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬Ã€ â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•. â”œÃ‰â”¬Ã³â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼ â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ã â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–’â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã…. â”œÃ‰â”¼Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤, â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬Ã€ â”œÃ¦Ã£Ã†â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ã˜â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ‰â”¬Â©.]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¼Â¢ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ¦â”¬Ã¼ â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•. â”œÃ‰â”¬Ã³â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼ â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£ â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ã â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–’â”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã…. â”œÃ‰â”¼Ã­â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã… â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤, â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ‰â”¬Â©.]]></ru>
+            <da><![CDATA[Fuldt kompatibel med multiplayer. Kun serveren behandler betalinger â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ indkomst bliver aldrig duplikeret. Hver aktiv farm fâ”œÃ¢â”¬Ã‘r sin egen indkomst, automatisk synkroniseret til alle klienter.]]></da>
         </text>
 
-        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page 2 ├óÔé¼ÔÇØ How Payments Work ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
+        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page 2 â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ How Payments Work â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
         <text name="im_help_p2_modes_title">
             <en><![CDATA[Pay Modes]]></en>
             <de><![CDATA[Zahlungsmodi]]></de>
             <fr><![CDATA[Modes de paiement]]></fr>
-            <pl><![CDATA[Tryby p├àÔÇÜatno├àÔÇ║ci]]></pl>
+            <pl><![CDATA[Tryby pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci]]></pl>
             <es><![CDATA[Modos de pago]]></es>
-            <it><![CDATA[Modalit├â┬á di pagamento]]></it>
-            <cz><![CDATA[Platebn├â┬¡ re├à┬¥imy]]></cz>
+            <it><![CDATA[Modalitâ”œÃ¢â”¬Ã¡ di pagamento]]></it>
+            <cz><![CDATA[Platebnâ”œÃ¢â”¬Â¡ reâ”œÃ â”¬Â¥imy]]></cz>
             <br><![CDATA[Modos de pagamento]]></br>
-            <uk><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝├É┬© ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ]]></uk>
-            <ru><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝├æÔÇ╣ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ]]></ru>
             <da><![CDATA[Betalingstyper]]></da>
         </text>
 
         <text name="im_help_p2_modes_text">
-            <en><![CDATA[Hourly: one payment every in-game hour (24 per day). Daily: one payment at the start of each in-game day. Switch at any time via ESC ├óÔÇáÔÇÖ Settings ├óÔÇáÔÇÖ Income Mod.]]></en>
-            <de><![CDATA[St├â┬╝ndlich: eine Zahlung pro Spielstunde (24 pro Tag). T├â┬ñglich: eine Zahlung zu Beginn jedes Spieltages. Jederzeit wechseln: ESC ├óÔÇáÔÇÖ Einstellungen ├óÔÇáÔÇÖ Einkommens-Mod.]]></de>
-            <fr><![CDATA[Horaire : un paiement par heure de jeu (24 par jour). Quotidien : un paiement au d├â┬®but de chaque journ├â┬®e. Changez via ├âÔÇ░chap ├óÔÇáÔÇÖ Param├â┬¿tres ├óÔÇáÔÇÖ Income Mod.]]></fr>
-            <pl><![CDATA[Godzinowy: jedna p├àÔÇÜatno├àÔÇ║├äÔÇí co godzin├äÔäó gry (24 na dzie├àÔÇ×). Dzienny: jedna p├àÔÇÜatno├àÔÇ║├äÔÇí na pocz├äÔÇªtku ka├à┬╝dego dnia. Zmie├àÔÇ× w ESC ├óÔÇáÔÇÖ Ustawienia ├óÔÇáÔÇÖ Income Mod.]]></pl>
-            <es><![CDATA[Horario: un pago por hora de juego (24 al d├â┬¡a). Diario: un pago al inicio de cada d├â┬¡a. Cambia en ESC ├óÔÇáÔÇÖ Ajustes ├óÔÇáÔÇÖ Income Mod.]]></es>
-            <it><![CDATA[Orario: un pagamento ogni ora (24 al giorno). Giornaliero: un pagamento all'inizio di ogni giorno. Cambia in ESC ├óÔÇáÔÇÖ Impostazioni ├óÔÇáÔÇÖ Income Mod.]]></it>
-            <cz><![CDATA[Hodinov├äÔÇ║: jedna platba ka├à┬¥dou hern├â┬¡ hodinu (24 za den). Denn├äÔÇ║: jedna platba na za├ä┬ì├â┬ítku ka├à┬¥d├â┬®ho dne. Zm├äÔÇ║├à╦åte v ESC ├óÔÇáÔÇÖ Nastaven├â┬¡ ├óÔÇáÔÇÖ Income Mod.]]></cz>
-            <br><![CDATA[Por hora: um pagamento por hora de jogo (24 ao dia). Di├â┬írio: um pagamento no in├â┬¡cio de cada dia. Mude em ESC ├óÔÇáÔÇÖ Configura├â┬º├â┬Áes ├óÔÇáÔÇÖ Income Mod.]]></br>
-            <uk><![CDATA[├É┼©├É┬¥├É┬│├É┬¥├É┬┤├É┬©├É┬¢├É┬¢├É┬¥: ├É┬¥├É┬┤├É┬¢├É┬░ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░ ├É┬║├É┬¥├É┬Â├É┬¢├æãÆ ├æÔÇô├É┬│├æÔé¼├É┬¥├É┬▓├æãÆ ├É┬│├É┬¥├É┬┤├É┬©├É┬¢├æãÆ (24 ├É┬¢├É┬░ ├É┬┤├É┬Á├É┬¢├æ┼Æ). ├É┬®├É┬¥├É┬┤├É┬Á├É┬¢├É┬¢├É┬¥: ├É┬¥├É┬┤├É┬¢├É┬░ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░ ├É┬¢├É┬░ ├É┬┐├É┬¥├æÔÇí├É┬░├æÔÇÜ├É┬║├æãÆ ├É┬║├É┬¥├É┬Â├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¢├æ┬Å. ├ÉÔÇö├É┬╝├æÔÇô├É┬¢├É┬©├æÔÇÜ├É┬©: ESC ├óÔÇáÔÇÖ ├É┬Ø├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å ├óÔÇáÔÇÖ Income Mod.]]></uk>
-            <ru><![CDATA[├É┼©├É┬¥├æÔÇí├É┬░├æ┬ü├É┬¥├É┬▓├É┬¥: ├É┬¥├É┬┤├É┬¢├É┬░ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░ ├É┬║├É┬░├É┬Â├É┬┤├æÔÇ╣├É┬╣ ├É┬©├É┬│├æÔé¼├É┬¥├É┬▓├É┬¥├É┬╣ ├æÔÇí├É┬░├æ┬ü (24 ├É┬▓ ├É┬┤├É┬Á├É┬¢├æ┼Æ). ├ÉÔÇó├É┬Â├É┬Á├É┬┤├É┬¢├É┬Á├É┬▓├É┬¢├É┬¥: ├É┬¥├É┬┤├É┬¢├É┬░ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░ ├É┬▓ ├É┬¢├É┬░├æÔÇí├É┬░├É┬╗├É┬Á ├É┬║├É┬░├É┬Â├É┬┤├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¢├æ┬Å. ├É┬í├É┬╝├É┬Á├É┬¢├É┬©├æÔÇÜ├É┬Á ├É┬▓ ESC ├óÔÇáÔÇÖ ├É┬Ø├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬© ├óÔÇáÔÇÖ Income Mod.]]></ru>
-            <da><![CDATA[Timevis: en betaling hver in-game time (24 pr. dag). Dagligt: en betaling ved starten af hver in-game dag. Skift n├â┬Ñr som helst via ESC ├óÔÇáÔÇÖ Indstillinger ├óÔÇáÔÇÖ Income Mod.]]></da>
+            <en><![CDATA[Hourly: one payment every in-game hour (24 per day). Daily: one payment at the start of each in-game day. Switch at any time via ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Settings â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></en>
+            <de><![CDATA[Stâ”œÃ¢â”¬â•ndlich: eine Zahlung pro Spielstunde (24 pro Tag). Tâ”œÃ¢â”¬Ã±glich: eine Zahlung zu Beginn jedes Spieltages. Jederzeit wechseln: ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Einstellungen â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Einkommens-Mod.]]></de>
+            <fr><![CDATA[Horaire : un paiement par heure de jeu (24 par jour). Quotidien : un paiement au dâ”œÃ¢â”¬Â®but de chaque journâ”œÃ¢â”¬Â®e. Changez via â”œÃ¢Ã”Ã‡â–‘chap â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Paramâ”œÃ¢â”¬Â¿tres â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></fr>
+            <pl><![CDATA[Godzinowy: jedna pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­ co godzinâ”œÃ¤Ã”Ã¤Ã³ gry (24 na dzieâ”œÃ Ã”Ã‡Ã—). Dzienny: jedna pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­ na poczâ”œÃ¤Ã”Ã‡Âªtku kaâ”œÃ â”¬â•dego dnia. Zmieâ”œÃ Ã”Ã‡Ã— w ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Ustawienia â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></pl>
+            <es><![CDATA[Horario: un pago por hora de juego (24 al dâ”œÃ¢â”¬Â¡a). Diario: un pago al inicio de cada dâ”œÃ¢â”¬Â¡a. Cambia en ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Ajustes â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></es>
+            <it><![CDATA[Orario: un pagamento ogni ora (24 al giorno). Giornaliero: un pagamento all'inizio di ogni giorno. Cambia in ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Impostazioni â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></it>
+            <cz><![CDATA[Hodinovâ”œÃ¤Ã”Ã‡â•‘: jedna platba kaâ”œÃ â”¬Â¥dou hernâ”œÃ¢â”¬Â¡ hodinu (24 za den). Dennâ”œÃ¤Ã”Ã‡â•‘: jedna platba na zaâ”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­tku kaâ”œÃ â”¬Â¥dâ”œÃ¢â”¬Â®ho dne. Zmâ”œÃ¤Ã”Ã‡â•‘â”œÃ â•¦Ã¥te v ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Nastavenâ”œÃ¢â”¬Â¡ â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></cz>
+            <br><![CDATA[Por hora: um pagamento por hora de jogo (24 ao dia). Diâ”œÃ¢â”¬Ã­rio: um pagamento no inâ”œÃ¢â”¬Â¡cio de cada dia. Mude em ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></br>
+            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† (24 â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†). â”œÃ‰â”¬Â®â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ¦Ã£Ã† â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…. â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬â•â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©: ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥: â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£ â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼ (24 â”œÃ‰â”¬â–“ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†). â”œÃ‰Ã”Ã‡Ã³â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬Ã â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…. â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â–“ ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></ru>
+            <da><![CDATA[Timevis: en betaling hver in-game time (24 pr. dag). Dagligt: en betaling ved starten af hver in-game dag. Skift nâ”œÃ¢â”¬Ã‘r som helst via ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Indstillinger â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></da>
         </text>
 
         <text name="im_help_p2_persist_title">
             <en><![CDATA[No Double-Payments]]></en>
             <de><![CDATA[Keine Doppelzahlungen]]></de>
             <fr><![CDATA[Pas de double paiement]]></fr>
-            <pl><![CDATA[Brak podw├â┬│jnych p├àÔÇÜatno├àÔÇ║ci]]></pl>
+            <pl><![CDATA[Brak podwâ”œÃ¢â”¬â”‚jnych pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci]]></pl>
             <es><![CDATA[Sin dobles pagos]]></es>
             <it><![CDATA[Nessun pagamento doppio]]></it>
-            <cz><![CDATA[├à┬¢├â┬ídn├â┬® dvojit├â┬® platby]]></cz>
+            <cz><![CDATA[â”œÃ â”¬Â¢â”œÃ¢â”¬Ã­dnâ”œÃ¢â”¬Â® dvojitâ”œÃ¢â”¬Â® platby]]></cz>
             <br><![CDATA[Sem pagamentos duplos]]></br>
-            <uk><![CDATA[├ÉÔÇÿ├É┬Á├É┬À ├É┬┐├É┬¥├É┬┤├É┬▓├æÔÇô├É┬╣├É┬¢├É┬©├æÔÇª ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ]]></uk>
-            <ru><![CDATA[├ÉÔÇÿ├É┬Á├É┬À ├É┬┤├É┬▓├É┬¥├É┬╣├É┬¢├æÔÇ╣├æÔÇª ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ]]></ru>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã¿â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Âª â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã¿â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Âª â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ]]></ru>
             <da><![CDATA[Ingen dobbelte betalinger]]></da>
         </text>
 
         <text name="im_help_p2_persist_text">
             <en><![CDATA[The last payment time is saved with your game. If you exit and reload, payments resume correctly. You will never be paid twice for the same hour or day.]]></en>
-            <de><![CDATA[Der letzte Zahlungszeitpunkt wird mit dem Spielstand gespeichert. Beim Neuladen werden Zahlungen korrekt fortgesetzt. Sie werden nie zweimal f├â┬╝r dieselbe Stunde oder denselben Tag bezahlt.]]></de>
-            <fr><![CDATA[Le dernier paiement est sauvegard├â┬® avec la partie. Au rechargement, les paiements reprennent correctement. Vous ne serez jamais pay├â┬® deux fois pour la m├â┬¬me heure ou le m├â┬¬me jour.]]></fr>
-            <pl><![CDATA[Ostatni czas p├àÔÇÜatno├àÔÇ║ci jest zapisywany z gr├äÔÇª. Po prze├àÔÇÜadowaniu p├àÔÇÜatno├àÔÇ║ci wznawiaj├äÔÇª si├äÔäó poprawnie. Nigdy nie otrzymasz podw├â┬│jnej p├àÔÇÜatno├àÔÇ║ci za t├äÔäó sam├äÔÇª godzin├äÔäó lub dzie├àÔÇ×.]]></pl>
-            <es><![CDATA[El ├â┬║ltimo pago se guarda con la partida. Al recargar, los pagos se reanudan correctamente. Nunca recibir├â┬ís dos pagos por la misma hora o d├â┬¡a.]]></es>
+            <de><![CDATA[Der letzte Zahlungszeitpunkt wird mit dem Spielstand gespeichert. Beim Neuladen werden Zahlungen korrekt fortgesetzt. Sie werden nie zweimal fâ”œÃ¢â”¬â•r dieselbe Stunde oder denselben Tag bezahlt.]]></de>
+            <fr><![CDATA[Le dernier paiement est sauvegardâ”œÃ¢â”¬Â® avec la partie. Au rechargement, les paiements reprennent correctement. Vous ne serez jamais payâ”œÃ¢â”¬Â® deux fois pour la mâ”œÃ¢â”¬Â¬me heure ou le mâ”œÃ¢â”¬Â¬me jour.]]></fr>
+            <pl><![CDATA[Ostatni czas pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci jest zapisywany z grâ”œÃ¤Ã”Ã‡Âª. Po przeâ”œÃ Ã”Ã‡Ãœadowaniu pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci wznawiajâ”œÃ¤Ã”Ã‡Âª siâ”œÃ¤Ã”Ã¤Ã³ poprawnie. Nigdy nie otrzymasz podwâ”œÃ¢â”¬â”‚jnej pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci za tâ”œÃ¤Ã”Ã¤Ã³ samâ”œÃ¤Ã”Ã‡Âª godzinâ”œÃ¤Ã”Ã¤Ã³ lub dzieâ”œÃ Ã”Ã‡Ã—.]]></pl>
+            <es><![CDATA[El â”œÃ¢â”¬â•‘ltimo pago se guarda con la partida. Al recargar, los pagos se reanudan correctamente. Nunca recibirâ”œÃ¢â”¬Ã­s dos pagos por la misma hora o dâ”œÃ¢â”¬Â¡a.]]></es>
             <it><![CDATA[L'ultimo pagamento viene salvato con la partita. Al ricaricamento i pagamenti riprendono correttamente. Non riceverai mai due pagamenti per la stessa ora o giorno.]]></it>
-            <cz><![CDATA[├ä┼Æas posledn├â┬¡ platby se ukl├â┬íd├â┬í se hrou. Po na├ä┬ìten├â┬¡ platby pokra├ä┬ìuj├â┬¡ spr├â┬ívn├äÔÇ║. Nikdy neobdr├à┬¥├â┬¡te dvojitou platbu za tut├â┬®├à┬¥ hodinu nebo den.]]></cz>
-            <br><![CDATA[O ├â┬║ltimo pagamento ├â┬® salvo com o jogo. Ao recarregar, os pagamentos retomam corretamente. Voc├â┬¬ nunca receber├â┬í dois pagamentos pela mesma hora ou dia.]]></br>
-            <uk><![CDATA[├É┬º├É┬░├æ┬ü ├É┬¥├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¢├æ┼Æ├É┬¥├æÔÇö ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬© ├É┬À├É┬▒├É┬Á├æÔé¼├æÔÇô├É┬│├É┬░├æÔÇØ├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├æÔé¼├É┬░├É┬À├É┬¥├É┬╝ ├É┬À ├É┬│├æÔé¼├É┬¥├æ┼¢. ├É┼©├æÔÇô├æ┬ü├É┬╗├æ┬Å ├É┬┐├É┬Á├æÔé¼├É┬Á├É┬À├É┬░├É┬▓├É┬░├É┬¢├æÔÇÜ├É┬░├É┬Â├É┬Á├É┬¢├É┬¢├æ┬Å ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬© ├É┬▓├æÔÇô├É┬┤├É┬¢├É┬¥├É┬▓├É┬╗├æ┼¢├æ┼¢├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├É┬┐├æÔé¼├É┬░├É┬▓├É┬©├É┬╗├æ┼Æ├É┬¢├É┬¥. ├ÉÔÇÖ├É┬© ├É┬¢├æÔÇô├É┬║├É┬¥├É┬╗├É┬© ├É┬¢├É┬Á ├É┬¥├æÔÇÜ├æÔé¼├É┬©├É┬╝├É┬░├æÔÇØ├æÔÇÜ├É┬Á ├É┬┐├É┬¥├É┬┤├É┬▓├æÔÇô├É┬╣├É┬¢├æãÆ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ ├É┬À├É┬░ ├É┬¥├É┬┤├É┬¢├æãÆ ├É┬╣ ├æÔÇÜ├æãÆ ├æ┬ü├É┬░├É┬╝├æãÆ ├É┬│├É┬¥├É┬┤├É┬©├É┬¢├æãÆ ├É┬░├É┬▒├É┬¥ ├É┬┤├É┬Á├É┬¢├æ┼Æ.]]></uk>
-            <ru><![CDATA[├ÉÔÇÖ├æÔé¼├É┬Á├É┬╝├æ┬Å ├É┬┐├É┬¥├æ┬ü├É┬╗├É┬Á├É┬┤├É┬¢├É┬Á├É┬╣ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣ ├æ┬ü├É┬¥├æÔÇª├æÔé¼├É┬░├É┬¢├æ┬Å├É┬Á├æÔÇÜ├æ┬ü├æ┬Å ├É┬▓├É┬╝├É┬Á├æ┬ü├æÔÇÜ├É┬Á ├æ┬ü ├É┬©├É┬│├æÔé¼├É┬¥├É┬╣. ├É┼©├æÔé¼├É┬© ├É┬┐├É┬Á├æÔé¼├É┬Á├É┬À├É┬░├É┬│├æÔé¼├æãÆ├É┬À├É┬║├É┬Á ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣ ├É┬▓├É┬¥├É┬À├É┬¥├É┬▒├É┬¢├É┬¥├É┬▓├É┬╗├æ┬Å├æ┼¢├æÔÇÜ├æ┬ü├æ┬Å ├É┬║├É┬¥├æÔé¼├æÔé¼├É┬Á├É┬║├æÔÇÜ├É┬¢├É┬¥. ├ÉÔÇÖ├æÔÇ╣ ├É┬¢├É┬©├É┬║├É┬¥├É┬│├É┬┤├É┬░ ├É┬¢├É┬Á ├É┬┐├É┬¥├É┬╗├æãÆ├æÔÇí├É┬©├æÔÇÜ├É┬Á ├É┬┤├É┬▓├É┬¥├É┬╣├É┬¢├æãÆ├æ┼¢ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ ├É┬À├É┬░ ├É┬¥├É┬┤├É┬©├É┬¢ ├É┬© ├æÔÇÜ├É┬¥├æÔÇÜ ├É┬Â├É┬Á ├æÔÇí├É┬░├æ┬ü ├É┬©├É┬╗├É┬© ├É┬┤├É┬Á├É┬¢├æ┼Æ.]]></ru>
-            <da><![CDATA[Det sidste betalingstidspunkt gemmes sammen med dit spil. Hvis du afslutter og genindl├â┬ªser, genoptages betalingerne korrekt. Du vil aldrig blive betalt to gange for den samme time eller dag.]]></da>
+            <cz><![CDATA[â”œÃ¤â”¼Ã†as poslednâ”œÃ¢â”¬Â¡ platby se uklâ”œÃ¢â”¬Ã­dâ”œÃ¢â”¬Ã­ se hrou. Po naâ”œÃ¤â”¬Ã¬tenâ”œÃ¢â”¬Â¡ platby pokraâ”œÃ¤â”¬Ã¬ujâ”œÃ¢â”¬Â¡ sprâ”œÃ¢â”¬Ã­vnâ”œÃ¤Ã”Ã‡â•‘. Nikdy neobdrâ”œÃ â”¬Â¥â”œÃ¢â”¬Â¡te dvojitou platbu za tutâ”œÃ¢â”¬Â®â”œÃ â”¬Â¥ hodinu nebo den.]]></cz>
+            <br><![CDATA[O â”œÃ¢â”¬â•‘ltimo pagamento â”œÃ¢â”¬Â® salvo com o jogo. Ao recarregar, os pagamentos retomam corretamente. Vocâ”œÃ¢â”¬Â¬ nunca receberâ”œÃ¢â”¬Ã­ dois pagamentos pela mesma hora ou dia.]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Âºâ”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼ â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã¶ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–’â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”‚â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â• â”œÃ‰â”¬Ã€ â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ¦â”¼Â¢. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥. â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ã â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ‰â”¬â•£ â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†.]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•£ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â–“â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ¦â”¬Ã¼ â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â© â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬Ã€â”œÃ‰â”¬â•‘â”œÃ‰â”¬Ã â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥. â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ã â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢ â”œÃ‰â”¬Â© â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ã â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼ â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†.]]></ru>
+            <da><![CDATA[Det sidste betalingstidspunkt gemmes sammen med dit spil. Hvis du afslutter og genindlâ”œÃ¢â”¬Âªser, genoptages betalingerne korrekt. Du vil aldrig blive betalt to gange for den samme time eller dag.]]></da>
         </text>
 
-        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page 3 ├óÔé¼ÔÇØ Income Settings ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
+        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page 3 â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Income Settings â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
         <text name="im_help_s1_enable_title">
             <en><![CDATA[Enable / Disable]]></en>
             <de><![CDATA[Aktivieren / Deaktivieren]]></de>
-            <fr><![CDATA[Activer / D├â┬®sactiver]]></fr>
-            <pl><![CDATA[W├àÔÇÜ├äÔÇªcz / Wy├àÔÇÜ├äÔÇªcz]]></pl>
+            <fr><![CDATA[Activer / Dâ”œÃ¢â”¬Â®sactiver]]></fr>
+            <pl><![CDATA[Wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz / Wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz]]></pl>
             <es><![CDATA[Activar / Desactivar]]></es>
             <it><![CDATA[Attiva / Disattiva]]></it>
-            <cz><![CDATA[Povolit / Zak├â┬ízat]]></cz>
+            <cz><![CDATA[Povolit / Zakâ”œÃ¢â”¬Ã­zat]]></cz>
             <br><![CDATA[Ativar / Desativar]]></br>
-            <uk><![CDATA[├É┬ú├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© / ├ÉÔÇÖ├É┬©├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬©]]></uk>
-            <ru><![CDATA[├ÉÔÇÖ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ / ├ÉÔÇÖ├æÔÇ╣├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© / â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† / â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†]]></ru>
             <da><![CDATA[Aktiver / Deaktiver]]></da>
         </text>
 
         <text name="im_help_s1_enable_text">
             <en><![CDATA[The master switch. When disabled, no income is paid and the HUD is hidden. Re-enabling resumes payments from the current in-game time.]]></en>
             <de><![CDATA[Der Hauptschalter. Wenn deaktiviert, werden keine Einnahmen ausgezahlt und der HUD ist ausgeblendet. Bei erneuter Aktivierung werden Zahlungen fortgesetzt.]]></de>
-            <fr><![CDATA[L'interrupteur principal. D├â┬®sactiv├â┬® : pas de revenu, HUD masqu├â┬®. R├â┬®activ├â┬® : les paiements reprennent ├â┬á partir du temps de jeu actuel.]]></fr>
-            <pl><![CDATA[G├àÔÇÜ├â┬│wny prze├àÔÇÜ├äÔÇªcznik. Gdy wy├àÔÇÜ├äÔÇªczony ├óÔé¼ÔÇØ brak dochod├â┬│w i HUD jest ukryty. Po ponownym w├àÔÇÜ├äÔÇªczeniu p├àÔÇÜatno├àÔÇ║ci wznawiaj├äÔÇª si├äÔäó od bie├à┬╝├äÔÇªcego czasu gry.]]></pl>
+            <fr><![CDATA[L'interrupteur principal. Dâ”œÃ¢â”¬Â®sactivâ”œÃ¢â”¬Â® : pas de revenu, HUD masquâ”œÃ¢â”¬Â®. Râ”œÃ¢â”¬Â®activâ”œÃ¢â”¬Â® : les paiements reprennent â”œÃ¢â”¬Ã¡ partir du temps de jeu actuel.]]></fr>
+            <pl><![CDATA[Gâ”œÃ Ã”Ã‡Ãœâ”œÃ¢â”¬â”‚wny przeâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcznik. Gdy wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczony â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ brak dochodâ”œÃ¢â”¬â”‚w i HUD jest ukryty. Po ponownym wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczeniu pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci wznawiajâ”œÃ¤Ã”Ã‡Âª siâ”œÃ¤Ã”Ã¤Ã³ od bieâ”œÃ â”¬â•â”œÃ¤Ã”Ã‡Âªcego czasu gry.]]></pl>
             <es><![CDATA[El interruptor principal. Desactivado: sin ingresos, HUD oculto. Al reactivar, los pagos se reanudan desde el tiempo de juego actual.]]></es>
             <it><![CDATA[L'interruttore principale. Disabilitato: nessun reddito, HUD nascosto. Riabilitato: i pagamenti riprendono dal tempo di gioco attuale.]]></it>
-            <cz><![CDATA[Hlavn├â┬¡ p├àÔäóep├â┬¡na├ä┬ì. Zak├â┬íz├â┬íno: ├à┬¥├â┬ídn├â┬¢ p├àÔäó├â┬¡jem, HUD je skryt├â┬¢. Po op├äÔÇ║tovn├â┬®m povolen├â┬¡ se platby obnov├â┬¡ od aktu├â┬íln├â┬¡ho hern├â┬¡ho ├ä┬ìasu.]]></cz>
+            <cz><![CDATA[Hlavnâ”œÃ¢â”¬Â¡ pâ”œÃ Ã”Ã¤Ã³epâ”œÃ¢â”¬Â¡naâ”œÃ¤â”¬Ã¬. Zakâ”œÃ¢â”¬Ã­zâ”œÃ¢â”¬Ã­no: â”œÃ â”¬Â¥â”œÃ¢â”¬Ã­dnâ”œÃ¢â”¬Â¢ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem, HUD je skrytâ”œÃ¢â”¬Â¢. Po opâ”œÃ¤Ã”Ã‡â•‘tovnâ”œÃ¢â”¬Â®m povolenâ”œÃ¢â”¬Â¡ se platby obnovâ”œÃ¢â”¬Â¡ od aktuâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡ho hernâ”œÃ¢â”¬Â¡ho â”œÃ¤â”¬Ã¬asu.]]></cz>
             <br><![CDATA[O interruptor principal. Desativado: sem renda, HUD oculto. Reativado: os pagamentos retomam do tempo de jogo atual.]]></br>
-            <uk><![CDATA[├ÉÔÇ£├É┬¥├É┬╗├É┬¥├É┬▓├É┬¢├É┬©├É┬╣ ├É┬┐├É┬Á├æÔé¼├É┬Á├É┬╝├É┬©├É┬║├É┬░├æÔÇí. ├ÉÔÇÖ├É┬©├É┬╝├É┬║├É┬¢├É┬Á├É┬¢├É┬¥: ├É┬¢├É┬Á├É┬╝├É┬░├æÔÇØ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ, HUD ├É┬┐├æÔé¼├É┬©├æÔÇª├É┬¥├É┬▓├É┬░├É┬¢├É┬©├É┬╣. ├É┼©├æÔé¼├É┬© ├É┬┐├É┬¥├É┬▓├æÔÇÜ├É┬¥├æÔé¼├É┬¢├É┬¥├É┬╝├æãÆ ├É┬▓├É┬╝├É┬©├É┬║├É┬░├É┬¢├É┬¢├æÔÇô ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬© ├É┬▓├æÔÇô├É┬┤├É┬¢├É┬¥├É┬▓├É┬╗├æ┼¢├æ┼¢├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├É┬À ├É┬┐├É┬¥├æÔÇÜ├É┬¥├æÔÇí├É┬¢├É┬¥├É┬│├É┬¥ ├æÔÇô├É┬│├æÔé¼├É┬¥├É┬▓├É┬¥├É┬│├É┬¥ ├æÔÇí├É┬░├æ┬ü├æãÆ.]]></uk>
-            <ru><![CDATA[├ÉÔÇ£├É┬╗├É┬░├É┬▓├É┬¢├æÔÇ╣├É┬╣ ├É┬┐├É┬Á├æÔé¼├É┬Á├É┬║├É┬╗├æ┼¢├æÔÇí├É┬░├æÔÇÜ├É┬Á├É┬╗├æ┼Æ. ├É┼¥├æÔÇÜ├É┬║├É┬╗├æ┼¢├æÔÇí├æÔÇÿ├É┬¢: ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤ ├É┬¢├É┬Á ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇí├É┬©├É┬▓├É┬░├É┬Á├æÔÇÜ├æ┬ü├æ┬Å, HUD ├æ┬ü├É┬║├æÔé¼├æÔÇ╣├æÔÇÜ. ├É┼©├æÔé¼├É┬© ├É┬┐├É┬¥├É┬▓├æÔÇÜ├É┬¥├æÔé¼├É┬¢├É┬¥├É┬╝ ├É┬▓├É┬║├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬¢├É┬©├É┬© ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣ ├É┬▓├É┬¥├É┬À├É┬¥├É┬▒├É┬¢├É┬¥├É┬▓├É┬╗├æ┬Å├æ┼¢├æÔÇÜ├æ┬ü├æ┬Å ├æ┬ü ├æÔÇÜ├É┬Á├É┬║├æãÆ├æÔÇ░├É┬Á├É┬│├É┬¥ ├É┬©├É┬│├æÔé¼├É┬¥├É┬▓├É┬¥├É┬│├É┬¥ ├É┬▓├æÔé¼├É┬Á├É┬╝├É┬Á├É┬¢├É┬©.]]></ru>
-            <da><![CDATA[Den hoveds├â┬ªtning. N├â┬Ñr deaktiveret, bliver der ikke betalt noget indkomst og HUD er skjult. Genaktivering genoptager betalinger fra det nuv├â┬ªrende in-game tidspunkt.]]></da>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Â£â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã­. â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†, HUD â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â© â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬â•â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬Ã€ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†.]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Â£â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†. â”œÃ‰â”¼Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã”Ã‡Ã¿â”œÃ‰â”¬Â¢: â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ã â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã…, HUD â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ãœ. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â© â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â• â”œÃ‰â”¬â–“â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼ â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©.]]></ru>
+            <da><![CDATA[Den hovedsâ”œÃ¢â”¬Âªtning. Nâ”œÃ¢â”¬Ã‘r deaktiveret, bliver der ikke betalt noget indkomst og HUD er skjult. Genaktivering genoptager betalinger fra det nuvâ”œÃ¢â”¬Âªrende in-game tidspunkt.]]></da>
         </text>
 
         <text name="im_help_s1_mode_title">
             <en><![CDATA[Pay Mode]]></en>
             <de><![CDATA[Zahlungsmodus]]></de>
             <fr><![CDATA[Mode de paiement]]></fr>
-            <pl><![CDATA[Tryb p├àÔÇÜatno├àÔÇ║ci]]></pl>
+            <pl><![CDATA[Tryb pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci]]></pl>
             <es><![CDATA[Modo de pago]]></es>
-            <it><![CDATA[Modalit├â┬á pagamento]]></it>
-            <cz><![CDATA[Platebn├â┬¡ re├à┬¥im]]></cz>
+            <it><![CDATA[Modalitâ”œÃ¢â”¬Ã¡ pagamento]]></it>
+            <cz><![CDATA[Platebnâ”œÃ¢â”¬Â¡ reâ”œÃ â”¬Â¥im]]></cz>
             <br><![CDATA[Modo de pagamento]]></br>
-            <uk><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ]]></uk>
-            <ru><![CDATA[├É┬á├É┬Á├É┬Â├É┬©├É┬╝ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ]]></ru>
             <da><![CDATA[Betalingstyper]]></da>
         </text>
 
         <text name="im_help_s1_mode_text">
             <en><![CDATA[Hourly pays 24 times per in-game day. Daily pays once per day. Hourly gives steady small payments; daily gives larger, less frequent ones. Both modes suit all playstyles.]]></en>
-            <de><![CDATA[St├â┬╝ndlich: 24 Zahlungen pro Tag. T├â┬ñglich: einmal pro Tag. St├â┬╝ndlich bietet gleichm├â┬ñ├â┼©ige kleine Zahlungen; t├â┬ñglich gr├â┬Â├â┼©ere, seltenere. Beide Modi sind f├â┬╝r alle Spielstile geeignet.]]></de>
-            <fr><![CDATA[Horaire : 24 paiements par jour. Quotidien : une fois par jour. Horaire donne des petits paiements r├â┬®guliers ; quotidien des paiements plus grands et moins fr├â┬®quents.]]></fr>
-            <pl><![CDATA[Godzinowy: 24 p├àÔÇÜatno├àÔÇ║ci na dzie├àÔÇ×. Dzienny: raz na dzie├àÔÇ×. Godzinowy daje ma├àÔÇÜe, regularne p├àÔÇÜatno├àÔÇ║ci; dzienny ├óÔé¼ÔÇØ wi├äÔäóksze, rzadsze. Oba tryby pasuj├äÔÇª do ka├à┬╝dego stylu gry.]]></pl>
-            <es><![CDATA[Horario: 24 pagos por d├â┬¡a. Diario: una vez al d├â┬¡a. Horario da pagos peque├â┬▒os regulares; diario da pagos m├â┬ís grandes y menos frecuentes. Ambos modos se adaptan a todos los estilos.]]></es>
-            <it><![CDATA[Orario: 24 pagamenti al giorno. Giornaliero: una volta al giorno. Orario d├â┬á pagamenti piccoli regolari; giornaliero d├â┬á pagamenti pi├â┬╣ grandi e meno frequenti.]]></it>
-            <cz><![CDATA[Hodinov├äÔÇ║: 24 plateb za den. Denn├äÔÇ║: jednou za den. Hodinov├äÔÇ║ p├àÔäóin├â┬í├à┬í├â┬¡ pravideln├â┬® mal├â┬® platby; denn├äÔÇ║ v├äÔÇ║t├à┬í├â┬¡, m├â┬®n├äÔÇ║ ├ä┬ìast├â┬®. Oba re├à┬¥imy se hod├â┬¡ pro v├à┬íechny styly hry.]]></cz>
-            <br><![CDATA[Por hora: 24 pagamentos por dia. Di├â┬írio: uma vez ao dia. Por hora d├â┬í pagamentos pequenos e regulares; di├â┬írio d├â┬í pagamentos maiores e menos frequentes.]]></br>
-            <uk><![CDATA[├É┼©├É┬¥├É┬│├É┬¥├É┬┤├É┬©├É┬¢├É┬¢├É┬¥: 24 ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬© ├É┬¢├É┬░ ├É┬┤├É┬Á├É┬¢├æ┼Æ. ├É┬®├É┬¥├É┬┤├É┬Á├É┬¢├É┬¢├É┬¥: ├æÔé¼├É┬░├É┬À ├É┬¢├É┬░ ├É┬┤├É┬Á├É┬¢├æ┼Æ. ├É┼©├É┬¥├É┬│├É┬¥├É┬┤├É┬©├É┬¢├É┬¢├É┬¥ ├É┬┤├É┬░├æÔÇØ ├É┬¢├É┬Á├É┬▓├É┬Á├É┬╗├É┬©├É┬║├æÔÇô ├æÔé¼├É┬Á├É┬│├æãÆ├É┬╗├æ┬Å├æÔé¼├É┬¢├æÔÇô ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬©; ├æÔÇ░├É┬¥├É┬┤├É┬Á├É┬¢├É┬¢├É┬¥ ├óÔé¼ÔÇØ ├É┬▒├æÔÇô├É┬╗├æ┼Æ├æ╦å├æÔÇô, ├É┬░├É┬╗├É┬Á ├æÔé¼├æÔÇô├É┬┤├æ╦å├æÔÇô. ├É┼¥├É┬▒├É┬©├É┬┤├É┬▓├É┬░ ├æÔé¼├É┬Á├É┬Â├É┬©├É┬╝├É┬© ├É┬┐├æÔÇô├É┬┤├æÔÇª├É┬¥├É┬┤├æ┬Å├æÔÇÜ├æ┼Æ ├É┬┤├É┬╗├æ┬Å ├É┬▒├æãÆ├É┬┤├æ┼Æ-├æ┬Å├É┬║├É┬¥├É┬│├É┬¥ ├æ┬ü├æÔÇÜ├É┬©├É┬╗├æ┼¢ ├É┬│├æÔé¼├É┬©.]]></uk>
-            <ru><![CDATA[├É┼©├É┬¥├æÔÇí├É┬░├æ┬ü├É┬¥├É┬▓├É┬¥: 24 ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣ ├É┬▓ ├É┬┤├É┬Á├É┬¢├æ┼Æ. ├ÉÔÇó├É┬Â├É┬Á├É┬┤├É┬¢├É┬Á├É┬▓├É┬¢├É┬¥: ├æÔé¼├É┬░├É┬À ├É┬▓ ├É┬┤├É┬Á├É┬¢├æ┼Æ. ├É┼©├É┬¥├æÔÇí├É┬░├æ┬ü├É┬¥├É┬▓├É┬¥ ├É┬┤├É┬░├æÔÇÿ├æÔÇÜ ├É┬¢├É┬Á├É┬▒├É┬¥├É┬╗├æ┼Æ├æ╦å├É┬©├É┬Á ├æÔé¼├É┬Á├É┬│├æãÆ├É┬╗├æ┬Å├æÔé¼├É┬¢├æÔÇ╣├É┬Á ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇ╣; ├É┬Á├É┬Â├É┬Á├É┬┤├É┬¢├É┬Á├É┬▓├É┬¢├É┬¥ ├óÔé¼ÔÇØ ├É┬▒├É┬¥├É┬╗├æ┼Æ├æ╦å├É┬©├É┬Á, ├É┬¢├É┬¥ ├æÔé¼├É┬Á├É┬┤├É┬║├É┬©├É┬Á. ├É┼¥├É┬▒├É┬░ ├æÔé¼├É┬Á├É┬Â├É┬©├É┬╝├É┬░ ├É┬┐├É┬¥├É┬┤├æÔÇª├É┬¥├É┬┤├æ┬Å├æÔÇÜ ├É┬┤├É┬╗├æ┬Å ├É┬╗├æ┼¢├É┬▒├É┬¥├É┬│├É┬¥ ├æ┬ü├æÔÇÜ├É┬©├É┬╗├æ┬Å ├É┬©├É┬│├æÔé¼├æÔÇ╣.]]></ru>
-            <da><![CDATA[Timevis: 24 betalinger pr. in-game time. Dagligt: en betaling ved starten af hver in-game dag. Skift n├â┬Ñr som helst via ESC ├óÔÇáÔÇÖ Indstillinger ├óÔÇáÔÇÖ Income Mod.]]></da>
+            <de><![CDATA[Stâ”œÃ¢â”¬â•ndlich: 24 Zahlungen pro Tag. Tâ”œÃ¢â”¬Ã±glich: einmal pro Tag. Stâ”œÃ¢â”¬â•ndlich bietet gleichmâ”œÃ¢â”¬Ã±â”œÃ¢â”¼Â©ige kleine Zahlungen; tâ”œÃ¢â”¬Ã±glich grâ”œÃ¢â”¬Ã‚â”œÃ¢â”¼Â©ere, seltenere. Beide Modi sind fâ”œÃ¢â”¬â•r alle Spielstile geeignet.]]></de>
+            <fr><![CDATA[Horaire : 24 paiements par jour. Quotidien : une fois par jour. Horaire donne des petits paiements râ”œÃ¢â”¬Â®guliers ; quotidien des paiements plus grands et moins frâ”œÃ¢â”¬Â®quents.]]></fr>
+            <pl><![CDATA[Godzinowy: 24 pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci na dzieâ”œÃ Ã”Ã‡Ã—. Dzienny: raz na dzieâ”œÃ Ã”Ã‡Ã—. Godzinowy daje maâ”œÃ Ã”Ã‡Ãœe, regularne pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci; dzienny â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ wiâ”œÃ¤Ã”Ã¤Ã³ksze, rzadsze. Oba tryby pasujâ”œÃ¤Ã”Ã‡Âª do kaâ”œÃ â”¬â•dego stylu gry.]]></pl>
+            <es><![CDATA[Horario: 24 pagos por dâ”œÃ¢â”¬Â¡a. Diario: una vez al dâ”œÃ¢â”¬Â¡a. Horario da pagos pequeâ”œÃ¢â”¬â–’os regulares; diario da pagos mâ”œÃ¢â”¬Ã­s grandes y menos frecuentes. Ambos modos se adaptan a todos los estilos.]]></es>
+            <it><![CDATA[Orario: 24 pagamenti al giorno. Giornaliero: una volta al giorno. Orario dâ”œÃ¢â”¬Ã¡ pagamenti piccoli regolari; giornaliero dâ”œÃ¢â”¬Ã¡ pagamenti piâ”œÃ¢â”¬â•£ grandi e meno frequenti.]]></it>
+            <cz><![CDATA[Hodinovâ”œÃ¤Ã”Ã‡â•‘: 24 plateb za den. Dennâ”œÃ¤Ã”Ã‡â•‘: jednou za den. Hodinovâ”œÃ¤Ã”Ã‡â•‘ pâ”œÃ Ã”Ã¤Ã³inâ”œÃ¢â”¬Ã­â”œÃ â”¬Ã­â”œÃ¢â”¬Â¡ pravidelnâ”œÃ¢â”¬Â® malâ”œÃ¢â”¬Â® platby; dennâ”œÃ¤Ã”Ã‡â•‘ vâ”œÃ¤Ã”Ã‡â•‘tâ”œÃ â”¬Ã­â”œÃ¢â”¬Â¡, mâ”œÃ¢â”¬Â®nâ”œÃ¤Ã”Ã‡â•‘ â”œÃ¤â”¬Ã¬astâ”œÃ¢â”¬Â®. Oba reâ”œÃ â”¬Â¥imy se hodâ”œÃ¢â”¬Â¡ pro vâ”œÃ â”¬Ã­echny styly hry.]]></cz>
+            <br><![CDATA[Por hora: 24 pagamentos por dia. Diâ”œÃ¢â”¬Ã­rio: uma vez ao dia. Por hora dâ”œÃ¢â”¬Ã­ pagamentos pequenos e regulares; diâ”œÃ¢â”¬Ã­rio dâ”œÃ¢â”¬Ã­ pagamentos maiores e menos frequentes.]]></br>
+            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: 24 â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†. â”œÃ‰â”¬Â®â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†. â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ã´ â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©; â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ã´, â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬Ã â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ã´. â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬Â©â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘ â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦â”¬Ã…â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â–’â”œÃ¦Ã£Ã†â”œÃ‰â”¬â”¤â”œÃ¦â”¼Ã†-â”œÃ¦â”¬Ã…â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©.]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥: 24 â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬â–“ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†. â”œÃ‰Ã”Ã‡Ã³â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€ â”œÃ‰â”¬â–“ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†. â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã¿â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬Ã â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£; â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã, â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã. â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘ â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦â”¬Ã…â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡â•£.]]></ru>
+            <da><![CDATA[Timevis: 24 betalinger pr. in-game time. Dagligt: en betaling ved starten af hver in-game dag. Skift nâ”œÃ¢â”¬Ã‘r som helst via ESC â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Indstillinger â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Income Mod.]]></da>
         </text>
 
         <text name="im_help_s1_diff_title">
             <en><![CDATA[Difficulty]]></en>
             <de><![CDATA[Schwierigkeit]]></de>
-            <fr><![CDATA[Difficult├â┬®]]></fr>
-            <pl><![CDATA[Trudno├àÔÇ║├äÔÇí]]></pl>
+            <fr><![CDATA[Difficultâ”œÃ¢â”¬Â®]]></fr>
+            <pl><![CDATA[Trudnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­]]></pl>
             <es><![CDATA[Dificultad]]></es>
-            <it><![CDATA[Difficolt├â┬á]]></it>
-            <cz><![CDATA[Obt├â┬¡├à┬¥nost]]></cz>
+            <it><![CDATA[Difficoltâ”œÃ¢â”¬Ã¡]]></it>
+            <cz><![CDATA[Obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nost]]></cz>
             <br><![CDATA[Dificuldade]]></br>
-            <uk><![CDATA[├É┬í├É┬║├É┬╗├É┬░├É┬┤├É┬¢├æÔÇô├æ┬ü├æÔÇÜ├æ┼Æ]]></uk>
-            <ru><![CDATA[├É┬í├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æ┼Æ]]></ru>
-            <da><![CDATA[Sv├â┬ªrhedsgrad]]></da>
+            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†]]></ru>
+            <da><![CDATA[Svâ”œÃ¢â”¬Âªrhedsgrad]]></da>
         </text>
 
         <text name="im_help_s1_diff_text">
             <en><![CDATA[Sets the base income per payment. Easy: $5,000. Normal: $2,400. Hard: $1,100. These are base amounts before any multiplier or seasonal modifier is applied.]]></en>
-            <de><![CDATA[Legt den Basiseinkommensbetrag fest. Einfach: 5.000$. Normal: 2.400$. Schwer: 1.100$. Das sind Grundbetr├â┬ñge vor jeglichem Multiplikator oder saisonalem Modifikator.]]></de>
-            <fr><![CDATA[D├â┬®finit le revenu de base par paiement. Facile : 5 000$. Normal : 2 400$. Difficile : 1 100$. Ce sont des montants de base avant tout multiplicateur ou modificateur saisonnier.]]></fr>
-            <pl><![CDATA[Ustawia podstawow├äÔÇª kwot├äÔäó za p├àÔÇÜatno├àÔÇ║├äÔÇí. ├à┬üatwy: 5 000$. Normalny: 2 400$. Trudny: 1 100$. S├äÔÇª to kwoty bazowe przed zastosowaniem mno├à┬╝nika lub modyfikatora sezonowego.]]></pl>
-            <es><![CDATA[Define el ingreso base por pago. F├â┬ícil: $5.000. Normal: $2.400. Dif├â┬¡cil: $1.100. Estos son montos base antes de cualquier multiplicador o modificador estacional.]]></es>
+            <de><![CDATA[Legt den Basiseinkommensbetrag fest. Einfach: 5.000$. Normal: 2.400$. Schwer: 1.100$. Das sind Grundbetrâ”œÃ¢â”¬Ã±ge vor jeglichem Multiplikator oder saisonalem Modifikator.]]></de>
+            <fr><![CDATA[Dâ”œÃ¢â”¬Â®finit le revenu de base par paiement. Facile : 5 000$. Normal : 2 400$. Difficile : 1 100$. Ce sont des montants de base avant tout multiplicateur ou modificateur saisonnier.]]></fr>
+            <pl><![CDATA[Ustawia podstawowâ”œÃ¤Ã”Ã‡Âª kwotâ”œÃ¤Ã”Ã¤Ã³ za pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­. â”œÃ â”¬Ã¼atwy: 5 000$. Normalny: 2 400$. Trudny: 1 100$. Sâ”œÃ¤Ã”Ã‡Âª to kwoty bazowe przed zastosowaniem mnoâ”œÃ â”¬â•nika lub modyfikatora sezonowego.]]></pl>
+            <es><![CDATA[Define el ingreso base por pago. Fâ”œÃ¢â”¬Ã­cil: $5.000. Normal: $2.400. Difâ”œÃ¢â”¬Â¡cil: $1.100. Estos son montos base antes de cualquier multiplicador o modificador estacional.]]></es>
             <it><![CDATA[Imposta il reddito base per pagamento. Facile: $5.000. Normale: $2.400. Difficile: $1.100. Sono importi base prima di qualsiasi moltiplicatore o modificatore stagionale.]]></it>
-            <cz><![CDATA[Nastavuje z├â┬íkladn├â┬¡ p├àÔäó├â┬¡jem za platbu. Snadn├â┬®: 5 000$. Norm├â┬íln├â┬¡: 2 400$. T├äÔÇ║├à┬¥k├â┬®: 1 100$. Jde o z├â┬íkladn├â┬¡ ├ä┬ì├â┬ístky p├àÔäóed jak├â┬¢mkoli multiplik├â┬ítorem nebo sez├â┬│nn├â┬¡m modifik├â┬ítorem.]]></cz>
-            <br><![CDATA[Define a renda base por pagamento. F├â┬ícil: $5.000. Normal: $2.400. Dif├â┬¡cil: $1.100. S├â┬úo valores base antes de qualquer multiplicador ou modificador sazonal.]]></br>
-            <uk><![CDATA[├ÉÔÇÖ├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¥├É┬▓├É┬╗├æ┼¢├æÔÇØ ├É┬▒├É┬░├É┬À├É┬¥├É┬▓├É┬©├É┬╣ ├É┬┤├É┬¥├æÔÇª├æÔÇô├É┬┤ ├É┬À├É┬░ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ. ├ÉÔÇ║├É┬Á├É┬│├É┬║├É┬¥: $5 000. ├É┬Ø├É┬¥├æÔé¼├É┬╝├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥: $2 400. ├ÉÔÇÖ├É┬░├É┬Â├É┬║├É┬¥: $1 100. ├É┬ª├É┬Á ├É┬▒├É┬░├É┬À├É┬¥├É┬▓├æÔÇô ├æ┬ü├æãÆ├É┬╝├É┬© ├É┬┤├É┬¥ ├É┬À├É┬░├æ┬ü├æÔÇÜ├É┬¥├æ┬ü├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å ├É┬▒├æãÆ├É┬┤├æ┼Æ-├æ┬Å├É┬║├É┬¥├É┬│├É┬¥ ├É┬╝├É┬¢├É┬¥├É┬Â├É┬¢├É┬©├É┬║├É┬░ ├É┬░├É┬▒├É┬¥ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬¥├É┬│├É┬¥ ├É┬╝├É┬¥├É┬┤├É┬©├æÔÇ×├æÔÇô├É┬║├É┬░├æÔÇÜ├É┬¥├æÔé¼├É┬░.]]></uk>
-            <ru><![CDATA[├É┬ú├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬░├É┬▓├É┬╗├É┬©├É┬▓├É┬░├É┬Á├æÔÇÜ ├É┬▒├É┬░├É┬À├É┬¥├É┬▓├æÔÇ╣├É┬╣ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤ ├É┬À├É┬░ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ. ├ÉÔÇ║├É┬Á├É┬│├É┬║├É┬¥: $5 000. ├É┼¥├É┬▒├æÔÇ╣├æÔÇí├É┬¢├É┬¥: $2 400. ├É┬í├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥: $1 100. ├É┬¡├æÔÇÜ├É┬¥ ├É┬▒├É┬░├É┬À├É┬¥├É┬▓├æÔÇ╣├É┬Á ├æ┬ü├æãÆ├É┬╝├É┬╝├æÔÇ╣ ├É┬┤├É┬¥ ├É┬┐├æÔé¼├É┬©├É┬╝├É┬Á├É┬¢├É┬Á├É┬¢├É┬©├æ┬Å ├É┬╝├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┬Å ├É┬©├É┬╗├É┬© ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬¥├É┬│├É┬¥ ├É┬╝├É┬¥├É┬┤├É┬©├æÔÇ×├É┬©├É┬║├É┬░├æÔÇÜ├É┬¥├æÔé¼├É┬░.]]></ru>
-            <da><![CDATA[Indstiller den grundl├â┬ªggende indkomst pr. betaling. Let: $5.000. Normal: $2.400. Sv├â┬ªr: $1.100. Dette er grundbel├â┬©b f├â┬©r nogen multiplikator eller s├â┬ªsonm├â┬ªssig modifikator anvendes.]]></da>
+            <cz><![CDATA[Nastavuje zâ”œÃ¢â”¬Ã­kladnâ”œÃ¢â”¬Â¡ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem za platbu. Snadnâ”œÃ¢â”¬Â®: 5 000$. Normâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡: 2 400$. Tâ”œÃ¤Ã”Ã‡â•‘â”œÃ â”¬Â¥kâ”œÃ¢â”¬Â®: 1 100$. Jde o zâ”œÃ¢â”¬Ã­kladnâ”œÃ¢â”¬Â¡ â”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­stky pâ”œÃ Ã”Ã¤Ã³ed jakâ”œÃ¢â”¬Â¢mkoli multiplikâ”œÃ¢â”¬Ã­torem nebo sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡m modifikâ”œÃ¢â”¬Ã­torem.]]></cz>
+            <br><![CDATA[Define a renda base por pagamento. Fâ”œÃ¢â”¬Ã­cil: $5.000. Normal: $2.400. Difâ”œÃ¢â”¬Â¡cil: $1.100. Sâ”œÃ¢â”¬Ãºo valores base antes de qualquer multiplicador ou modificador sazonal.]]></br>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†. â”œÃ‰Ã”Ã‡â•‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥: $5 000. â”œÃ‰â”¬Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: $2 400. â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥: $1 100. â”œÃ‰â”¬Âªâ”œÃ‰â”¬Ã â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬â–’â”œÃ¦Ã£Ã†â”œÃ‰â”¬â”¤â”œÃ¦â”¼Ã†-â”œÃ¦â”¬Ã…â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â•â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã—â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘.]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†. â”œÃ‰Ã”Ã‡â•‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥: $5 000. â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: $2 400. â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥: $1 100. â”œÃ‰â”¬Â¡â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬Ã â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘.]]></ru>
+            <da><![CDATA[Indstiller den grundlâ”œÃ¢â”¬Âªggende indkomst pr. betaling. Let: $5.000. Normal: $2.400. Svâ”œÃ¢â”¬Âªr: $1.100. Dette er grundbelâ”œÃ¢â”¬Â©b fâ”œÃ¢â”¬Â©r nogen multiplikator eller sâ”œÃ¢â”¬Âªsonmâ”œÃ¢â”¬Âªssig modifikator anvendes.]]></da>
         </text>
 
-        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page 4 ├óÔé¼ÔÇØ Advanced Settings ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
+        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page 4 â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Advanced Settings â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
         <text name="im_help_s2_mult_title">
             <en><![CDATA[Income Multiplier]]></en>
             <de><![CDATA[Einkommensmultiplikator]]></de>
             <fr><![CDATA[Multiplicateur de revenu]]></fr>
-            <pl><![CDATA[Mno├à┬╝nik dochodu]]></pl>
+            <pl><![CDATA[Mnoâ”œÃ â”¬â•nik dochodu]]></pl>
             <es><![CDATA[Multiplicador de ingresos]]></es>
             <it><![CDATA[Moltiplicatore reddito]]></it>
-            <cz><![CDATA[P├àÔäó├â┬¡jmov├â┬¢ multiplik├â┬ítor]]></cz>
+            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmovâ”œÃ¢â”¬Â¢ multiplikâ”œÃ¢â”¬Ã­tor]]></cz>
             <br><![CDATA[Multiplicador de renda]]></br>
-            <uk><![CDATA[├É┼ô├É┬¢├É┬¥├É┬Â├É┬¢├É┬©├É┬║ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
-            <ru><![CDATA[├É┼ô├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┼Æ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
             <da><![CDATA[Indkomstmultiplikator]]></da>
         </text>
 
         <text name="im_help_s2_mult_text">
-            <en><![CDATA[Scales all income by 1x, 2x, 5x, or 10x. Applied after difficulty, before seasonal. Example: Normal ($2,400) ├âÔÇö 5x = $12,000 per payment. Great for creative or boosted playthroughs.]]></en>
-            <de><![CDATA[Skaliert alle Einnahmen um 1x, 2x, 5x oder 10x. Wird nach Schwierigkeit, vor Saison angewendet. Beispiel: Normal (2.400$) ├âÔÇö 5x = 12.000$ pro Zahlung.]]></de>
-            <fr><![CDATA[Multiplie tous les revenus par 1x, 2x, 5x ou 10x. Appliqu├â┬® apr├â┬¿s la difficult├â┬®, avant le saisonnier. Exemple : Normal (2 400$) ├âÔÇö 5x = 12 000$ par paiement.]]></fr>
-            <pl><![CDATA[Skaluje wszystkie dochody 1x, 2x, 5x lub 10x. Stosowany po trudno├àÔÇ║ci, przed sezonem. Przyk├àÔÇÜad: Normalny (2 400$) ├âÔÇö 5x = 12 000$ za p├àÔÇÜatno├àÔÇ║├äÔÇí.]]></pl>
-            <es><![CDATA[Escala los ingresos por 1x, 2x, 5x o 10x. Aplicado tras la dificultad, antes del estacional. Ejemplo: Normal ($2.400) ├âÔÇö 5x = $12.000 por pago.]]></es>
-            <it><![CDATA[Moltiplica il reddito per 1x, 2x, 5x o 10x. Applicato dopo la difficolt├â┬á, prima del stagionale. Esempio: Normale ($2.400) ├âÔÇö 5x = $12.000 per pagamento.]]></it>
-            <cz><![CDATA[├à┬ák├â┬íluje p├àÔäó├â┬¡jmy 1x, 2x, 5x nebo 10x. Aplikuje se po obt├â┬¡├à┬¥nosti, p├àÔäóed sez├â┬│nou. P├àÔäó├â┬¡klad: Norm├â┬íln├â┬¡ (2 400$) ├âÔÇö 5x = 12 000$ za platbu.]]></cz>
-            <br><![CDATA[Escala a renda em 1x, 2x, 5x ou 10x. Aplicado ap├â┬│s a dificuldade, antes do sazonal. Exemplo: Normal ($2.400) ├âÔÇö 5x = $12.000 por pagamento.]]></br>
-            <uk><![CDATA[├É┼ô├É┬░├æ┬ü├æ╦å├æÔÇÜ├É┬░├É┬▒├æãÆ├æÔÇØ ├É┬▓├É┬Á├æ┬ü├æ┼Æ ├É┬┤├É┬¥├æÔÇª├æÔÇô├É┬┤ ├É┬¢├É┬░ 1x, 2x, 5x ├É┬░├É┬▒├É┬¥ 10x. ├ÉÔÇö├É┬░├æ┬ü├æÔÇÜ├É┬¥├æ┬ü├É┬¥├É┬▓├æãÆ├æÔÇØ├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├É┬┐├æÔÇô├æ┬ü├É┬╗├æ┬Å ├æ┬ü├É┬║├É┬╗├É┬░├É┬┤├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æÔÇô, ├É┬┐├É┬Á├æÔé¼├É┬Á├É┬┤ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬©├É┬╝. ├É┼©├æÔé¼├É┬©├É┬║├É┬╗├É┬░├É┬┤: ├É┬Ø├É┬¥├æÔé¼├É┬╝├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥ ($2 400) ├âÔÇö 5x = $12 000 ├É┬À├É┬░ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ.]]></uk>
-            <ru><![CDATA[├É┼ô├É┬░├æ┬ü├æ╦å├æÔÇÜ├É┬░├É┬▒├É┬©├æÔé¼├æãÆ├É┬Á├æÔÇÜ ├É┬▓├É┬Á├æ┬ü├æ┼Æ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤ ├É┬¢├É┬░ 1x, 2x, 5x ├É┬©├É┬╗├É┬© 10x. ├É┼©├æÔé¼├É┬©├É┬╝├É┬Á├É┬¢├æ┬Å├É┬Á├æÔÇÜ├æ┬ü├æ┬Å ├É┬┐├É┬¥├æ┬ü├É┬╗├É┬Á ├æ┬ü├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├É┬©, ├É┬┤├É┬¥ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬¥├É┬│├É┬¥. ├É┼©├æÔé¼├É┬©├É┬╝├É┬Á├æÔé¼: ├É┼¥├É┬▒├æÔÇ╣├æÔÇí├É┬¢├É┬¥ ($2 400) ├âÔÇö 5x = $12 000 ├É┬À├É┬░ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ.]]></ru>
-            <da><![CDATA[Skalerer al indkomst med 1x, 2x, 5x eller 10x. Anvendes efter sv├â┬ªrhedsgrad, f├â┬©r s├â┬ªson. Eksempel: Normal ($2.400) ├âÔÇö 5x = $12.000 pr. betaling.]]></da>
+            <en><![CDATA[Scales all income by 1x, 2x, 5x, or 10x. Applied after difficulty, before seasonal. Example: Normal ($2,400) â”œÃ¢Ã”Ã‡Ã¶ 5x = $12,000 per payment. Great for creative or boosted playthroughs.]]></en>
+            <de><![CDATA[Skaliert alle Einnahmen um 1x, 2x, 5x oder 10x. Wird nach Schwierigkeit, vor Saison angewendet. Beispiel: Normal (2.400$) â”œÃ¢Ã”Ã‡Ã¶ 5x = 12.000$ pro Zahlung.]]></de>
+            <fr><![CDATA[Multiplie tous les revenus par 1x, 2x, 5x ou 10x. Appliquâ”œÃ¢â”¬Â® aprâ”œÃ¢â”¬Â¿s la difficultâ”œÃ¢â”¬Â®, avant le saisonnier. Exemple : Normal (2 400$) â”œÃ¢Ã”Ã‡Ã¶ 5x = 12 000$ par paiement.]]></fr>
+            <pl><![CDATA[Skaluje wszystkie dochody 1x, 2x, 5x lub 10x. Stosowany po trudnoâ”œÃ Ã”Ã‡â•‘ci, przed sezonem. Przykâ”œÃ Ã”Ã‡Ãœad: Normalny (2 400$) â”œÃ¢Ã”Ã‡Ã¶ 5x = 12 000$ za pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­.]]></pl>
+            <es><![CDATA[Escala los ingresos por 1x, 2x, 5x o 10x. Aplicado tras la dificultad, antes del estacional. Ejemplo: Normal ($2.400) â”œÃ¢Ã”Ã‡Ã¶ 5x = $12.000 por pago.]]></es>
+            <it><![CDATA[Moltiplica il reddito per 1x, 2x, 5x o 10x. Applicato dopo la difficoltâ”œÃ¢â”¬Ã¡, prima del stagionale. Esempio: Normale ($2.400) â”œÃ¢Ã”Ã‡Ã¶ 5x = $12.000 per pagamento.]]></it>
+            <cz><![CDATA[â”œÃ â”¬Ã¡kâ”œÃ¢â”¬Ã­luje pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmy 1x, 2x, 5x nebo 10x. Aplikuje se po obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nosti, pâ”œÃ Ã”Ã¤Ã³ed sezâ”œÃ¢â”¬â”‚nou. Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡klad: Normâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡ (2 400$) â”œÃ¢Ã”Ã‡Ã¶ 5x = 12 000$ za platbu.]]></cz>
+            <br><![CDATA[Escala a renda em 1x, 2x, 5x ou 10x. Aplicado apâ”œÃ¢â”¬â”‚s a dificuldade, antes do sazonal. Exemplo: Normal ($2.400) â”œÃ¢Ã”Ã‡Ã¶ 5x = $12.000 por pagamento.]]></br>
+            <uk><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ¦â”¼Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ 1x, 2x, 5x â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ 10x. â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã´, â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤: â”œÃ‰â”¬Ã˜â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ ($2 400) â”œÃ¢Ã”Ã‡Ã¶ 5x = $12 000 â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†.]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Ã´â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ¦â”¼Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ 1x, 2x, 5x â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© 10x. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ã â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©, â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼: â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ ($2 400) â”œÃ¢Ã”Ã‡Ã¶ 5x = $12 000 â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†.]]></ru>
+            <da><![CDATA[Skalerer al indkomst med 1x, 2x, 5x eller 10x. Anvendes efter svâ”œÃ¢â”¬Âªrhedsgrad, fâ”œÃ¢â”¬Â©r sâ”œÃ¢â”¬Âªson. Eksempel: Normal ($2.400) â”œÃ¢Ã”Ã‡Ã¶ 5x = $12.000 pr. betaling.]]></da>
         </text>
 
         <text name="im_help_s2_seasonal_title">
@@ -1148,56 +1148,56 @@
             <pl><![CDATA[Efekty sezonowe]]></pl>
             <es><![CDATA[Efectos estacionales]]></es>
             <it><![CDATA[Effetti stagionali]]></it>
-            <cz><![CDATA[Sez├â┬│nn├â┬¡ efekty]]></cz>
+            <cz><![CDATA[Sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡ efekty]]></cz>
             <br><![CDATA[Efeitos sazonais]]></br>
-            <uk><![CDATA[├É┬í├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├æÔÇô ├É┬Á├æÔÇ×├É┬Á├É┬║├æÔÇÜ├É┬©]]></uk>
-            <ru><![CDATA[├É┬í├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├æÔÇ╣├É┬Á ├æ┬ì├æÔÇ×├æÔÇ×├É┬Á├É┬║├æÔÇÜ├æÔÇ╣]]></ru>
-            <da><![CDATA[S├â┬ªsonale effekter]]></da>
+            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬Ã â”œÃ¦â”¬Ã¬â”œÃ¦Ã”Ã‡Ã—â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡â•£]]></ru>
+            <da><![CDATA[Sâ”œÃ¢â”¬Âªsonale effekter]]></da>
         </text>
 
         <text name="im_help_s2_seasonal_text">
             <en><![CDATA[When enabled, a seasonal modifier is applied. Spring: 0.8x. Summer: 1.0x. Autumn: 1.2x (peak). Winter: 0.7x (off-season). Disabled by default.]]></en>
-            <de><![CDATA[Wenn aktiviert, wird ein saisonaler Modifikator angewendet. Fr├â┬╝hling: 0,8x. Sommer: 1,0x. Herbst: 1,2x (H├â┬Âhepunkt). Winter: 0,7x. Standardm├â┬ñ├â┼©ig deaktiviert.]]></de>
-            <fr><![CDATA[Quand activ├â┬®, un modificateur saisonnier est appliqu├â┬®. Printemps : 0,8x. ├âÔÇ░t├â┬® : 1,0x. Automne : 1,2x (pic). Hiver : 0,7x (hors-saison). D├â┬®sactiv├â┬® par d├â┬®faut.]]></fr>
-            <pl><![CDATA[Po w├àÔÇÜ├äÔÇªczeniu stosowany jest modyfikator sezonowy. Wiosna: 0,8x. Lato: 1,0x. Jesie├àÔÇ×: 1,2x (szczyt). Zima: 0,7x. Domy├àÔÇ║lnie wy├àÔÇÜ├äÔÇªczone.]]></pl>
-            <es><![CDATA[Cuando est├â┬í habilitado se aplica un modificador estacional. Primavera: 0,8x. Verano: 1,0x. Oto├â┬▒o: 1,2x (pico). Invierno: 0,7x. Desactivado por defecto.]]></es>
+            <de><![CDATA[Wenn aktiviert, wird ein saisonaler Modifikator angewendet. Frâ”œÃ¢â”¬â•hling: 0,8x. Sommer: 1,0x. Herbst: 1,2x (Hâ”œÃ¢â”¬Ã‚hepunkt). Winter: 0,7x. Standardmâ”œÃ¢â”¬Ã±â”œÃ¢â”¼Â©ig deaktiviert.]]></de>
+            <fr><![CDATA[Quand activâ”œÃ¢â”¬Â®, un modificateur saisonnier est appliquâ”œÃ¢â”¬Â®. Printemps : 0,8x. â”œÃ¢Ã”Ã‡â–‘tâ”œÃ¢â”¬Â® : 1,0x. Automne : 1,2x (pic). Hiver : 0,7x (hors-saison). Dâ”œÃ¢â”¬Â®sactivâ”œÃ¢â”¬Â® par dâ”œÃ¢â”¬Â®faut.]]></fr>
+            <pl><![CDATA[Po wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczeniu stosowany jest modyfikator sezonowy. Wiosna: 0,8x. Lato: 1,0x. Jesieâ”œÃ Ã”Ã‡Ã—: 1,2x (szczyt). Zima: 0,7x. Domyâ”œÃ Ã”Ã‡â•‘lnie wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczone.]]></pl>
+            <es><![CDATA[Cuando estâ”œÃ¢â”¬Ã­ habilitado se aplica un modificador estacional. Primavera: 0,8x. Verano: 1,0x. Otoâ”œÃ¢â”¬â–’o: 1,2x (pico). Invierno: 0,7x. Desactivado por defecto.]]></es>
             <it><![CDATA[Quando abilitato, viene applicato un modificatore stagionale. Primavera: 0,8x. Estate: 1,0x. Autunno: 1,2x (picco). Inverno: 0,7x. Disabilitato per default.]]></it>
-            <cz><![CDATA[Kdy├à┬¥ je povoleno, pou├à┬¥ije se sez├â┬│nn├â┬¡ modifik├â┬ítor. Jaro: 0,8x. L├â┬®to: 1,0x. Podzim: 1,2x (vrchol). Zima: 0,7x. Ve v├â┬¢choz├â┬¡m nastaven├â┬¡ zak├â┬íz├â┬íno.]]></cz>
-            <br><![CDATA[Quando ativado, um modificador sazonal ├â┬® aplicado. Primavera: 0,8x. Ver├â┬úo: 1,0x. Outono: 1,2x (pico). Inverno: 0,7x. Desativado por padr├â┬úo.]]></br>
-            <uk><![CDATA[├É┼í├É┬¥├É┬╗├É┬© ├æãÆ├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├É┬Á├É┬¢├É┬¥, ├É┬À├É┬░├æ┬ü├æÔÇÜ├É┬¥├æ┬ü├É┬¥├É┬▓├æãÆ├æÔÇØ├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬©├É┬╣ ├É┬╝├É┬¥├É┬┤├É┬©├æÔÇ×├æÔÇô├É┬║├É┬░├æÔÇÜ├É┬¥├æÔé¼. ├ÉÔÇÖ├É┬Á├æ┬ü├É┬¢├É┬░: 0,8x. ├ÉÔÇ║├æÔÇô├æÔÇÜ├É┬¥: 1,0x. ├É┼¥├æ┬ü├æÔÇô├É┬¢├æ┼Æ: 1,2x (├É┬┐├æÔÇô├É┬║). ├ÉÔÇö├É┬©├É┬╝├É┬░: 0,7x. ├ÉÔÇö├É┬░ ├É┬À├É┬░├É┬╝├É┬¥├É┬▓├æÔÇí├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å├É┬╝ ├É┬▓├É┬©├É┬╝├É┬║├É┬¢├É┬Á├É┬¢├É┬¥.]]></uk>
-            <ru><![CDATA[├É┼í├É┬¥├É┬│├É┬┤├É┬░ ├É┬▓├É┬║├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬¢├É┬¥, ├É┬┐├æÔé¼├É┬©├É┬╝├É┬Á├É┬¢├æ┬Å├É┬Á├æÔÇÜ├æ┬ü├æ┬Å ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├æÔÇ╣├É┬╣ ├É┬╝├É┬¥├É┬┤├É┬©├æÔÇ×├É┬©├É┬║├É┬░├æÔÇÜ├É┬¥├æÔé¼. ├ÉÔÇÖ├É┬Á├æ┬ü├É┬¢├É┬░: 0,8x. ├ÉÔÇ║├É┬Á├æÔÇÜ├É┬¥: 1,0x. ├É┼¥├æ┬ü├É┬Á├É┬¢├æ┼Æ: 1,2x (├É┬┐├É┬©├É┬║). ├ÉÔÇö├É┬©├É┬╝├É┬░: 0,7x. ├É┼©├É┬¥ ├æãÆ├É┬╝├É┬¥├É┬╗├æÔÇí├É┬░├É┬¢├É┬©├æ┼¢ ├É┬¥├æÔÇÜ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬¢├É┬¥.]]></ru>
-            <da><![CDATA[N├â┬Ñr aktiveret, anvendes en s├â┬ªsonm├â┬ªssig modifikator. For├â┬Ñr: 0,8x. Sommer: 1,0x. Efter├â┬Ñr: 1,2x (top). Vinter: 0,7x. Deaktiveret som standard.]]></da>
+            <cz><![CDATA[Kdyâ”œÃ â”¬Â¥ je povoleno, pouâ”œÃ â”¬Â¥ije se sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡ modifikâ”œÃ¢â”¬Ã­tor. Jaro: 0,8x. Lâ”œÃ¢â”¬Â®to: 1,0x. Podzim: 1,2x (vrchol). Zima: 0,7x. Ve vâ”œÃ¢â”¬Â¢chozâ”œÃ¢â”¬Â¡m nastavenâ”œÃ¢â”¬Â¡ zakâ”œÃ¢â”¬Ã­zâ”œÃ¢â”¬Ã­no.]]></cz>
+            <br><![CDATA[Quando ativado, um modificador sazonal â”œÃ¢â”¬Â® aplicado. Primavera: 0,8x. Verâ”œÃ¢â”¬Ãºo: 1,0x. Outono: 1,2x (pico). Inverno: 0,7x. Desativado por padrâ”œÃ¢â”¬Ãºo.]]></br>
+            <uk><![CDATA[â”œÃ‰â”¼Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥, â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã—â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼. â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘: 0,8x. â”œÃ‰Ã”Ã‡â•‘â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥: 1,0x. â”œÃ‰â”¼Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†: 1,2x (â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•‘). â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘: 0,7x. â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬â• â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥.]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥, â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼. â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘: 0,8x. â”œÃ‰Ã”Ã‡â•‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥: 1,0x. â”œÃ‰â”¼Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†: 1,2x (â”œÃ‰â”¬â”â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘). â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘: 0,7x. â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥ â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¼Â¢ â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥.]]></ru>
+            <da><![CDATA[Nâ”œÃ¢â”¬Ã‘r aktiveret, anvendes en sâ”œÃ¢â”¬Âªsonmâ”œÃ¢â”¬Âªssig modifikator. Forâ”œÃ¢â”¬Ã‘r: 0,8x. Sommer: 1,0x. Efterâ”œÃ¢â”¬Ã‘r: 1,2x (top). Vinter: 0,7x. Deaktiveret som standard.]]></da>
         </text>
 
         <text name="im_help_s2_custom_title">
             <en><![CDATA[Custom Amount]]></en>
             <de><![CDATA[Benutzerdefinierter Betrag]]></de>
-            <fr><![CDATA[Montant personnalis├â┬®]]></fr>
+            <fr><![CDATA[Montant personnalisâ”œÃ¢â”¬Â®]]></fr>
             <pl><![CDATA[Niestandardowa kwota]]></pl>
             <es><![CDATA[Cantidad personalizada]]></es>
             <it><![CDATA[Importo personalizzato]]></it>
-            <cz><![CDATA[Vlastn├â┬¡ ├ä┬ì├â┬ístka]]></cz>
+            <cz><![CDATA[Vlastnâ”œÃ¢â”¬Â¡ â”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­stka]]></cz>
             <br><![CDATA[Valor personalizado]]></br>
-            <uk><![CDATA[├ÉÔÇÖ├É┬╗├É┬░├æ┬ü├É┬¢├É┬░ ├æ┬ü├æãÆ├É┬╝├É┬░]]></uk>
-            <ru><![CDATA[├É┼©├É┬¥├É┬╗├æ┼Æ├É┬À├É┬¥├É┬▓├É┬░├æÔÇÜ├É┬Á├É┬╗├æ┼Æ├æ┬ü├É┬║├É┬░├æ┬Å ├æ┬ü├æãÆ├É┬╝├É┬╝├É┬░]]></ru>
-            <da><![CDATA[Brugerdefineret bel├â┬©b]]></da>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘]]></ru>
+            <da><![CDATA[Brugerdefineret belâ”œÃ¢â”¬Â©b]]></da>
         </text>
 
         <text name="im_help_s2_custom_text">
             <en><![CDATA[Override the difficulty amount with a fixed value via console: IncomeSetCustomAmount 3000. Set to 0 to return to the difficulty-based amount. The multiplier still applies on top.]]></en>
-            <de><![CDATA[├â┼ôberschreibt den Schwierigkeitsbetrag per Konsole: IncomeSetCustomAmount 3000. Auf 0 setzen, um zur schwierigkeitsbezogenen Menge zur├â┬╝ckzukehren. Der Multiplikator gilt weiterhin.]]></de>
-            <fr><![CDATA[Remplace le montant de difficult├â┬® via console : IncomeSetCustomAmount 3000. Mettre 0 pour revenir au montant de difficult├â┬®. Le multiplicateur s'applique toujours par-dessus.]]></fr>
-            <pl><![CDATA[Zast├äÔäópuje kwot├äÔäó trudno├àÔÇ║ci przez konsol├äÔäó: IncomeSetCustomAmount 3000. Ustaw 0, aby wr├â┬│ci├äÔÇí do kwoty opartej na trudno├àÔÇ║ci. Mno├à┬╝nik nadal obowi├äÔÇªzuje.]]></pl>
-            <es><![CDATA[Anula el monto de dificultad via consola: IncomeSetCustomAmount 3000. Establece 0 para volver al monto por dificultad. El multiplicador a├â┬║n se aplica encima.]]></es>
-            <it><![CDATA[Sostituisce l'importo di difficolt├â┬á via console: IncomeSetCustomAmount 3000. Imposta 0 per tornare all'importo basato sulla difficolt├â┬á. Il moltiplicatore si applica comunque.]]></it>
-            <cz><![CDATA[P├àÔäóep├â┬¡├à┬íe obt├â┬¡├à┬¥nostn├â┬¡ ├ä┬ì├â┬ístku p├àÔäóes konzoli: IncomeSetCustomAmount 3000. Nastavte 0 pro n├â┬ívrat k obt├â┬¡├à┬¥nostn├â┬¡ ├ä┬ì├â┬ístce. Multiplik├â┬ítor se st├â┬íle pou├à┬¥ije.]]></cz>
+            <de><![CDATA[â”œÃ¢â”¼Ã´berschreibt den Schwierigkeitsbetrag per Konsole: IncomeSetCustomAmount 3000. Auf 0 setzen, um zur schwierigkeitsbezogenen Menge zurâ”œÃ¢â”¬â•ckzukehren. Der Multiplikator gilt weiterhin.]]></de>
+            <fr><![CDATA[Remplace le montant de difficultâ”œÃ¢â”¬Â® via console : IncomeSetCustomAmount 3000. Mettre 0 pour revenir au montant de difficultâ”œÃ¢â”¬Â®. Le multiplicateur s'applique toujours par-dessus.]]></fr>
+            <pl><![CDATA[Zastâ”œÃ¤Ã”Ã¤Ã³puje kwotâ”œÃ¤Ã”Ã¤Ã³ trudnoâ”œÃ Ã”Ã‡â•‘ci przez konsolâ”œÃ¤Ã”Ã¤Ã³: IncomeSetCustomAmount 3000. Ustaw 0, aby wrâ”œÃ¢â”¬â”‚ciâ”œÃ¤Ã”Ã‡Ã­ do kwoty opartej na trudnoâ”œÃ Ã”Ã‡â•‘ci. Mnoâ”œÃ â”¬â•nik nadal obowiâ”œÃ¤Ã”Ã‡Âªzuje.]]></pl>
+            <es><![CDATA[Anula el monto de dificultad via consola: IncomeSetCustomAmount 3000. Establece 0 para volver al monto por dificultad. El multiplicador aâ”œÃ¢â”¬â•‘n se aplica encima.]]></es>
+            <it><![CDATA[Sostituisce l'importo di difficoltâ”œÃ¢â”¬Ã¡ via console: IncomeSetCustomAmount 3000. Imposta 0 per tornare all'importo basato sulla difficoltâ”œÃ¢â”¬Ã¡. Il moltiplicatore si applica comunque.]]></it>
+            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³epâ”œÃ¢â”¬Â¡â”œÃ â”¬Ã­e obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nostnâ”œÃ¢â”¬Â¡ â”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­stku pâ”œÃ Ã”Ã¤Ã³es konzoli: IncomeSetCustomAmount 3000. Nastavte 0 pro nâ”œÃ¢â”¬Ã­vrat k obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nostnâ”œÃ¢â”¬Â¡ â”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­stce. Multiplikâ”œÃ¢â”¬Ã­tor se stâ”œÃ¢â”¬Ã­le pouâ”œÃ â”¬Â¥ije.]]></cz>
             <br><![CDATA[Substitui o valor de dificuldade via console: IncomeSetCustomAmount 3000. Defina 0 para voltar ao valor de dificuldade. O multiplicador ainda se aplica.]]></br>
-            <uk><![CDATA[├ÉÔÇö├É┬░├É┬╝├æÔÇô├É┬¢├æ┼¢├æÔÇØ ├æ┬ü├æãÆ├É┬╝├æãÆ ├æ┬ü├É┬║├É┬╗├É┬░├É┬┤├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æÔÇô ├æÔÇí├É┬Á├æÔé¼├É┬Á├É┬À ├É┬║├É┬¥├É┬¢├æ┬ü├É┬¥├É┬╗├æ┼Æ: IncomeSetCustomAmount 3000. ├ÉÔÇÖ├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¥├É┬▓├æÔÇô├æÔÇÜ├æ┼Æ 0 ├É┬┤├É┬╗├æ┬Å ├É┬┐├É┬¥├É┬▓├É┬Á├æÔé¼├É┬¢├É┬Á├É┬¢├É┬¢├æ┬Å ├É┬┤├É┬¥ ├æ┬ü├æãÆ├É┬╝├É┬© ├É┬¢├É┬░ ├É┬¥├æ┬ü├É┬¢├É┬¥├É┬▓├æÔÇô ├æ┬ü├É┬║├É┬╗├É┬░├É┬┤├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æÔÇô. ├É┼ô├É┬¢├É┬¥├É┬Â├É┬¢├É┬©├É┬║ ├É┬▓├æ┬ü├É┬Á ├É┬¥├É┬┤├É┬¢├É┬¥ ├É┬À├É┬░├æ┬ü├æÔÇÜ├É┬¥├æ┬ü├É┬¥├É┬▓├æãÆ├æÔÇØ├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å.]]></uk>
-            <ru><![CDATA[├ÉÔÇö├É┬░├É┬╝├É┬Á├É┬¢├æ┬Å├É┬Á├æÔÇÜ ├æ┬ü├æãÆ├É┬╝├É┬╝├æãÆ ├æ┬ü├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├É┬© ├æÔÇí├É┬Á├æÔé¼├É┬Á├É┬À ├É┬║├É┬¥├É┬¢├æ┬ü├É┬¥├É┬╗├æ┼Æ: IncomeSetCustomAmount 3000. ├É┬ú├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¥├É┬▓├É┬©├æÔÇÜ├É┬Á 0 ├É┬┤├É┬╗├æ┬Å ├É┬▓├É┬¥├É┬À├É┬▓├æÔé¼├É┬░├æÔÇÜ├É┬░ ├É┬║ ├æ┬ü├æãÆ├É┬╝├É┬╝├É┬Á ├æ┬ü├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├É┬©. ├É┼ô├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┼Æ ├É┬▓├æ┬ü├æÔÇÿ ├æÔé¼├É┬░├É┬▓├É┬¢├É┬¥ ├É┬┐├æÔé¼├É┬©├É┬╝├É┬Á├É┬¢├æ┬Å├É┬Á├æÔÇÜ├æ┬ü├æ┬Å.]]></ru>
-            <da><![CDATA[Erstatter sv├â┬ªrhedsgradsbel├â┬©bet via konsol: IncomeSetCustomAmount 3000. Indstil 0 for at vende tilbage til sv├â┬ªrhedsgradsbel├â┬©bet. Multiplikatoren anvendes stadig.]]></da>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¢â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã˜ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã´ â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€ â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†: IncomeSetCustomAmount 3000. â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† 0 â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã´. â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘ â”œÃ‰â”¬â–“â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ã â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã….]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€ â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†: IncomeSetCustomAmount 3000. â”œÃ‰â”¬Ãºâ”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã 0 â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬â•‘ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ‰â”¬Ã â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©. â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã† â”œÃ‰â”¬â–“â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã¿ â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã….]]></ru>
+            <da><![CDATA[Erstatter svâ”œÃ¢â”¬Âªrhedsgradsbelâ”œÃ¢â”¬Â©bet via konsol: IncomeSetCustomAmount 3000. Indstil 0 for at vende tilbage til svâ”œÃ¢â”¬Âªrhedsgradsbelâ”œÃ¢â”¬Â©bet. Multiplikatoren anvendes stadig.]]></da>
         </text>
 
-        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page 5 ├óÔé¼ÔÇØ Display & Reset ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
+        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page 5 â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Display & Reset â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
         <text name="im_help_s3_hud_title">
             <en><![CDATA[Income HUD]]></en>
             <de><![CDATA[Einkommens-HUD]]></de>
@@ -1205,25 +1205,25 @@
             <pl><![CDATA[HUD dochodu]]></pl>
             <es><![CDATA[HUD de ingresos]]></es>
             <it><![CDATA[HUD reddito]]></it>
-            <cz><![CDATA[HUD p├àÔäó├â┬¡jm├à┬»]]></cz>
+            <cz><![CDATA[HUD pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â»]]></cz>
             <br><![CDATA[HUD de renda]]></br>
-            <uk><![CDATA[HUD ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
-            <ru><![CDATA[HUD ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
+            <uk><![CDATA[HUD â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
+            <ru><![CDATA[HUD â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
             <da><![CDATA[Indkomst-HUD]]></da>
         </text>
 
         <text name="im_help_s3_hud_text">
             <en><![CDATA[Shows your income rate, mode, difficulty, multiplier, seasonal status, next payment time, and last 5 payments. Toggle with the I key or disable permanently in Settings.]]></en>
-            <de><![CDATA[Zeigt Einkommensh├â┬Âhe, Modus, Schwierigkeit, Multiplikator, Saisonstatus, n├â┬ñchste Zahlung und die letzten 5 Zahlungen. Mit I umschalten oder in Einstellungen dauerhaft deaktivieren.]]></de>
-            <fr><![CDATA[Affiche revenu, mode, difficult├â┬®, multiplicateur, ├â┬®tat saisonnier, prochain paiement et 5 derniers paiements. Touche I pour basculer ou d├â┬®sactiver dans Param├â┬¿tres.]]></fr>
-            <pl><![CDATA[Pokazuje doch├â┬│d, tryb, trudno├àÔÇ║├äÔÇí, mno├à┬╝nik, status sezonowy, nast├äÔäópn├äÔÇª p├àÔÇÜatno├àÔÇ║├äÔÇí i 5 ostatnich p├àÔÇÜatno├àÔÇ║ci. Prze├àÔÇÜ├äÔÇªcz klawiszem I lub wy├àÔÇÜ├äÔÇªcz w ustawieniach.]]></pl>
-            <es><![CDATA[Muestra ingreso, modo, dificultad, multiplicador, estado estacional, pr├â┬│ximo pago y ├â┬║ltimos 5 pagos. Tecla I para alternar o desactivar en Ajustes.]]></es>
-            <it><![CDATA[Mostra reddito, modalit├â┬á, difficolt├â┬á, moltiplicatore, stato stagionale, prossimo pagamento e ultimi 5 pagamenti. Tasto I per alternare o disabilitare nelle Impostazioni.]]></it>
-            <cz><![CDATA[Zobrazuje p├àÔäó├â┬¡jem, re├à┬¥im, obt├â┬¡├à┬¥nost, multiplik├â┬ítor, sez├â┬│nn├â┬¡ stav, p├àÔäó├â┬¡├à┬ít├â┬¡ platbu a posledn├â┬¡ch 5 plateb. Kl├â┬ívesou I p├àÔäóepn├äÔÇ║te nebo trvale zaka├à┬¥te v Nastaven├â┬¡.]]></cz>
-            <br><![CDATA[Mostra renda, modo, dificuldade, multiplicador, status sazonal, pr├â┬│ximo pagamento e ├â┬║ltimos 5 pagamentos. Tecla I para alternar ou desativar nas Configura├â┬º├â┬Áes.]]></br>
-            <uk><![CDATA[├É┼©├É┬¥├É┬║├É┬░├É┬À├æãÆ├æÔÇØ ├É┬┤├É┬¥├æÔÇª├æÔÇô├É┬┤, ├æÔé¼├É┬Á├É┬Â├É┬©├É┬╝, ├æ┬ü├É┬║├É┬╗├É┬░├É┬┤├É┬¢├æÔÇô├æ┬ü├æÔÇÜ├æ┼Æ, ├É┬╝├É┬¢├É┬¥├É┬Â├É┬¢├É┬©├É┬║, ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬©├É┬╣ ├æ┬ü├æÔÇÜ├É┬░├æÔÇÜ├æãÆ├æ┬ü, ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æãÆ├É┬┐├É┬¢├æãÆ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ ├æÔÇÜ├É┬░ 5 ├É┬¥├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¢├æÔÇô├æÔÇª ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ. ├É┼í├É┬╗├É┬░├É┬▓├æÔÇô├æ╦å├É┬░ I ├É┬┤├É┬╗├æ┬Å ├É┬┐├É┬Á├æÔé¼├É┬Á├É┬╝├É┬©├É┬║├É┬░├É┬¢├É┬¢├æ┬Å ├É┬░├É┬▒├É┬¥ ├É┬▓├É┬©├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© ├É┬▓ ├É┬Ø├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å├æÔÇª.]]></uk>
-            <ru><![CDATA[├É┼©├É┬¥├É┬║├É┬░├É┬À├æÔÇ╣├É┬▓├É┬░├É┬Á├æÔÇÜ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤, ├æÔé¼├É┬Á├É┬Â├É┬©├É┬╝, ├æ┬ü├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æ┼Æ, ├É┬╝├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┼Æ, ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├æÔÇ╣├É┬╣ ├æ┬ü├æÔÇÜ├É┬░├æÔÇÜ├æãÆ├æ┬ü, ├æ┬ü├É┬╗├É┬Á├É┬┤├æãÆ├æ┼¢├æÔÇ░├æãÆ├æ┼¢ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ ├É┬© ├É┬┐├É┬¥├æ┬ü├É┬╗├É┬Á├É┬┤├É┬¢├É┬©├É┬Á 5 ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ. ├É┼í├É┬╗├É┬░├É┬▓├É┬©├æ╦å├É┬░ I ├É┬┤├É┬╗├æ┬Å ├É┬┐├É┬Á├æÔé¼├É┬Á├É┬║├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬¢├É┬©├æ┬Å ├É┬©├É┬╗├É┬© ├É┬¥├æÔÇÜ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├æ┼Æ ├É┬▓ ├É┬Ø├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬░├æÔÇª.]]></ru>
-            <da><![CDATA[Viser indkomst, tilstand, sv├â┬ªrhedsgrad, multiplikator, s├â┬ªsonstatus, n├â┬ªste betaling og de sidste 5 betalinger. Tasten I for at skifte eller deaktivere i Indstillinger.]]></da>
+            <de><![CDATA[Zeigt Einkommenshâ”œÃ¢â”¬Ã‚he, Modus, Schwierigkeit, Multiplikator, Saisonstatus, nâ”œÃ¢â”¬Ã±chste Zahlung und die letzten 5 Zahlungen. Mit I umschalten oder in Einstellungen dauerhaft deaktivieren.]]></de>
+            <fr><![CDATA[Affiche revenu, mode, difficultâ”œÃ¢â”¬Â®, multiplicateur, â”œÃ¢â”¬Â®tat saisonnier, prochain paiement et 5 derniers paiements. Touche I pour basculer ou dâ”œÃ¢â”¬Â®sactiver dans Paramâ”œÃ¢â”¬Â¿tres.]]></fr>
+            <pl><![CDATA[Pokazuje dochâ”œÃ¢â”¬â”‚d, tryb, trudnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­, mnoâ”œÃ â”¬â•nik, status sezonowy, nastâ”œÃ¤Ã”Ã¤Ã³pnâ”œÃ¤Ã”Ã‡Âª pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­ i 5 ostatnich pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci. Przeâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz klawiszem I lub wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz w ustawieniach.]]></pl>
+            <es><![CDATA[Muestra ingreso, modo, dificultad, multiplicador, estado estacional, prâ”œÃ¢â”¬â”‚ximo pago y â”œÃ¢â”¬â•‘ltimos 5 pagos. Tecla I para alternar o desactivar en Ajustes.]]></es>
+            <it><![CDATA[Mostra reddito, modalitâ”œÃ¢â”¬Ã¡, difficoltâ”œÃ¢â”¬Ã¡, moltiplicatore, stato stagionale, prossimo pagamento e ultimi 5 pagamenti. Tasto I per alternare o disabilitare nelle Impostazioni.]]></it>
+            <cz><![CDATA[Zobrazuje pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem, reâ”œÃ â”¬Â¥im, obtâ”œÃ¢â”¬Â¡â”œÃ â”¬Â¥nost, multiplikâ”œÃ¢â”¬Ã­tor, sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡ stav, pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡â”œÃ â”¬Ã­tâ”œÃ¢â”¬Â¡ platbu a poslednâ”œÃ¢â”¬Â¡ch 5 plateb. Klâ”œÃ¢â”¬Ã­vesou I pâ”œÃ Ã”Ã¤Ã³epnâ”œÃ¤Ã”Ã‡â•‘te nebo trvale zakaâ”œÃ â”¬Â¥te v Nastavenâ”œÃ¢â”¬Â¡.]]></cz>
+            <br><![CDATA[Mostra renda, modo, dificuldade, multiplicador, status sazonal, prâ”œÃ¢â”¬â”‚ximo pagamento e â”œÃ¢â”¬â•‘ltimos 5 pagamentos. Tecla I para alternar ou desativar nas Configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães.]]></br>
+            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤, â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â•, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†, â”œÃ‰â”¬â•â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ¦â”¬Ã¼, â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â”â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ 5 â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Âª â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ. â”œÃ‰â”¼Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘ I â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â–“ â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ¦Ã”Ã‡Âª.]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤, â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â•, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†, â”œÃ‰â”¬â•â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â•£ â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ¦â”¬Ã¼, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡â–‘â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ‰â”¬Â© â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã 5 â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ. â”œÃ‰â”¼Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘ I â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â©â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â–“ â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª.]]></ru>
+            <da><![CDATA[Viser indkomst, tilstand, svâ”œÃ¢â”¬Âªrhedsgrad, multiplikator, sâ”œÃ¢â”¬Âªsonstatus, nâ”œÃ¢â”¬Âªste betaling og de sidste 5 betalinger. Tasten I for at skifte eller deaktivere i Indstillinger.]]></da>
         </text>
 
         <text name="im_help_s3_notify_title">
@@ -1233,196 +1233,196 @@
             <pl><![CDATA[Powiadomienia]]></pl>
             <es><![CDATA[Notificaciones]]></es>
             <it><![CDATA[Notifiche]]></it>
-            <cz><![CDATA[Upozorn├äÔÇ║n├â┬¡]]></cz>
-            <br><![CDATA[Notifica├â┬º├â┬Áes]]></br>
-            <uk><![CDATA[├É┬í├É┬┐├É┬¥├É┬▓├æÔÇô├æÔÇ░├É┬Á├É┬¢├É┬¢├æ┬Å]]></uk>
-            <ru><![CDATA[├É┬ú├É┬▓├É┬Á├É┬┤├É┬¥├É┬╝├É┬╗├É┬Á├É┬¢├É┬©├æ┬Å]]></ru>
+            <cz><![CDATA[Upozornâ”œÃ¤Ã”Ã‡â•‘nâ”œÃ¢â”¬Â¡]]></cz>
+            <br><![CDATA[Notificaâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ãºâ”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã…]]></ru>
             <da><![CDATA[Notifikationer]]></da>
         </text>
 
         <text name="im_help_s3_notify_text">
             <en><![CDATA[When enabled, a pop-up appears each time income is paid showing the amount received. Disable if you prefer a quieter experience without payment alerts.]]></en>
-            <de><![CDATA[Wenn aktiviert, erscheint bei jeder Zahlung ein Pop-up mit dem erhaltenen Betrag. Deaktivieren f├â┬╝r eine ruhigere Spielerfahrung ohne Zahlungsbenachrichtigungen.]]></de>
-            <fr><![CDATA[Quand activ├â┬®, un pop-up appara├â┬«t ├â┬á chaque paiement avec le montant re├â┬ºu. D├â┬®sactiver pour une exp├â┬®rience plus calme sans alertes de paiement.]]></fr>
-            <pl><![CDATA[Po w├àÔÇÜ├äÔÇªczeniu pojawia si├äÔäó powiadomienie pop-up przy ka├à┬╝dej p├àÔÇÜatno├àÔÇ║ci z kwot├äÔÇª. Wy├àÔÇÜ├äÔÇªcz dla spokojniejszej rozgrywki bez alert├â┬│w p├àÔÇÜatno├àÔÇ║ci.]]></pl>
-            <es><![CDATA[Cuando est├â┬í habilitado, aparece un pop-up con cada pago mostrando el monto recibido. Desactiva para una experiencia sin alertas de pago.]]></es>
-            <it><![CDATA[Quando abilitato, appare un pop-up ad ogni pagamento con l'importo ricevuto. Disabilita per un'esperienza pi├â┬╣ silenziosa senza avvisi di pagamento.]]></it>
-            <cz><![CDATA[Kdy├à┬¥ je povoleno, p├àÔäói ka├à┬¥d├â┬® platb├äÔÇ║ se zobraz├â┬¡ pop-up s p├àÔäóijatou ├ä┬ì├â┬ístkou. Zaka├à┬¥te pro klidn├äÔÇ║j├à┬í├â┬¡ hern├â┬¡ z├â┬í├à┬¥itek bez platebn├â┬¡ch upozorn├äÔÇ║n├â┬¡.]]></cz>
-            <br><![CDATA[Quando ativado, um pop-up aparece a cada pagamento mostrando o valor recebido. Desative para uma experi├â┬¬ncia mais tranquila sem alertas de pagamento.]]></br>
-            <uk><![CDATA[├É┼í├É┬¥├É┬╗├É┬© ├æãÆ├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├É┬Á├É┬¢├É┬¥, ├É┬┐├æÔé¼├É┬© ├É┬║├É┬¥├É┬Â├É┬¢├æÔÇô├É┬╣ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æÔÇô ├É┬À'├æ┬Å├É┬▓├É┬╗├æ┬Å├æÔÇØ├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├æ┬ü├É┬┐├É┬╗├É┬©├É┬▓├É┬░├æ┼¢├æÔÇí├É┬Á ├æ┬ü├É┬┐├É┬¥├É┬▓├æÔÇô├æÔÇ░├É┬Á├É┬¢├É┬¢├æ┬Å ├É┬À ├É┬¥├æÔÇÜ├æÔé¼├É┬©├É┬╝├É┬░├É┬¢├É┬¥├æ┼¢ ├æ┬ü├æãÆ├É┬╝├É┬¥├æ┼¢. ├ÉÔÇÖ├É┬©├É┬╝├É┬║├É┬¢├æÔÇô├æÔÇÜ├æ┼Æ ├É┬┤├É┬╗├æ┬Å ├æ┬ü├É┬┐├É┬¥├É┬║├æÔÇô├É┬╣├É┬¢├æÔÇô├æ╦å├É┬¥├É┬│├É┬¥ ├æÔÇô├É┬│├æÔé¼├É┬¥├É┬▓├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¥├æ┬ü├É┬▓├æÔÇô├É┬┤├æãÆ ├É┬▒├É┬Á├É┬À ├æ┬ü├É┬┐├É┬¥├É┬▓├æÔÇô├æÔÇ░├É┬Á├É┬¢├æ┼Æ.]]></uk>
-            <ru><![CDATA[├É┼í├É┬¥├É┬│├É┬┤├É┬░ ├É┬▓├É┬║├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬¢├É┬¥, ├É┬┐├æÔé¼├É┬© ├É┬║├É┬░├É┬Â├É┬┤├É┬¥├É┬╣ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬Á ├É┬┐├É┬¥├æ┬Å├É┬▓├É┬╗├æ┬Å├É┬Á├æÔÇÜ├æ┬ü├æ┬Å ├É┬▓├æ┬ü├É┬┐├É┬╗├æÔÇ╣├É┬▓├É┬░├æ┼¢├æÔÇ░├É┬Á├É┬Á ├æãÆ├É┬▓├É┬Á├É┬┤├É┬¥├É┬╝├É┬╗├É┬Á├É┬¢├É┬©├É┬Á ├æ┬ü ├æ┬ü├æãÆ├É┬╝├É┬╝├É┬¥├É┬╣. ├É┼¥├æÔÇÜ├É┬║├É┬╗├æ┼¢├æÔÇí├É┬©├æÔÇÜ├É┬Á ├É┬┤├É┬╗├æ┬Å ├æ┬ü├É┬┐├É┬¥├É┬║├É┬¥├É┬╣├É┬¢├É┬¥├É┬│├É┬¥ ├É┬©├É┬│├æÔé¼├É┬¥├É┬▓├É┬¥├É┬│├É┬¥ ├É┬¥├É┬┐├æÔÇ╣├æÔÇÜ├É┬░ ├É┬▒├É┬Á├É┬À ├æãÆ├É┬▓├É┬Á├É┬┤├É┬¥├É┬╝├É┬╗├É┬Á├É┬¢├É┬©├É┬╣ ├É┬¥ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├É┬░├æÔÇª.]]></ru>
-            <da><![CDATA[N├â┬Ñr aktiveret, vises et pop-up ved hver betaling med det modtagne bel├â┬©b. Deaktiver for en roligere oplevelse uden betalingsbeskeder.]]></da>
+            <de><![CDATA[Wenn aktiviert, erscheint bei jeder Zahlung ein Pop-up mit dem erhaltenen Betrag. Deaktivieren fâ”œÃ¢â”¬â•r eine ruhigere Spielerfahrung ohne Zahlungsbenachrichtigungen.]]></de>
+            <fr><![CDATA[Quand activâ”œÃ¢â”¬Â®, un pop-up apparaâ”œÃ¢â”¬Â«t â”œÃ¢â”¬Ã¡ chaque paiement avec le montant reâ”œÃ¢â”¬Âºu. Dâ”œÃ¢â”¬Â®sactiver pour une expâ”œÃ¢â”¬Â®rience plus calme sans alertes de paiement.]]></fr>
+            <pl><![CDATA[Po wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczeniu pojawia siâ”œÃ¤Ã”Ã¤Ã³ powiadomienie pop-up przy kaâ”œÃ â”¬â•dej pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci z kwotâ”œÃ¤Ã”Ã‡Âª. Wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªcz dla spokojniejszej rozgrywki bez alertâ”œÃ¢â”¬â”‚w pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci.]]></pl>
+            <es><![CDATA[Cuando estâ”œÃ¢â”¬Ã­ habilitado, aparece un pop-up con cada pago mostrando el monto recibido. Desactiva para una experiencia sin alertas de pago.]]></es>
+            <it><![CDATA[Quando abilitato, appare un pop-up ad ogni pagamento con l'importo ricevuto. Disabilita per un'esperienza piâ”œÃ¢â”¬â•£ silenziosa senza avvisi di pagamento.]]></it>
+            <cz><![CDATA[Kdyâ”œÃ â”¬Â¥ je povoleno, pâ”œÃ Ã”Ã¤Ã³i kaâ”œÃ â”¬Â¥dâ”œÃ¢â”¬Â® platbâ”œÃ¤Ã”Ã‡â•‘ se zobrazâ”œÃ¢â”¬Â¡ pop-up s pâ”œÃ Ã”Ã¤Ã³ijatou â”œÃ¤â”¬Ã¬â”œÃ¢â”¬Ã­stkou. Zakaâ”œÃ â”¬Â¥te pro klidnâ”œÃ¤Ã”Ã‡â•‘jâ”œÃ â”¬Ã­â”œÃ¢â”¬Â¡ hernâ”œÃ¢â”¬Â¡ zâ”œÃ¢â”¬Ã­â”œÃ â”¬Â¥itek bez platebnâ”œÃ¢â”¬Â¡ch upozornâ”œÃ¤Ã”Ã‡â•‘nâ”œÃ¢â”¬Â¡.]]></cz>
+            <br><![CDATA[Quando ativado, um pop-up aparece a cada pagamento mostrando o valor recebido. Desative para uma experiâ”œÃ¢â”¬Â¬ncia mais tranquila sem alertas de pagamento.]]></br>
+            <uk><![CDATA[â”œÃ‰â”¼Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥, â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â© â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•£ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬Ã€'â”œÃ¦â”¬Ã…â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ã â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬Ã€ â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¼Â¢ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ¦â”¼Â¢. â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–’â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†.]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥, â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â© â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã…â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â–“â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã â”œÃ¦â”¬Ã¼ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£. â”œÃ‰â”¼Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬â–’â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€ â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª.]]></ru>
+            <da><![CDATA[Nâ”œÃ¢â”¬Ã‘r aktiveret, vises et pop-up ved hver betaling med det modtagne belâ”œÃ¢â”¬Â©b. Deaktiver for en roligere oplevelse uden betalingsbeskeder.]]></da>
         </text>
 
         <text name="im_help_s3_reset_title">
             <en><![CDATA[Reset Settings]]></en>
-            <de><![CDATA[Einstellungen zur├â┬╝cksetzen]]></de>
-            <fr><![CDATA[R├â┬®initialiser les param├â┬¿tres]]></fr>
+            <de><![CDATA[Einstellungen zurâ”œÃ¢â”¬â•cksetzen]]></de>
+            <fr><![CDATA[Râ”œÃ¢â”¬Â®initialiser les paramâ”œÃ¢â”¬Â¿tres]]></fr>
             <pl><![CDATA[Resetuj ustawienia]]></pl>
             <es><![CDATA[Restablecer ajustes]]></es>
             <it><![CDATA[Ripristina impostazioni]]></it>
-            <cz><![CDATA[Resetovat nastaven├â┬¡]]></cz>
-            <br><![CDATA[Redefinir configura├â┬º├â┬Áes]]></br>
-            <uk><![CDATA[├É┬í├É┬║├É┬©├É┬¢├æãÆ├æÔÇÜ├É┬© ├É┬¢├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å]]></uk>
-            <ru><![CDATA[├É┬í├É┬▒├æÔé¼├É┬¥├æ┬ü├É┬©├æÔÇÜ├æ┼Æ ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬©]]></ru>
+            <cz><![CDATA[Resetovat nastavenâ”œÃ¢â”¬Â¡]]></cz>
+            <br><![CDATA[Redefinir configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã­â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©]]></ru>
             <da><![CDATA[Nulstil indstillinger]]></da>
         </text>
 
         <text name="im_help_s3_reset_text">
             <en><![CDATA[Press the X key while on the Settings page to reset all Income Mod settings to defaults. Useful if settings become inconsistent. This action cannot be undone.]]></en>
-            <de><![CDATA[Dr├â┬╝cken Sie X auf der Einstellungsseite, um alle Income-Mod-Einstellungen zur├â┬╝ckzusetzen. N├â┬╝tzlich bei inkonsistenten Einstellungen. Kann nicht r├â┬╝ckg├â┬ñngig gemacht werden.]]></de>
-            <fr><![CDATA[Appuyez sur X dans Param├â┬¿tres pour r├â┬®initialiser tous les param├â┬¿tres d'Income Mod. Utile si les param├â┬¿tres deviennent incoh├â┬®rents. Cette action est irr├â┬®versible.]]></fr>
-            <pl><![CDATA[Naci├àÔÇ║nij X na stronie Ustawie├àÔÇ×, aby zresetowa├äÔÇí wszystkie ustawienia Income Mod do domy├àÔÇ║lnych. Tej akcji nie mo├à┬╝na cofn├äÔÇª├äÔÇí.]]></pl>
-            <es><![CDATA[Pulsa X en la p├â┬ígina de Ajustes para restablecer todos los ajustes de Income Mod. Esta acci├â┬│n no se puede deshacer.]]></es>
-            <it><![CDATA[Premi X nella pagina Impostazioni per ripristinare tutte le impostazioni di Income Mod ai valori predefiniti. Questa azione non pu├â┬▓ essere annullata.]]></it>
-            <cz><![CDATA[Stiskn├äÔÇ║te X na str├â┬ínce Nastaven├â┬¡ pro reset v├à┬íech nastaven├â┬¡ Income Modu. Tuto akci nelze vr├â┬ítit zp├äÔÇ║t.]]></cz>
-            <br><![CDATA[Pressione X nas Configura├â┬º├â┬Áes para redefinir todas as configura├â┬º├â┬Áes do Income Mod. Esta a├â┬º├â┬úo n├â┬úo pode ser desfeita.]]></br>
-            <uk><![CDATA[├É┬Ø├É┬░├æÔÇÜ├É┬©├æ┬ü├É┬¢├æÔÇô├æÔÇÜ├æ┼Æ X ├É┬¢├É┬░ ├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├æÔÇô├É┬¢├æÔÇá├æÔÇô ├É┬Ø├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├æ┼Æ, ├æÔÇ░├É┬¥├É┬▒ ├æ┬ü├É┬║├É┬©├É┬¢├æãÆ├æÔÇÜ├É┬© ├É┬▓├æ┬ü├æÔÇô ├É┬¢├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å Income Mod ├É┬┤├É┬¥ ├É┬À├É┬¢├É┬░├æÔÇí├É┬Á├É┬¢├æ┼Æ ├É┬À├É┬░ ├É┬À├É┬░├É┬╝├É┬¥├É┬▓├æÔÇí├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å├É┬╝. ├É┬ª├æ┼¢ ├É┬┤├æÔÇô├æ┼¢ ├É┬¢├É┬Á ├É┬╝├É┬¥├É┬Â├É┬¢├É┬░ ├æ┬ü├É┬║├É┬░├æ┬ü├æãÆ├É┬▓├É┬░├æÔÇÜ├É┬©.]]></uk>
-            <ru><![CDATA[├É┬Ø├É┬░├É┬Â├É┬╝├É┬©├æÔÇÜ├É┬Á X ├É┬¢├É┬░ ├æ┬ü├æÔÇÜ├æÔé¼├É┬░├É┬¢├É┬©├æÔÇá├É┬Á ├É┬Ø├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬Á├É┬║, ├æÔÇí├æÔÇÜ├É┬¥├É┬▒├æÔÇ╣ ├æ┬ü├É┬▒├æÔé¼├É┬¥├æ┬ü├É┬©├æÔÇÜ├æ┼Æ ├É┬▓├æ┬ü├É┬Á ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬© Income Mod ├É┬┤├É┬¥ ├É┬À├É┬¢├É┬░├æÔÇí├É┬Á├É┬¢├É┬©├É┬╣ ├É┬┐├É┬¥ ├æãÆ├É┬╝├É┬¥├É┬╗├æÔÇí├É┬░├É┬¢├É┬©├æ┼¢. ├É┬¡├æÔÇÜ├É┬¥ ├É┬┤├É┬Á├É┬╣├æ┬ü├æÔÇÜ├É┬▓├É┬©├É┬Á ├É┬¢├É┬Á├É┬╗├æ┼Æ├É┬À├æ┬Å ├É┬¥├æÔÇÜ├É┬╝├É┬Á├É┬¢├É┬©├æÔÇÜ├æ┼Æ.]]></ru>
-            <da><![CDATA[Tryk p├â┬Ñ X p├â┬Ñ siden Indstillinger for at nulstille alle Income Mod indstillinger til standard. Denne handling kan ikke fortrydes.]]></da>
+            <de><![CDATA[Drâ”œÃ¢â”¬â•cken Sie X auf der Einstellungsseite, um alle Income-Mod-Einstellungen zurâ”œÃ¢â”¬â•ckzusetzen. Nâ”œÃ¢â”¬â•tzlich bei inkonsistenten Einstellungen. Kann nicht râ”œÃ¢â”¬â•ckgâ”œÃ¢â”¬Ã±ngig gemacht werden.]]></de>
+            <fr><![CDATA[Appuyez sur X dans Paramâ”œÃ¢â”¬Â¿tres pour râ”œÃ¢â”¬Â®initialiser tous les paramâ”œÃ¢â”¬Â¿tres d'Income Mod. Utile si les paramâ”œÃ¢â”¬Â¿tres deviennent incohâ”œÃ¢â”¬Â®rents. Cette action est irrâ”œÃ¢â”¬Â®versible.]]></fr>
+            <pl><![CDATA[Naciâ”œÃ Ã”Ã‡â•‘nij X na stronie Ustawieâ”œÃ Ã”Ã‡Ã—, aby zresetowaâ”œÃ¤Ã”Ã‡Ã­ wszystkie ustawienia Income Mod do domyâ”œÃ Ã”Ã‡â•‘lnych. Tej akcji nie moâ”œÃ â”¬â•na cofnâ”œÃ¤Ã”Ã‡Âªâ”œÃ¤Ã”Ã‡Ã­.]]></pl>
+            <es><![CDATA[Pulsa X en la pâ”œÃ¢â”¬Ã­gina de Ajustes para restablecer todos los ajustes de Income Mod. Esta acciâ”œÃ¢â”¬â”‚n no se puede deshacer.]]></es>
+            <it><![CDATA[Premi X nella pagina Impostazioni per ripristinare tutte le impostazioni di Income Mod ai valori predefiniti. Questa azione non puâ”œÃ¢â”¬â–“ essere annullata.]]></it>
+            <cz><![CDATA[Stisknâ”œÃ¤Ã”Ã‡â•‘te X na strâ”œÃ¢â”¬Ã­nce Nastavenâ”œÃ¢â”¬Â¡ pro reset vâ”œÃ â”¬Ã­ech nastavenâ”œÃ¢â”¬Â¡ Income Modu. Tuto akci nelze vrâ”œÃ¢â”¬Ã­tit zpâ”œÃ¤Ã”Ã‡â•‘t.]]></cz>
+            <br><![CDATA[Pressione X nas Configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães para redefinir todas as configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães do Income Mod. Esta aâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ãºo nâ”œÃ¢â”¬Ãºo pode ser desfeita.]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† X â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã¡â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†, â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… Income Mod â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã† â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬â•. â”œÃ‰â”¬Âªâ”œÃ¦â”¼Â¢ â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¼Â¢ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ã â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©.]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã X â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã¡â”œÃ‰â”¬Ã â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘, â”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡â•£ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† â”œÃ‰â”¬â–“â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ã â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© Income Mod â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥ â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¼Â¢. â”œÃ‰â”¬Â¡â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•£â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Ã€â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†.]]></ru>
+            <da><![CDATA[Tryk pâ”œÃ¢â”¬Ã‘ X pâ”œÃ¢â”¬Ã‘ siden Indstillinger for at nulstille alle Income Mod indstillinger til standard. Denne handling kan ikke fortrydes.]]></da>
         </text>
 
-        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page 6 ├óÔé¼ÔÇØ HUD & Income Report ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
+        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page 6 â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ HUD & Income Report â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
         <text name="im_help_t1_hud_title">
-            <en><![CDATA[Income HUD ├óÔé¼ÔÇØ I Key]]></en>
-            <de><![CDATA[Einkommens-HUD ├óÔé¼ÔÇØ Taste I]]></de>
-            <fr><![CDATA[HUD de revenu ├óÔé¼ÔÇØ Touche I]]></fr>
-            <pl><![CDATA[HUD dochodu ├óÔé¼ÔÇØ Klawisz I]]></pl>
-            <es><![CDATA[HUD de ingresos ├óÔé¼ÔÇØ Tecla I]]></es>
-            <it><![CDATA[HUD reddito ├óÔé¼ÔÇØ Tasto I]]></it>
-            <cz><![CDATA[HUD p├àÔäó├â┬¡jm├à┬» ├óÔé¼ÔÇØ Kl├â┬ívesa I]]></cz>
-            <br><![CDATA[HUD de renda ├óÔé¼ÔÇØ Tecla I]]></br>
-            <uk><![CDATA[HUD ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ ├óÔé¼ÔÇØ ├É┼í├É┬╗├É┬░├É┬▓├æÔÇô├æ╦å├É┬░ I]]></uk>
-            <ru><![CDATA[HUD ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░ ├óÔé¼ÔÇØ ├É┼í├É┬╗├É┬░├É┬▓├É┬©├æ╦å├É┬░ I]]></ru>
-            <da><![CDATA[Indkomst-HUD ├óÔé¼ÔÇØ Tasten I]]></da>
+            <en><![CDATA[Income HUD â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ I Key]]></en>
+            <de><![CDATA[Einkommens-HUD â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Taste I]]></de>
+            <fr><![CDATA[HUD de revenu â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Touche I]]></fr>
+            <pl><![CDATA[HUD dochodu â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Klawisz I]]></pl>
+            <es><![CDATA[HUD de ingresos â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tecla I]]></es>
+            <it><![CDATA[HUD reddito â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tasto I]]></it>
+            <cz><![CDATA[HUD pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â» â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Klâ”œÃ¢â”¬Ã­vesa I]]></cz>
+            <br><![CDATA[HUD de renda â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tecla I]]></br>
+            <uk><![CDATA[HUD â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã† â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¼Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘ I]]></uk>
+            <ru><![CDATA[HUD â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘ â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¼Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘ I]]></ru>
+            <da><![CDATA[Indkomst-HUD â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tasten I]]></da>
         </text>
 
         <text name="im_help_t1_hud_text">
             <en><![CDATA[Press I during gameplay to toggle the income HUD on or off. It shows your income, payment mode, next payment time, and recent history. The HUD setting persists between sessions.]]></en>
-            <de><![CDATA[Dr├â┬╝cken Sie I w├â┬ñhrend des Spiels, um das Einkommens-HUD ein- oder auszublenden. Es zeigt Einkommen, Zahlungsmodus, n├â┬ñchste Zahlung und den Verlauf. Die Einstellung bleibt erhalten.]]></de>
-            <fr><![CDATA[Appuyez sur I pendant le jeu pour afficher ou masquer le HUD. Il affiche revenu, mode de paiement, prochain paiement et historique r├â┬®cent. Le r├â┬®glage persiste entre sessions.]]></fr>
-            <pl><![CDATA[Naci├àÔÇ║nij I podczas gry, aby w├àÔÇÜ├äÔÇªczy├äÔÇí lub wy├àÔÇÜ├äÔÇªczy├äÔÇí HUD dochodu. Pokazuje doch├â┬│d, tryb p├àÔÇÜatno├àÔÇ║ci, nast├äÔäópn├äÔÇª p├àÔÇÜatno├àÔÇ║├äÔÇí i histori├äÔäó. Ustawienie jest zachowywane mi├äÔäódzy sesjami.]]></pl>
-            <es><![CDATA[Pulsa I durante el juego para activar o desactivar el HUD. Muestra ingreso, modo de pago, pr├â┬│ximo pago e historial reciente. El ajuste persiste entre sesiones.]]></es>
-            <it><![CDATA[Premi I durante il gioco per attivare o disattivare il HUD. Mostra reddito, modalit├â┬á di pagamento, prossimo pagamento e cronologia recente. L'impostazione persiste tra sessioni.]]></it>
-            <cz><![CDATA[Stiskn├äÔÇ║te I p├àÔäói h├àÔäóe pro p├àÔäóepnut├â┬¡ HUD. Zobrazuje p├àÔäó├â┬¡jem, platebn├â┬¡ re├à┬¥im, p├àÔäó├â┬¡├à┬ít├â┬¡ platbu a historii. Nastaven├â┬¡ se uchov├â┬ív├â┬í mezi sezen├â┬¡mi.]]></cz>
-            <br><![CDATA[Pressione I durante o jogo para alternar o HUD. Mostra renda, modo de pagamento, pr├â┬│ximo pagamento e hist├â┬│rico recente. O ajuste persiste entre sess├â┬Áes.]]></br>
-            <uk><![CDATA[├É┬Ø├É┬░├æÔÇÜ├É┬©├æ┬ü├É┬¢├æÔÇô├æÔÇÜ├æ┼Æ I ├É┬┐├æÔÇô├É┬┤ ├æÔÇí├É┬░├æ┬ü ├É┬│├æÔé¼├É┬©, ├æÔÇ░├É┬¥├É┬▒ ├æãÆ├É┬▓├æÔÇô├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© ├É┬░├É┬▒├É┬¥ ├É┬▓├É┬©├É┬╝├É┬║├É┬¢├æãÆ├æÔÇÜ├É┬© HUD. ├É┼©├É┬¥├É┬║├É┬░├É┬À├æãÆ├æÔÇØ ├É┬┤├É┬¥├æÔÇª├æÔÇô├É┬┤, ├æÔé¼├É┬Á├É┬Â├É┬©├É┬╝ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ, ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æãÆ├É┬┐├É┬¢├æãÆ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ ├æÔÇÜ├É┬░ ├É┬¢├É┬Á├æÔÇ░├É┬¥├É┬┤├É┬░├É┬▓├É┬¢├æ┼¢ ├æÔÇô├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├æÔÇô├æ┼¢. ├É┬Ø├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å ├É┬À├É┬▒├É┬Á├æÔé¼├æÔÇô├É┬│├É┬░├æÔÇØ├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├É┬╝├æÔÇô├É┬Â ├æ┬ü├É┬Á├æ┬ü├æÔÇô├æ┬Å├É┬╝├É┬©.]]></uk>
-            <ru><![CDATA[├É┬Ø├É┬░├É┬Â├É┬╝├É┬©├æÔÇÜ├É┬Á I ├É┬▓├É┬¥ ├É┬▓├æÔé¼├É┬Á├É┬╝├æ┬Å ├É┬©├É┬│├æÔé¼├æÔÇ╣ ├É┬┤├É┬╗├æ┬Å ├É┬┐├É┬Á├æÔé¼├É┬Á├É┬║├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬¢├É┬©├æ┬Å HUD. ├É┼©├É┬¥├É┬║├É┬░├É┬À├æÔÇ╣├É┬▓├É┬░├É┬Á├æÔÇÜ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤, ├æÔé¼├É┬Á├É┬Â├É┬©├É┬╝ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ, ├æ┬ü├É┬╗├É┬Á├É┬┤├æãÆ├æ┼¢├æÔÇ░├æãÆ├æ┼¢ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ ├É┬© ├É┬¢├É┬Á├É┬┤├É┬░├É┬▓├É┬¢├æ┼¢├æ┼¢ ├É┬©├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├É┬©├æ┼¢. ├É┬Ø├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬░ ├æ┬ü├É┬¥├æÔÇª├æÔé¼├É┬░├É┬¢├æ┬Å├É┬Á├æÔÇÜ├æ┬ü├æ┬Å ├É┬╝├É┬Á├É┬Â├É┬┤├æãÆ ├æ┬ü├É┬Á├æ┬ü├æ┬ü├É┬©├æ┬Å├É┬╝├É┬©.]]></ru>
-            <da><![CDATA[Tryk p├â┬Ñ I under spil for at skifte HUD. Viser indkomst, betalingsm├â┬Ñde, n├â┬ªste betaling og nylig historie. Indstillingen bevares mellem sessioner.]]></da>
+            <de><![CDATA[Drâ”œÃ¢â”¬â•cken Sie I wâ”œÃ¢â”¬Ã±hrend des Spiels, um das Einkommens-HUD ein- oder auszublenden. Es zeigt Einkommen, Zahlungsmodus, nâ”œÃ¢â”¬Ã±chste Zahlung und den Verlauf. Die Einstellung bleibt erhalten.]]></de>
+            <fr><![CDATA[Appuyez sur I pendant le jeu pour afficher ou masquer le HUD. Il affiche revenu, mode de paiement, prochain paiement et historique râ”œÃ¢â”¬Â®cent. Le râ”œÃ¢â”¬Â®glage persiste entre sessions.]]></fr>
+            <pl><![CDATA[Naciâ”œÃ Ã”Ã‡â•‘nij I podczas gry, aby wâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczyâ”œÃ¤Ã”Ã‡Ã­ lub wyâ”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczyâ”œÃ¤Ã”Ã‡Ã­ HUD dochodu. Pokazuje dochâ”œÃ¢â”¬â”‚d, tryb pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘ci, nastâ”œÃ¤Ã”Ã¤Ã³pnâ”œÃ¤Ã”Ã‡Âª pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­ i historiâ”œÃ¤Ã”Ã¤Ã³. Ustawienie jest zachowywane miâ”œÃ¤Ã”Ã¤Ã³dzy sesjami.]]></pl>
+            <es><![CDATA[Pulsa I durante el juego para activar o desactivar el HUD. Muestra ingreso, modo de pago, prâ”œÃ¢â”¬â”‚ximo pago e historial reciente. El ajuste persiste entre sesiones.]]></es>
+            <it><![CDATA[Premi I durante il gioco per attivare o disattivare il HUD. Mostra reddito, modalitâ”œÃ¢â”¬Ã¡ di pagamento, prossimo pagamento e cronologia recente. L'impostazione persiste tra sessioni.]]></it>
+            <cz><![CDATA[Stisknâ”œÃ¤Ã”Ã‡â•‘te I pâ”œÃ Ã”Ã¤Ã³i hâ”œÃ Ã”Ã¤Ã³e pro pâ”œÃ Ã”Ã¤Ã³epnutâ”œÃ¢â”¬Â¡ HUD. Zobrazuje pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem, platebnâ”œÃ¢â”¬Â¡ reâ”œÃ â”¬Â¥im, pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡â”œÃ â”¬Ã­tâ”œÃ¢â”¬Â¡ platbu a historii. Nastavenâ”œÃ¢â”¬Â¡ se uchovâ”œÃ¢â”¬Ã­vâ”œÃ¢â”¬Ã­ mezi sezenâ”œÃ¢â”¬Â¡mi.]]></cz>
+            <br><![CDATA[Pressione I durante o jogo para alternar o HUD. Mostra renda, modo de pagamento, prâ”œÃ¢â”¬â”‚ximo pagamento e histâ”œÃ¢â”¬â”‚rico recente. O ajuste persiste entre sessâ”œÃ¢â”¬Ães.]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† I â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤ â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼ â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©, â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’ â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© HUD. â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤, â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ, â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â”â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦â”¼Â¢ â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¼Â¢. â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–’â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”‚â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Ã‚ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã…â”œÃ‰â”¬â•â”œÃ‰â”¬Â©.]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã I â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡â•£ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã… HUD. â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤, â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœ, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡â–‘â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ‰â”¬Â© â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦â”¼Â¢â”œÃ¦â”¼Â¢ â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ¦â”¼Â¢. â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã† â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã…â”œÃ‰â”¬â•â”œÃ‰â”¬Â©.]]></ru>
+            <da><![CDATA[Tryk pâ”œÃ¢â”¬Ã‘ I under spil for at skifte HUD. Viser indkomst, betalingsmâ”œÃ¢â”¬Ã‘de, nâ”œÃ¢â”¬Âªste betaling og nylig historie. Indstillingen bevares mellem sessioner.]]></da>
         </text>
 
         <text name="im_help_t1_report_title">
-            <en><![CDATA[Income Report ├óÔé¼ÔÇØ U Key]]></en>
-            <de><![CDATA[Einkommensbericht ├óÔé¼ÔÇØ Taste U]]></de>
-            <fr><![CDATA[Rapport de revenu ├óÔé¼ÔÇØ Touche U]]></fr>
-            <pl><![CDATA[Raport dochodu ├óÔé¼ÔÇØ Klawisz U]]></pl>
-            <es><![CDATA[Informe de ingresos ├óÔé¼ÔÇØ Tecla U]]></es>
-            <it><![CDATA[Rapporto reddito ├óÔé¼ÔÇØ Tasto U]]></it>
-            <cz><![CDATA[P├àÔäóehled p├àÔäó├â┬¡jm├à┬» ├óÔé¼ÔÇØ Kl├â┬ívesa U]]></cz>
-            <br><![CDATA[Relat├â┬│rio de renda ├óÔé¼ÔÇØ Tecla U]]></br>
-            <uk><![CDATA[├ÉÔÇö├É┬▓├æÔÇô├æÔÇÜ ├É┬┐├æÔé¼├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬© ├óÔé¼ÔÇØ ├É┼í├É┬╗├É┬░├É┬▓├æÔÇô├æ╦å├É┬░ U]]></uk>
-            <ru><![CDATA[├É┼¥├æÔÇÜ├æÔÇí├æÔÇÿ├æÔÇÜ ├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░├æÔÇª ├óÔé¼ÔÇØ ├É┼í├É┬╗├É┬░├É┬▓├É┬©├æ╦å├É┬░ U]]></ru>
-            <da><![CDATA[Indkomstrapport ├óÔé¼ÔÇØ Tasten U]]></da>
+            <en><![CDATA[Income Report â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ U Key]]></en>
+            <de><![CDATA[Einkommensbericht â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Taste U]]></de>
+            <fr><![CDATA[Rapport de revenu â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Touche U]]></fr>
+            <pl><![CDATA[Raport dochodu â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Klawisz U]]></pl>
+            <es><![CDATA[Informe de ingresos â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tecla U]]></es>
+            <it><![CDATA[Rapporto reddito â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tasto U]]></it>
+            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³ehled pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â» â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Klâ”œÃ¢â”¬Ã­vesa U]]></cz>
+            <br><![CDATA[Relatâ”œÃ¢â”¬â”‚rio de renda â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tecla U]]></br>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â© â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¼Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘ U]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã”Ã‡Ã¿â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¼Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘ U]]></ru>
+            <da><![CDATA[Indkomstrapport â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Tasten U]]></da>
         </text>
 
         <text name="im_help_t1_report_text">
             <en><![CDATA[Press U to open the Income Report dialog. Shows configuration, total earnings (last 10 payments), average per payment, next scheduled payment, and a full detailed payment history table.]]></en>
-            <de><![CDATA[Dr├â┬╝cken Sie U, um den Einkommensbericht zu ├â┬Âffnen. Zeigt Konfiguration, Gesamteinnahmen (letzte 10), Durchschnitt, n├â┬ñchste Zahlung und detaillierte Verlaufstabelle.]]></de>
-            <fr><![CDATA[Appuyez sur U pour ouvrir le rapport. Affiche configuration, gains totaux (10 derniers), moyenne par paiement, prochain paiement et tableau historique d├â┬®taill├â┬®.]]></fr>
-            <pl><![CDATA[Naci├àÔÇ║nij U, aby otworzy├äÔÇí raport dochodu. Pokazuje konfiguracj├äÔäó, ├àÔÇÜ├äÔÇªczne zarobki (ostatnie 10), ├àÔÇ║redni├äÔÇª, nast├äÔäópn├äÔÇª p├àÔÇÜatno├àÔÇ║├äÔÇí i szczeg├â┬│├àÔÇÜow├äÔÇª tabel├äÔäó historii.]]></pl>
-            <es><![CDATA[Pulsa U para abrir el informe de ingresos. Muestra configuraci├â┬│n, ganancias totales (├â┬║ltimos 10), promedio, pr├â┬│ximo pago y tabla de historial detallada.]]></es>
+            <de><![CDATA[Drâ”œÃ¢â”¬â•cken Sie U, um den Einkommensbericht zu â”œÃ¢â”¬Ã‚ffnen. Zeigt Konfiguration, Gesamteinnahmen (letzte 10), Durchschnitt, nâ”œÃ¢â”¬Ã±chste Zahlung und detaillierte Verlaufstabelle.]]></de>
+            <fr><![CDATA[Appuyez sur U pour ouvrir le rapport. Affiche configuration, gains totaux (10 derniers), moyenne par paiement, prochain paiement et tableau historique dâ”œÃ¢â”¬Â®taillâ”œÃ¢â”¬Â®.]]></fr>
+            <pl><![CDATA[Naciâ”œÃ Ã”Ã‡â•‘nij U, aby otworzyâ”œÃ¤Ã”Ã‡Ã­ raport dochodu. Pokazuje konfiguracjâ”œÃ¤Ã”Ã¤Ã³, â”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczne zarobki (ostatnie 10), â”œÃ Ã”Ã‡â•‘redniâ”œÃ¤Ã”Ã‡Âª, nastâ”œÃ¤Ã”Ã¤Ã³pnâ”œÃ¤Ã”Ã‡Âª pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­ i szczegâ”œÃ¢â”¬â”‚â”œÃ Ã”Ã‡Ãœowâ”œÃ¤Ã”Ã‡Âª tabelâ”œÃ¤Ã”Ã¤Ã³ historii.]]></pl>
+            <es><![CDATA[Pulsa U para abrir el informe de ingresos. Muestra configuraciâ”œÃ¢â”¬â”‚n, ganancias totales (â”œÃ¢â”¬â•‘ltimos 10), promedio, prâ”œÃ¢â”¬â”‚ximo pago y tabla de historial detallada.]]></es>
             <it><![CDATA[Premi U per aprire il rapporto. Mostra configurazione, guadagni totali (ultimi 10), media per pagamento, prossimo pagamento e tabella cronologia dettagliata.]]></it>
-            <cz><![CDATA[Stiskn├äÔÇ║te U pro otev├àÔäóen├â┬¡ p├àÔäóehledu p├àÔäó├â┬¡jm├à┬». Zobrazuje konfiguraci, celkov├â┬® v├â┬¢d├äÔÇ║lky (posledn├â┬¡ch 10), pr├à┬»m├äÔÇ║r, p├àÔäó├â┬¡├à┬ít├â┬¡ platbu a podrobnou historii.]]></cz>
-            <br><![CDATA[Pressione U para abrir o relat├â┬│rio de renda. Mostra configura├â┬º├â┬úo, ganhos totais (├â┬║ltimos 10), m├â┬®dia, pr├â┬│ximo pagamento e tabela de hist├â┬│rico detalhado.]]></br>
-            <uk><![CDATA[├É┬Ø├É┬░├æÔÇÜ├É┬©├æ┬ü├É┬¢├æÔÇô├æÔÇÜ├æ┼Æ U, ├æÔÇ░├É┬¥├É┬▒ ├É┬▓├æÔÇô├É┬┤├É┬║├æÔé¼├É┬©├æÔÇÜ├É┬© ├É┬À├É┬▓├æÔÇô├æÔÇÜ ├É┬┐├æÔé¼├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬©. ├É┼©├É┬¥├É┬║├É┬░├É┬À├æãÆ├æÔÇØ ├É┬║├É┬¥├É┬¢├æÔÇ×├æÔÇô├É┬│├æãÆ├æÔé¼├É┬░├æÔÇá├æÔÇô├æ┼¢, ├É┬À├É┬░├É┬│├É┬░├É┬╗├æ┼Æ├É┬¢├É┬©├É┬╣ ├É┬À├É┬░├æÔé¼├É┬¥├É┬▒├æÔÇô├æÔÇÜ├É┬¥├É┬║ (├É┬¥├æ┬ü├æÔÇÜ├É┬░├É┬¢├É┬¢├æÔÇô 10), ├æ┬ü├É┬Á├æÔé¼├É┬Á├É┬┤├É┬¢├æÔÇØ, ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æãÆ├É┬┐├É┬¢├æãÆ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ ├æÔÇÜ├É┬░ ├É┬┤├É┬Á├æÔÇÜ├É┬░├É┬╗├æ┼Æ├É┬¢├æãÆ ├æÔÇÜ├É┬░├É┬▒├É┬╗├É┬©├æÔÇá├æ┼¢ ├æÔÇô├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├æÔÇô├æÔÇö.]]></uk>
-            <ru><![CDATA[├É┬Ø├É┬░├É┬Â├É┬╝├É┬©├æÔÇÜ├É┬Á U ├É┬┤├É┬╗├æ┬Å ├É┬¥├æÔÇÜ├É┬║├æÔé¼├æÔÇ╣├æÔÇÜ├É┬©├æ┬Å ├É┬¥├æÔÇÜ├æÔÇí├æÔÇÿ├æÔÇÜ├É┬░ ├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░├æÔÇª. ├É┼©├É┬¥├É┬║├É┬░├É┬À├æÔÇ╣├É┬▓├É┬░├É┬Á├æÔÇÜ ├É┬║├É┬¥├É┬¢├æÔÇ×├É┬©├É┬│├æãÆ├æÔé¼├É┬░├æÔÇá├É┬©├æ┼¢, ├É┬¥├É┬▒├æÔÇ░├É┬©├É┬╣ ├É┬À├É┬░├æÔé¼├É┬░├É┬▒├É┬¥├æÔÇÜ├É┬¥├É┬║ (├É┬┐├É┬¥├æ┬ü├É┬╗├É┬Á├É┬┤├É┬¢├É┬©├É┬Á 10), ├æ┬ü├æÔé¼├É┬Á├É┬┤├É┬¢├É┬Á├É┬Á, ├æ┬ü├É┬╗├É┬Á├É┬┤├æãÆ├æ┼¢├æÔÇ░├æãÆ├æ┼¢ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ ├É┬© ├É┬┐├É┬¥├É┬┤├æÔé¼├É┬¥├É┬▒├É┬¢├æãÆ├æ┼¢ ├æÔÇÜ├É┬░├É┬▒├É┬╗├É┬©├æÔÇá├æãÆ ├É┬©├æ┬ü├æÔÇÜ├É┬¥├æÔé¼├É┬©├É┬©.]]></ru>
-            <da><![CDATA[Tryk p├â┬Ñ U for at ├â┬Ñbne indkomstrapporten. Viser konfiguration, samlede indt├â┬ªgter (sidste 10), gennemsnit, n├â┬ªste betaling og en detaljeret historietabel.]]></da>
+            <cz><![CDATA[Stisknâ”œÃ¤Ã”Ã‡â•‘te U pro otevâ”œÃ Ã”Ã¤Ã³enâ”œÃ¢â”¬Â¡ pâ”œÃ Ã”Ã¤Ã³ehledu pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmâ”œÃ â”¬Â». Zobrazuje konfiguraci, celkovâ”œÃ¢â”¬Â® vâ”œÃ¢â”¬Â¢dâ”œÃ¤Ã”Ã‡â•‘lky (poslednâ”œÃ¢â”¬Â¡ch 10), prâ”œÃ â”¬Â»mâ”œÃ¤Ã”Ã‡â•‘r, pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡â”œÃ â”¬Ã­tâ”œÃ¢â”¬Â¡ platbu a podrobnou historii.]]></cz>
+            <br><![CDATA[Pressione U para abrir o relatâ”œÃ¢â”¬â”‚rio de renda. Mostra configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ãºo, ganhos totais (â”œÃ¢â”¬â•‘ltimos 10), mâ”œÃ¢â”¬Â®dia, prâ”œÃ¢â”¬â”‚ximo pagamento e tabela de histâ”œÃ¢â”¬â”‚rico detalhado.]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† U, â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â© â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©. â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã—â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”‚â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã¡â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¼Â¢, â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”‚â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘ (â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´ 10), â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã˜, â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â”â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã¡â”œÃ¦â”¼Â¢ â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ã¶.]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã U â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ¦â”¬Ã… â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã‡Ã­â”œÃ¦Ã”Ã‡Ã¿â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª. â”œÃ‰â”¼Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Â©â”œÃ‰â”¬â”‚â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã¡â”œÃ‰â”¬Â©â”œÃ¦â”¼Â¢, â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘ (â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã 10), â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã, â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡â–‘â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã† â”œÃ‰â”¬Â© â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ‰â”¬â–’â”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ã¡â”œÃ¦Ã£Ã† â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬Â©.]]></ru>
+            <da><![CDATA[Tryk pâ”œÃ¢â”¬Ã‘ U for at â”œÃ¢â”¬Ã‘bne indkomstrapporten. Viser konfiguration, samlede indtâ”œÃ¢â”¬Âªgter (sidste 10), gennemsnit, nâ”œÃ¢â”¬Âªste betaling og en detaljeret historietabel.]]></da>
         </text>
 
-        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page 7 ├óÔé¼ÔÇØ Income Tips ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
+        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page 7 â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ Income Tips â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
         <text name="im_help_t2_season_title">
             <en><![CDATA[Best Season for Income]]></en>
-            <de><![CDATA[Beste Saison f├â┬╝r Einkommen]]></de>
+            <de><![CDATA[Beste Saison fâ”œÃ¢â”¬â•r Einkommen]]></de>
             <fr><![CDATA[Meilleure saison pour les revenus]]></fr>
-            <pl><![CDATA[Najlepsza pora roku na doch├â┬│d]]></pl>
+            <pl><![CDATA[Najlepsza pora roku na dochâ”œÃ¢â”¬â”‚d]]></pl>
             <es><![CDATA[Mejor temporada para ingresos]]></es>
             <it><![CDATA[Stagione migliore per il reddito]]></it>
-            <cz><![CDATA[Nejlep├à┬í├â┬¡ sez├â┬│na pro p├àÔäó├â┬¡jem]]></cz>
-            <br><![CDATA[Melhor esta├â┬º├â┬úo para renda]]></br>
-            <uk><![CDATA[├É┬Ø├É┬░├É┬╣├É┬║├æÔé¼├É┬░├æÔÇ░├É┬©├É┬╣ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢ ├É┬┤├É┬╗├æ┬Å ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
-            <ru><![CDATA[├ÉÔÇ║├æãÆ├æÔÇí├æ╦å├É┬©├É┬╣ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢ ├É┬┤├É┬╗├æ┬Å ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
-            <da><![CDATA[Bedste s├â┬ªson for indkomst]]></da>
+            <cz><![CDATA[Nejlepâ”œÃ â”¬Ã­â”œÃ¢â”¬Â¡ sezâ”œÃ¢â”¬â”‚na pro pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem]]></cz>
+            <br><![CDATA[Melhor estaâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ãºo para renda]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Ã˜â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡â–‘â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
+            <ru><![CDATA[â”œÃ‰Ã”Ã‡â•‘â”œÃ¦Ã£Ã†â”œÃ¦Ã”Ã‡Ã­â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
+            <da><![CDATA[Bedste sâ”œÃ¢â”¬Âªson for indkomst]]></da>
         </text>
 
         <text name="im_help_t2_season_text">
-            <en><![CDATA[With Seasonal Effects on, Autumn gives 1.2x income ├óÔé¼ÔÇØ the season peak. Winter is lowest at 0.7x. Consider enabling a high multiplier during Autumn for maximum combined income.]]></en>
-            <de><![CDATA[Mit saisonalen Effekten bietet Herbst 1,2x Einkommen ├óÔé¼ÔÇØ der saisonale H├â┬Âhepunkt. Winter ist mit 0,7x am niedrigsten. Aktivieren Sie einen hohen Multiplikator im Herbst f├â┬╝r maximales Einkommen.]]></de>
-            <fr><![CDATA[Avec les effets saisonniers, l'automne donne 1,2x ├óÔé¼ÔÇØ le pic saisonnier. L'hiver est le plus bas ├â┬á 0,7x. Envisagez un grand multiplicateur en automne pour un revenu maximum.]]></fr>
-            <pl><![CDATA[Przy efektach sezonowych jesie├àÔÇ× daje 1,2x ├óÔé¼ÔÇØ sezonowy szczyt. Zima jest najni├à┬╝sza (0,7x). Rozwa├à┬╝ wysoki mno├à┬╝nik jesieni├äÔÇª dla maksymalnego ├àÔÇÜ├äÔÇªczonego dochodu.]]></pl>
-            <es><![CDATA[Con efectos estacionales, el oto├â┬▒o da 1,2x ├óÔé¼ÔÇØ el pico estacional. El invierno es el m├â┬ís bajo con 0,7x. Considera usar un multiplicador alto en oto├â┬▒o para ingreso m├â┬íximo combinado.]]></es>
-            <it><![CDATA[Con gli effetti stagionali, l'autunno d├â┬á 1,2x ├óÔé¼ÔÇØ il picco stagionale. L'inverno ├â┬¿ il pi├â┬╣ basso con 0,7x. Considera un moltiplicatore alto in autunno per il massimo reddito combinato.]]></it>
-            <cz><![CDATA[Se sez├â┬│nn├â┬¡mi efekty p├àÔäóin├â┬í├à┬í├â┬¡ podzim 1,2x ├óÔé¼ÔÇØ sez├â┬│nn├â┬¡ vrchol. Zima je nejni├à┬¥├à┬í├â┬¡ (0,7x). Zva├à┬¥te vysok├â┬¢ multiplik├â┬ítor na podzim pro maxim├â┬íln├â┬¡ kombinovan├â┬¢ p├àÔäó├â┬¡jem.]]></cz>
-            <br><![CDATA[Com efeitos sazonais, o outono d├â┬í 1,2x ├óÔé¼ÔÇØ o pico sazonal. O inverno ├â┬® o mais baixo com 0,7x. Considere usar um multiplicador alto no outono para renda m├â┬íxima combinada.]]></br>
-            <uk><![CDATA[├É┼©├æÔé¼├É┬© ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├É┬©├æÔÇª ├É┬Á├æÔÇ×├É┬Á├É┬║├æÔÇÜ├É┬░├æÔÇª ├É┼¥├æ┬ü├æÔÇô├É┬¢├æ┼Æ ├É┬┤├É┬░├æÔÇØ 1,2x ├óÔé¼ÔÇØ ├É┬┐├æÔÇô├É┬║ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├æãÆ. ├ÉÔÇö├É┬©├É┬╝├É┬░ ├É┬¢├É┬░├É┬╣├É┬¢├É┬©├É┬Â├æÔÇí├É┬░ ├óÔé¼ÔÇØ 0,7x. ├É┬á├É┬¥├É┬À├É┬│├É┬╗├æ┬Å├É┬¢├æ┼Æ├æÔÇÜ├É┬Á ├É┬▓├É┬Á├É┬╗├É┬©├É┬║├É┬©├É┬╣ ├É┬╝├É┬¢├É┬¥├É┬Â├É┬¢├É┬©├É┬║ ├É┬▓├É┬¥├æ┬ü├É┬Á├É┬¢├É┬© ├É┬┤├É┬╗├æ┬Å ├É┬╝├É┬░├É┬║├æ┬ü├É┬©├É┬╝├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥├É┬│├É┬¥ ├æ┬ü├æãÆ├É┬║├æãÆ├É┬┐├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ.]]></uk>
-            <ru><![CDATA[├É┼©├æÔé¼├É┬© ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬¢├æÔÇ╣├æÔÇª ├æ┬ì├æÔÇ×├æÔÇ×├É┬Á├É┬║├æÔÇÜ├É┬░├æÔÇª ├É┼¥├æ┬ü├É┬Á├É┬¢├æ┼Æ ├É┬┤├É┬░├æÔÇÿ├æÔÇÜ 1,2x ├óÔé¼ÔÇØ ├É┬┐├É┬©├É┬║ ├æ┬ü├É┬Á├É┬À├É┬¥├É┬¢├É┬░. ├ÉÔÇö├É┬©├É┬╝├É┬░ ├É┬¢├É┬░├É┬©├É┬╝├É┬Á├É┬¢├æ┼Æ├æ╦å├É┬░├æ┬Å ├óÔé¼ÔÇØ 0,7x. ├É┬á├É┬░├æ┬ü├æ┬ü├É┬╝├É┬¥├æÔÇÜ├æÔé¼├É┬©├æÔÇÜ├É┬Á ├É┬▒├É┬¥├É┬╗├æ┼Æ├æ╦å├É┬¥├É┬╣ ├É┬╝├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┼Æ ├É┬¥├æ┬ü├É┬Á├É┬¢├æ┼Æ├æ┼¢ ├É┬┤├É┬╗├æ┬Å ├É┬╝├É┬░├É┬║├æ┬ü├É┬©├É┬╝├É┬░├É┬╗├æ┼Æ├É┬¢├É┬¥├É┬│├É┬¥ ├æ┬ü├É┬¥├É┬▓├É┬¥├É┬║├æãÆ├É┬┐├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░.]]></ru>
-            <da><![CDATA[Med s├â┬ªsonale effekter giver efter├â┬Ñret 1,2x ├óÔé¼ÔÇØ s├â┬ªsonens top. Vinter er lavest p├â┬Ñ 0,7x. Overvej at aktivere en h├â┬©j multiplikator om efter├â┬Ñret for maksimal kombineret indkomst.]]></da>
+            <en><![CDATA[With Seasonal Effects on, Autumn gives 1.2x income â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ the season peak. Winter is lowest at 0.7x. Consider enabling a high multiplier during Autumn for maximum combined income.]]></en>
+            <de><![CDATA[Mit saisonalen Effekten bietet Herbst 1,2x Einkommen â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ der saisonale Hâ”œÃ¢â”¬Ã‚hepunkt. Winter ist mit 0,7x am niedrigsten. Aktivieren Sie einen hohen Multiplikator im Herbst fâ”œÃ¢â”¬â•r maximales Einkommen.]]></de>
+            <fr><![CDATA[Avec les effets saisonniers, l'automne donne 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ le pic saisonnier. L'hiver est le plus bas â”œÃ¢â”¬Ã¡ 0,7x. Envisagez un grand multiplicateur en automne pour un revenu maximum.]]></fr>
+            <pl><![CDATA[Przy efektach sezonowych jesieâ”œÃ Ã”Ã‡Ã— daje 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ sezonowy szczyt. Zima jest najniâ”œÃ â”¬â•sza (0,7x). Rozwaâ”œÃ â”¬â• wysoki mnoâ”œÃ â”¬â•nik jesieniâ”œÃ¤Ã”Ã‡Âª dla maksymalnego â”œÃ Ã”Ã‡Ãœâ”œÃ¤Ã”Ã‡Âªczonego dochodu.]]></pl>
+            <es><![CDATA[Con efectos estacionales, el otoâ”œÃ¢â”¬â–’o da 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ el pico estacional. El invierno es el mâ”œÃ¢â”¬Ã­s bajo con 0,7x. Considera usar un multiplicador alto en otoâ”œÃ¢â”¬â–’o para ingreso mâ”œÃ¢â”¬Ã­ximo combinado.]]></es>
+            <it><![CDATA[Con gli effetti stagionali, l'autunno dâ”œÃ¢â”¬Ã¡ 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ il picco stagionale. L'inverno â”œÃ¢â”¬Â¿ il piâ”œÃ¢â”¬â•£ basso con 0,7x. Considera un moltiplicatore alto in autunno per il massimo reddito combinato.]]></it>
+            <cz><![CDATA[Se sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡mi efekty pâ”œÃ Ã”Ã¤Ã³inâ”œÃ¢â”¬Ã­â”œÃ â”¬Ã­â”œÃ¢â”¬Â¡ podzim 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ sezâ”œÃ¢â”¬â”‚nnâ”œÃ¢â”¬Â¡ vrchol. Zima je nejniâ”œÃ â”¬Â¥â”œÃ â”¬Ã­â”œÃ¢â”¬Â¡ (0,7x). Zvaâ”œÃ â”¬Â¥te vysokâ”œÃ¢â”¬Â¢ multiplikâ”œÃ¢â”¬Ã­tor na podzim pro maximâ”œÃ¢â”¬Ã­lnâ”œÃ¢â”¬Â¡ kombinovanâ”œÃ¢â”¬Â¢ pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jem.]]></cz>
+            <br><![CDATA[Com efeitos sazonais, o outono dâ”œÃ¢â”¬Ã­ 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ o pico sazonal. O inverno â”œÃ¢â”¬Â® o mais baixo com 0,7x. Considere usar um multiplicador alto no outono para renda mâ”œÃ¢â”¬Ã­xima combinada.]]></br>
+            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Âª â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª â”œÃ‰â”¼Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜ 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬â”â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â•‘ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã†. â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•£â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬Ã‚â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬â–‘ â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ 0,7x. â”œÃ‰â”¬Ã¡â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã€â”œÃ‰â”¬â”‚â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬â•â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘ â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â© â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•‘â”œÃ¦Ã£Ã†â”œÃ‰â”¬â”â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†.]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ¦Ã”Ã‡Âª â”œÃ¦â”¬Ã¬â”œÃ¦Ã”Ã‡Ã—â”œÃ¦Ã”Ã‡Ã—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Âª â”œÃ‰â”¼Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã† â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã¿â”œÃ¦Ã”Ã‡Ãœ 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ â”œÃ‰â”¬â”â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘. â”œÃ‰Ã”Ã‡Ã¶â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†â”œÃ¦â•¦Ã¥â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã… â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ 0,7x. â”œÃ‰â”¬Ã¡â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â–’â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦â•¦Ã¥â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£ â”œÃ‰â”¬â•â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã† â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ¦Ã£Ã†â”œÃ‰â”¬â”â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘.]]></ru>
+            <da><![CDATA[Med sâ”œÃ¢â”¬Âªsonale effekter giver efterâ”œÃ¢â”¬Ã‘ret 1,2x â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ sâ”œÃ¢â”¬Âªsonens top. Vinter er lavest pâ”œÃ¢â”¬Ã‘ 0,7x. Overvej at aktivere en hâ”œÃ¢â”¬Â©j multiplikator om efterâ”œÃ¢â”¬Ã‘ret for maksimal kombineret indkomst.]]></da>
         </text>
 
         <text name="im_help_t2_calc_title">
             <en><![CDATA[Income Formula]]></en>
             <de><![CDATA[Einkommensformel]]></de>
             <fr><![CDATA[Formule de revenu]]></fr>
-            <pl><![CDATA[Wz├â┬│r dochodu]]></pl>
-            <es><![CDATA[F├â┬│rmula de ingresos]]></es>
+            <pl><![CDATA[Wzâ”œÃ¢â”¬â”‚r dochodu]]></pl>
+            <es><![CDATA[Fâ”œÃ¢â”¬â”‚rmula de ingresos]]></es>
             <it><![CDATA[Formula del reddito]]></it>
-            <cz><![CDATA[Vzorec p├àÔäó├â┬¡jmu]]></cz>
-            <br><![CDATA[F├â┬│rmula de renda]]></br>
-            <uk><![CDATA[├É┬ñ├É┬¥├æÔé¼├É┬╝├æãÆ├É┬╗├É┬░ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ]]></uk>
-            <ru><![CDATA[├É┬ñ├É┬¥├æÔé¼├É┬╝├æãÆ├É┬╗├É┬░ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░]]></ru>
+            <cz><![CDATA[Vzorec pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmu]]></cz>
+            <br><![CDATA[Fâ”œÃ¢â”¬â”‚rmula de renda]]></br>
+            <uk><![CDATA[â”œÃ‰â”¬Ã±â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¬Ã±â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘]]></ru>
             <da><![CDATA[Indkomstformel]]></da>
         </text>
 
         <text name="im_help_t2_calc_text">
-            <en><![CDATA[Final = Base ├âÔÇö Multiplier ├âÔÇö Seasonal. Example: Hard ($1,100) ├âÔÇö 10x ├âÔÇö Autumn (1.2x) = $13,200 per period. Use the IncomeNext console command to preview your next scheduled payout.]]></en>
-            <de><![CDATA[Endwert = Basis ├âÔÇö Multiplikator ├âÔÇö Saisonfaktor. Beispiel: Schwer (1.100$) ├âÔÇö 10x ├âÔÇö Herbst (1,2x) = 13.200$ pro Zeitraum. IncomeNext in der Konsole zeigt die n├â┬ñchste Zahlung.]]></de>
-            <fr><![CDATA[Final = Base ├âÔÇö Multiplicateur ├âÔÇö Saisonnier. Exemple : Difficile (1 100$) ├âÔÇö 10x ├âÔÇö Automne (1,2x) = 13 200$ par p├â┬®riode. Utilisez IncomeNext en console pour voir la prochaine ├â┬®ch├â┬®ance.]]></fr>
-            <pl><![CDATA[Ko├àÔÇ×cowy = Podstawa ├âÔÇö Mno├à┬╝nik ├âÔÇö Sezon. Przyk├àÔÇÜad: Trudny (1 100$) ├âÔÇö 10x ├âÔÇö Jesie├àÔÇ× (1,2x) = 13 200$ za okres. U├à┬╝yj IncomeNext w konsoli, aby zobaczy├äÔÇí nast├äÔäópn├äÔÇª p├àÔÇÜatno├àÔÇ║├äÔÇí.]]></pl>
-            <es><![CDATA[Final = Base ├âÔÇö Multiplicador ├âÔÇö Estacional. Ejemplo: Dif├â┬¡cil ($1.100) ├âÔÇö 10x ├âÔÇö Oto├â┬▒o (1,2x) = $13.200 por per├â┬¡odo. Usa IncomeNext en consola para ver el pr├â┬│ximo pago programado.]]></es>
-            <it><![CDATA[Finale = Base ├âÔÇö Moltiplicatore ├âÔÇö Stagionale. Esempio: Difficile ($1.100) ├âÔÇö 10x ├âÔÇö Autunno (1,2x) = $13.200 per periodo. Usa IncomeNext in console per il prossimo pagamento.]]></it>
-            <cz><![CDATA[V├â┬¢sledek = Z├â┬íklad ├âÔÇö Multiplik├â┬ítor ├âÔÇö Sez├â┬│na. P├àÔäó├â┬¡klad: T├äÔÇ║├à┬¥k├â┬® (1 100$) ├âÔÇö 10x ├âÔÇö Podzim (1,2x) = 13 200$ za obdob├â┬¡. IncomeNext v konzoli uk├â┬í├à┬¥e p├àÔäó├â┬¡├à┬ít├â┬¡ platbu.]]></cz>
-            <br><![CDATA[Final = Base ├âÔÇö Multiplicador ├âÔÇö Sazonal. Exemplo: Dif├â┬¡cil ($1.100) ├âÔÇö 10x ├âÔÇö Outono (1,2x) = $13.200 por per├â┬¡odo. Use IncomeNext no console para ver o pr├â┬│ximo pagamento.]]></br>
-            <uk><![CDATA[├É┼©├æÔÇô├É┬┤├æ┬ü├æãÆ├É┬╝├É┬¥├É┬║ = ├ÉÔÇÿ├É┬░├É┬À├É┬░ ├âÔÇö ├É┼ô├É┬¢├É┬¥├É┬Â├É┬¢├É┬©├É┬║ ├âÔÇö ├É┬í├É┬Á├É┬À├É┬¥├É┬¢. ├É┼©├æÔé¼├É┬©├É┬║├É┬╗├É┬░├É┬┤: ├ÉÔÇÖ├É┬░├É┬Â├É┬║├É┬¥ ($1 100) ├âÔÇö 10x ├âÔÇö ├É┼¥├æ┬ü├æÔÇô├É┬¢├æ┼Æ (1,2x) = $13 200 ├É┬À├É┬░ ├É┬┐├É┬Á├æÔé¼├æÔÇô├É┬¥├É┬┤. IncomeNext ├æãÆ ├É┬║├É┬¥├É┬¢├æ┬ü├É┬¥├É┬╗├æÔÇô ├É┬┐├É┬¥├É┬║├É┬░├É┬Â├É┬Á ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æãÆ├É┬┐├É┬¢├æãÆ ├É┬▓├É┬©├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ.]]></uk>
-            <ru><![CDATA[├É╦£├æÔÇÜ├É┬¥├É┬│ = ├ÉÔÇÿ├É┬░├É┬À├É┬░ ├âÔÇö ├É┼ô├É┬¢├É┬¥├É┬Â├É┬©├æÔÇÜ├É┬Á├É┬╗├æ┼Æ ├âÔÇö ├É┬í├É┬Á├É┬À├É┬¥├É┬¢. ├É┼©├æÔé¼├É┬©├É┬╝├É┬Á├æÔé¼: ├É┬í├É┬╗├É┬¥├É┬Â├É┬¢├É┬¥ ($1 100) ├âÔÇö 10x ├âÔÇö ├É┼¥├æ┬ü├É┬Á├É┬¢├æ┼Æ (1,2x) = $13 200 ├É┬À├É┬░ ├É┬┐├É┬Á├æÔé¼├É┬©├É┬¥├É┬┤. IncomeNext ├É┬▓ ├É┬║├É┬¥├É┬¢├æ┬ü├É┬¥├É┬╗├É┬© ├É┬┐├É┬¥├É┬║├É┬░├É┬Â├É┬Á├æÔÇÜ ├æ┬ü├É┬╗├É┬Á├É┬┤├æãÆ├æ┼¢├æÔÇ░├æãÆ├æ┼¢ ├É┬▓├æÔÇ╣├É┬┐├É┬╗├É┬░├æÔÇÜ├æãÆ.]]></ru>
-            <da><![CDATA[Endelig = Base ├âÔÇö Multiplikator ├âÔÇö S├â┬ªson. Eksempel: Sv├â┬ªr ($1.100) ├âÔÇö 10x ├âÔÇö Efter├â┬Ñr (1,2x) = $13.200 pr. periode. Brug IncomeNext konsolkommandoen for at forh├â┬Ñndsvise din n├â┬ªste planlagte udbetaling.]]></da>
+            <en><![CDATA[Final = Base â”œÃ¢Ã”Ã‡Ã¶ Multiplier â”œÃ¢Ã”Ã‡Ã¶ Seasonal. Example: Hard ($1,100) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Autumn (1.2x) = $13,200 per period. Use the IncomeNext console command to preview your next scheduled payout.]]></en>
+            <de><![CDATA[Endwert = Basis â”œÃ¢Ã”Ã‡Ã¶ Multiplikator â”œÃ¢Ã”Ã‡Ã¶ Saisonfaktor. Beispiel: Schwer (1.100$) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Herbst (1,2x) = 13.200$ pro Zeitraum. IncomeNext in der Konsole zeigt die nâ”œÃ¢â”¬Ã±chste Zahlung.]]></de>
+            <fr><![CDATA[Final = Base â”œÃ¢Ã”Ã‡Ã¶ Multiplicateur â”œÃ¢Ã”Ã‡Ã¶ Saisonnier. Exemple : Difficile (1 100$) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Automne (1,2x) = 13 200$ par pâ”œÃ¢â”¬Â®riode. Utilisez IncomeNext en console pour voir la prochaine â”œÃ¢â”¬Â®châ”œÃ¢â”¬Â®ance.]]></fr>
+            <pl><![CDATA[Koâ”œÃ Ã”Ã‡Ã—cowy = Podstawa â”œÃ¢Ã”Ã‡Ã¶ Mnoâ”œÃ â”¬â•nik â”œÃ¢Ã”Ã‡Ã¶ Sezon. Przykâ”œÃ Ã”Ã‡Ãœad: Trudny (1 100$) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Jesieâ”œÃ Ã”Ã‡Ã— (1,2x) = 13 200$ za okres. Uâ”œÃ â”¬â•yj IncomeNext w konsoli, aby zobaczyâ”œÃ¤Ã”Ã‡Ã­ nastâ”œÃ¤Ã”Ã¤Ã³pnâ”œÃ¤Ã”Ã‡Âª pâ”œÃ Ã”Ã‡Ãœatnoâ”œÃ Ã”Ã‡â•‘â”œÃ¤Ã”Ã‡Ã­.]]></pl>
+            <es><![CDATA[Final = Base â”œÃ¢Ã”Ã‡Ã¶ Multiplicador â”œÃ¢Ã”Ã‡Ã¶ Estacional. Ejemplo: Difâ”œÃ¢â”¬Â¡cil ($1.100) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Otoâ”œÃ¢â”¬â–’o (1,2x) = $13.200 por perâ”œÃ¢â”¬Â¡odo. Usa IncomeNext en consola para ver el prâ”œÃ¢â”¬â”‚ximo pago programado.]]></es>
+            <it><![CDATA[Finale = Base â”œÃ¢Ã”Ã‡Ã¶ Moltiplicatore â”œÃ¢Ã”Ã‡Ã¶ Stagionale. Esempio: Difficile ($1.100) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Autunno (1,2x) = $13.200 per periodo. Usa IncomeNext in console per il prossimo pagamento.]]></it>
+            <cz><![CDATA[Vâ”œÃ¢â”¬Â¢sledek = Zâ”œÃ¢â”¬Ã­klad â”œÃ¢Ã”Ã‡Ã¶ Multiplikâ”œÃ¢â”¬Ã­tor â”œÃ¢Ã”Ã‡Ã¶ Sezâ”œÃ¢â”¬â”‚na. Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡klad: Tâ”œÃ¤Ã”Ã‡â•‘â”œÃ â”¬Â¥kâ”œÃ¢â”¬Â® (1 100$) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Podzim (1,2x) = 13 200$ za obdobâ”œÃ¢â”¬Â¡. IncomeNext v konzoli ukâ”œÃ¢â”¬Ã­â”œÃ â”¬Â¥e pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡â”œÃ â”¬Ã­tâ”œÃ¢â”¬Â¡ platbu.]]></cz>
+            <br><![CDATA[Final = Base â”œÃ¢Ã”Ã‡Ã¶ Multiplicador â”œÃ¢Ã”Ã‡Ã¶ Sazonal. Exemplo: Difâ”œÃ¢â”¬Â¡cil ($1.100) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Outono (1,2x) = $13.200 por perâ”œÃ¢â”¬Â¡odo. Use IncomeNext no console para ver o prâ”œÃ¢â”¬â”‚ximo pagamento.]]></br>
+            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ¦â”¬Ã¼â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘ = â”œÃ‰Ã”Ã‡Ã¿â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ¢Ã”Ã‡Ã¶ â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘ â”œÃ¢Ã”Ã‡Ã¶ â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ‰â”¬â”¤: â”œÃ‰Ã”Ã‡Ã–â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥ ($1 100) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ â”œÃ‰â”¼Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã† (1,2x) = $13 200 â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤. IncomeNext â”œÃ¦Ã£Ã† â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ã â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â”â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ‰â”¬â–“â”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†.]]></uk>
+            <ru><![CDATA[â”œÃ‰â•¦Â£â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚ = â”œÃ‰Ã”Ã‡Ã¿â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ¢Ã”Ã‡Ã¶ â”œÃ‰â”¼Ã´â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•—â”œÃ¦â”¼Ã† â”œÃ¢Ã”Ã‡Ã¶ â”œÃ‰â”¬Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã€â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢. â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼: â”œÃ‰â”¬Ã­â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥ ($1 100) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ â”œÃ‰â”¼Â¥â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ¦â”¼Ã† (1,2x) = $13 200 â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–‘ â”œÃ‰â”¬â”â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤. IncomeNext â”œÃ‰â”¬â–“ â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â© â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡â–‘â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†.]]></ru>
+            <da><![CDATA[Endelig = Base â”œÃ¢Ã”Ã‡Ã¶ Multiplikator â”œÃ¢Ã”Ã‡Ã¶ Sâ”œÃ¢â”¬Âªson. Eksempel: Svâ”œÃ¢â”¬Âªr ($1.100) â”œÃ¢Ã”Ã‡Ã¶ 10x â”œÃ¢Ã”Ã‡Ã¶ Efterâ”œÃ¢â”¬Ã‘r (1,2x) = $13.200 pr. periode. Brug IncomeNext konsolkommandoen for at forhâ”œÃ¢â”¬Ã‘ndsvise din nâ”œÃ¢â”¬Âªste planlagte udbetaling.]]></da>
         </text>
 
-        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Help Lines: Page 8 ├óÔé¼ÔÇØ About ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
+        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Help Lines: Page 8 â”œÃ³Ã”Ã©Â¼Ã”Ã‡Ã˜ About â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
         <text name="im_help_i1_about_title">
             <en><![CDATA[About This Mod]]></en>
-            <de><![CDATA[├â┼ôber diesen Mod]]></de>
-            <fr><![CDATA[├âÔé¼ propos de ce mod]]></fr>
+            <de><![CDATA[â”œÃ¢â”¼Ã´ber diesen Mod]]></de>
+            <fr><![CDATA[â”œÃ¢Ã”Ã©Â¼ propos de ce mod]]></fr>
             <pl><![CDATA[O tym modzie]]></pl>
             <es><![CDATA[Acerca de este mod]]></es>
             <it><![CDATA[Informazioni su questo mod]]></it>
             <cz><![CDATA[O tomto modu]]></cz>
             <br><![CDATA[Sobre este mod]]></br>
-            <uk><![CDATA[├É┼©├æÔé¼├É┬¥ ├æÔÇá├É┬Á├É┬╣ ├É┬╝├É┬¥├É┬┤]]></uk>
-            <ru><![CDATA[├É┼¥├É┬▒ ├æ┬ì├æÔÇÜ├É┬¥├É┬╝ ├É┬╝├É┬¥├É┬┤├É┬Á]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¼Â©â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥ â”œÃ¦Ã”Ã‡Ã¡â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•£ â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ‰â”¬â–’ â”œÃ¦â”¬Ã¬â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â• â”œÃ‰â”¬â•â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬Ã]]></ru>
             <da><![CDATA[Om denne mod]]></da>
         </text>
 
         <text name="im_help_i1_about_text">
             <en><![CDATA[Income Mod v2.0 adds a fully configurable passive income system to FS25. All settings persist per savegame. Compatible with multiplayer and other mods.]]></en>
-            <de><![CDATA[Einkommens-Mod v2.0 f├â┬╝gt FS25 ein vollst├â┬ñndig konfigurierbares passives Einkommenssystem hinzu. Alle Einstellungen werden pro Spielstand gespeichert. Multiplayer-kompatibel.]]></de>
-            <fr><![CDATA[Income Mod v2.0 ajoute un syst├â┬¿me de revenus passifs enti├â┬¿rement configurable ├â┬á FS25. Tous les param├â┬¿tres persistent par sauvegarde. Compatible multijoueur et autres mods.]]></fr>
-            <pl><![CDATA[Income Mod v2.0 dodaje do FS25 w pe├àÔÇÜni konfigurowalny system pasywnych dochod├â┬│w. Wszystkie ustawienia s├äÔÇª zachowywane dla ka├à┬╝dego zapisu. Kompatybilny z wieloosobowym.]]></pl>
-            <es><![CDATA[Income Mod v2.0 a├â┬▒ade un sistema de ingresos pasivos totalmente configurable a FS25. Todos los ajustes persisten por guardado. Compatible con multijugador y otros mods.]]></es>
+            <de><![CDATA[Einkommens-Mod v2.0 fâ”œÃ¢â”¬â•gt FS25 ein vollstâ”œÃ¢â”¬Ã±ndig konfigurierbares passives Einkommenssystem hinzu. Alle Einstellungen werden pro Spielstand gespeichert. Multiplayer-kompatibel.]]></de>
+            <fr><![CDATA[Income Mod v2.0 ajoute un systâ”œÃ¢â”¬Â¿me de revenus passifs entiâ”œÃ¢â”¬Â¿rement configurable â”œÃ¢â”¬Ã¡ FS25. Tous les paramâ”œÃ¢â”¬Â¿tres persistent par sauvegarde. Compatible multijoueur et autres mods.]]></fr>
+            <pl><![CDATA[Income Mod v2.0 dodaje do FS25 w peâ”œÃ Ã”Ã‡Ãœni konfigurowalny system pasywnych dochodâ”œÃ¢â”¬â”‚w. Wszystkie ustawienia sâ”œÃ¤Ã”Ã‡Âª zachowywane dla kaâ”œÃ â”¬â•dego zapisu. Kompatybilny z wieloosobowym.]]></pl>
+            <es><![CDATA[Income Mod v2.0 aâ”œÃ¢â”¬â–’ade un sistema de ingresos pasivos totalmente configurable a FS25. Todos los ajustes persisten por guardado. Compatible con multijugador y otros mods.]]></es>
             <it><![CDATA[Income Mod v2.0 aggiunge un sistema di reddito passivo completamente configurabile a FS25. Tutte le impostazioni persistono per salvataggio. Compatibile con multigiocatore e altri mod.]]></it>
-            <cz><![CDATA[Income Mod v2.0 p├àÔäóid├â┬ív├â┬í do FS25 pln├äÔÇ║ konfigurovateln├â┬¢ syst├â┬®m pasivn├â┬¡ho p├àÔäó├â┬¡jmu. V├à┬íechna nastaven├â┬¡ jsou zachov├â┬ína pro ka├à┬¥d├â┬¢ ulo├à┬¥en├â┬¢ stav. Kompatibiln├â┬¡ s v├â┬¡ce hr├â┬í├ä┬ìi.]]></cz>
-            <br><![CDATA[O Income Mod v2.0 adiciona um sistema de renda passiva totalmente configur├â┬ível ao FS25. Todas as configura├â┬º├â┬Áes persistem por salvamento. Compat├â┬¡vel com multiplayer e outros mods.]]></br>
-            <uk><![CDATA[Income Mod v2.0 ├É┬┤├É┬¥├É┬┤├É┬░├æÔÇØ ├É┬┤├É┬¥ FS25 ├É┬┐├É┬¥├É┬▓├É┬¢├æÔÇô├æ┬ü├æÔÇÜ├æ┼¢ ├É┬¢├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├É┬¥├É┬▓├æãÆ├É┬▓├É┬░├É┬¢├æãÆ ├æ┬ü├É┬©├æ┬ü├æÔÇÜ├É┬Á├É┬╝├æãÆ ├É┬┐├É┬░├æ┬ü├É┬©├É┬▓├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├æãÆ. ├ÉÔÇÖ├æ┬ü├æÔÇô ├É┬¢├É┬░├É┬╗├É┬░├æ╦å├æÔÇÜ├æãÆ├É┬▓├É┬░├É┬¢├É┬¢├æ┬Å ├É┬À├É┬▒├É┬Á├æÔé¼├æÔÇô├É┬│├É┬░├æ┼¢├æÔÇÜ├æ┼Æ├æ┬ü├æ┬Å ├É┬┤├É┬╗├æ┬Å ├É┬║├É┬¥├É┬Â├É┬¢├É┬¥├É┬│├É┬¥ ├É┬À├É┬▒├É┬Á├æÔé¼├É┬Á├É┬Â├É┬Á├É┬¢├É┬¢├æ┬Å. ├É┬í├æãÆ├É┬╝├æÔÇô├æ┬ü├É┬¢├É┬©├É┬╣ ├É┬À ├É┬╝├æãÆ├É┬╗├æ┼Æ├æÔÇÜ├É┬©├É┬┐├É┬╗├É┬Á├æÔÇØ├æÔé¼├É┬¥├É┬╝.]]></uk>
-            <ru><![CDATA[Income Mod v2.0 ├É┬┤├É┬¥├É┬▒├É┬░├É┬▓├É┬╗├æ┬Å├É┬Á├æÔÇÜ ├É┬▓ FS25 ├É┬┐├É┬¥├É┬╗├É┬¢├É┬¥├æ┬ü├æÔÇÜ├æ┼Æ├æ┼¢ ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬░├É┬©├É┬▓├É┬░├É┬Á├É┬╝├æãÆ├æ┼¢ ├æ┬ü├É┬©├æ┬ü├æÔÇÜ├É┬Á├É┬╝├æãÆ ├É┬┐├É┬░├æ┬ü├æ┬ü├É┬©├É┬▓├É┬¢├É┬¥├É┬│├É┬¥ ├É┬┤├É┬¥├æÔÇª├É┬¥├É┬┤├É┬░. ├ÉÔÇÖ├æ┬ü├É┬Á ├É┬¢├É┬░├æ┬ü├æÔÇÜ├æÔé¼├É┬¥├É┬╣├É┬║├É┬© ├æ┬ü├É┬¥├æÔÇª├æÔé¼├É┬░├É┬¢├æ┬Å├æ┼¢├æÔÇÜ├æ┬ü├æ┬Å ├É┬┤├É┬╗├æ┬Å ├É┬║├É┬░├É┬Â├É┬┤├É┬¥├É┬│├É┬¥ ├æ┬ü├É┬¥├æÔÇª├æÔé¼├É┬░├É┬¢├É┬Á├É┬¢├É┬©├æ┬Å. ├É┬í├É┬¥├É┬▓├É┬╝├É┬Á├æ┬ü├æÔÇÜ├É┬©├É┬╝ ├æ┬ü ├É┬╝├æãÆ├É┬╗├æ┼Æ├æÔÇÜ├É┬©├É┬┐├É┬╗├É┬Á├É┬Á├æÔé¼├É┬¥├É┬╝.]]></ru>
-            <da><![CDATA[Income Mod v2.0 tilf├â┬©jer et fuldt konfigurerbart passivt indkomstsystem til FS25. Alle indstillinger bevares pr. gemt spil. Kompatibel med multiplayer og andre mods.]]></da>
+            <cz><![CDATA[Income Mod v2.0 pâ”œÃ Ã”Ã¤Ã³idâ”œÃ¢â”¬Ã­vâ”œÃ¢â”¬Ã­ do FS25 plnâ”œÃ¤Ã”Ã‡â•‘ konfigurovatelnâ”œÃ¢â”¬Â¢ systâ”œÃ¢â”¬Â®m pasivnâ”œÃ¢â”¬Â¡ho pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡jmu. Vâ”œÃ â”¬Ã­echna nastavenâ”œÃ¢â”¬Â¡ jsou zachovâ”œÃ¢â”¬Ã­na pro kaâ”œÃ â”¬Â¥dâ”œÃ¢â”¬Â¢ uloâ”œÃ â”¬Â¥enâ”œÃ¢â”¬Â¢ stav. Kompatibilnâ”œÃ¢â”¬Â¡ s vâ”œÃ¢â”¬Â¡ce hrâ”œÃ¢â”¬Ã­â”œÃ¤â”¬Ã¬i.]]></cz>
+            <br><![CDATA[O Income Mod v2.0 adiciona um sistema de renda passiva totalmente configurâ”œÃ¢â”¬Ã­vel ao FS25. Todas as configuraâ”œÃ¢â”¬Âºâ”œÃ¢â”¬Ães persistem por salvamento. Compatâ”œÃ¢â”¬Â¡vel com multiplayer e outros mods.]]></br>
+            <uk><![CDATA[Income Mod v2.0 â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘â”œÃ¦Ã”Ã‡Ã˜ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥ FS25 â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Â¢ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ¦Ã£Ã† â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ¦Ã£Ã†. â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ‰â”¬â•—â”œÃ‰â”¬â–‘â”œÃ¦â•¦Ã¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã£Ã†â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã… â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–’â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”‚â”œÃ‰â”¬â–‘â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Ã‚â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬Ã€â”œÃ‰â”¬â–’â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ã‚â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…. â”œÃ‰â”¬Ã­â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•â”œÃ¦Ã”Ã‡Ã´â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£ â”œÃ‰â”¬Ã€ â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ã˜â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•.]]></uk>
+            <ru><![CDATA[Income Mod v2.0 â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–’â”œÃ‰â”¬â–‘â”œÃ‰â”¬â–“â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã…â”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã‡Ãœ â”œÃ‰â”¬â–“ FS25 â”œÃ‰â”¬â”â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã†â”œÃ¦â”¼Â¢ â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â©â”œÃ‰â”¬â–“â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ¦â”¼Â¢ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ãâ”œÃ‰â”¬â•â”œÃ¦Ã£Ã† â”œÃ‰â”¬â”â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â–“â”œÃ‰â”¬Â¢â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ‰â”¬Â¥â”œÃ‰â”¬â”¤â”œÃ‰â”¬â–‘. â”œÃ‰Ã”Ã‡Ã–â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Ã â”œÃ‰â”¬Â¢â”œÃ‰â”¬â–‘â”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â© â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã…â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¬Ã¼â”œÃ¦â”¬Ã… â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•—â”œÃ¦â”¬Ã… â”œÃ‰â”¬â•‘â”œÃ‰â”¬â–‘â”œÃ‰â”¬Ã‚â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â¥â”œÃ‰â”¬â”‚â”œÃ‰â”¬Â¥ â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ¦Ã”Ã‡Âªâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬Ãâ”œÃ‰â”¬Â¢â”œÃ‰â”¬Â©â”œÃ¦â”¬Ã…. â”œÃ‰â”¬Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ‰â”¬â•â”œÃ‰â”¬Ãâ”œÃ¦â”¬Ã¼â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â• â”œÃ¦â”¬Ã¼ â”œÃ‰â”¬â•â”œÃ¦Ã£Ã†â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Â©â”œÃ‰â”¬â”â”œÃ‰â”¬â•—â”œÃ‰â”¬Ãâ”œÃ‰â”¬Ãâ”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•.]]></ru>
+            <da><![CDATA[Income Mod v2.0 tilfâ”œÃ¢â”¬Â©jer et fuldt konfigurerbart passivt indkomstsystem til FS25. Alle indstillinger bevares pr. gemt spil. Kompatibel med multiplayer og andre mods.]]></da>
         </text>
 
         <text name="im_help_i1_cmd_title">
@@ -1432,25 +1432,25 @@
             <pl><![CDATA[Komendy konsoli]]></pl>
             <es><![CDATA[Comandos de consola]]></es>
             <it><![CDATA[Comandi console]]></it>
-            <cz><![CDATA[P├àÔäó├â┬¡kazy konzole]]></cz>
+            <cz><![CDATA[Pâ”œÃ Ã”Ã¤Ã³â”œÃ¢â”¬Â¡kazy konzole]]></cz>
             <br><![CDATA[Comandos do console]]></br>
-            <uk><![CDATA[├É┼í├É┬¥├É┬¢├æ┬ü├É┬¥├É┬╗├æ┼Æ├É┬¢├æÔÇô ├É┬║├É┬¥├É┬╝├É┬░├É┬¢├É┬┤├É┬©]]></uk>
-            <ru><![CDATA[├É┼í├É┬¥├É┬¢├æ┬ü├É┬¥├É┬╗├æ┼Æ├É┬¢├æÔÇ╣├É┬Á ├É┬║├É┬¥├É┬╝├É┬░├É┬¢├É┬┤├æÔÇ╣]]></ru>
+            <uk><![CDATA[â”œÃ‰â”¼Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã†â”œÃ‰â”¬Â¢â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬Ã â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•â”œÃ‰â”¬â–‘â”œÃ‰â”¬Â¢â”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡â•£]]></ru>
             <da><![CDATA[Konsolkommandoer]]></da>
         </text>
 
         <text name="im_help_i1_cmd_text">
             <en><![CDATA[Open the developer console (~) and type 'income' for the full list. Key commands: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></en>
-            <de><![CDATA[Entwicklerkonsole (~) ├â┬Âffnen und 'income' eingeben. Wichtige Befehle: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></de>
-            <fr><![CDATA[Ouvrez la console (~) et tapez 'income' pour la liste. Commandes cl├â┬®s : IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></fr>
-            <pl><![CDATA[Otw├â┬│rz konsol├äÔäó (~) i wpisz 'income'. Kluczowe: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></pl>
+            <de><![CDATA[Entwicklerkonsole (~) â”œÃ¢â”¬Ã‚ffnen und 'income' eingeben. Wichtige Befehle: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></de>
+            <fr><![CDATA[Ouvrez la console (~) et tapez 'income' pour la liste. Commandes clâ”œÃ¢â”¬Â®s : IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></fr>
+            <pl><![CDATA[Otwâ”œÃ¢â”¬â”‚rz konsolâ”œÃ¤Ã”Ã¤Ã³ (~) i wpisz 'income'. Kluczowe: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></pl>
             <es><![CDATA[Abre la consola (~) y escribe 'income'. Comandos clave: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></es>
             <it><![CDATA[Apri la console (~) e digita 'income'. Comandi chiave: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></it>
-            <cz><![CDATA[Otev├àÔäóete konzoli (~) a zadejte 'income'. Kl├â┬¡├ä┬ìov├â┬®: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></cz>
+            <cz><![CDATA[Otevâ”œÃ Ã”Ã¤Ã³ete konzoli (~) a zadejte 'income'. Klâ”œÃ¢â”¬Â¡â”œÃ¤â”¬Ã¬ovâ”œÃ¢â”¬Â®: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></cz>
             <br><![CDATA[Abra o console (~) e digite 'income'. Principais: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></br>
-            <uk><![CDATA[├ÉÔÇÖ├æÔÇô├É┬┤├É┬║├æÔé¼├É┬©├É┬╣├æÔÇÜ├É┬Á ├É┬║├É┬¥├É┬¢├æ┬ü├É┬¥├É┬╗├æ┼Æ (~) ├æÔÇô ├É┬▓├É┬▓├É┬Á├É┬┤├æÔÇô├æÔÇÜ├æ┼Æ 'income'. ├É┼í├É┬╗├æ┼¢├æÔÇí├É┬¥├É┬▓├æÔÇô: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></uk>
-            <ru><![CDATA[├É┼¥├æÔÇÜ├É┬║├æÔé¼├É┬¥├É┬╣├æÔÇÜ├É┬Á ├É┬║├É┬¥├É┬¢├æ┬ü├É┬¥├É┬╗├æ┼Æ (~) ├É┬© ├É┬▓├É┬▓├É┬Á├É┬┤├É┬©├æÔÇÜ├É┬Á 'income'. ├É┼í├É┬╗├æ┼¢├æÔÇí├É┬Á├É┬▓├æÔÇ╣├É┬Á: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></ru>
-            <da><![CDATA[├âÔÇªbn udviklerkonsollen (~) og skriv 'income' for den fulde liste. N├â┬©glekommandoer: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></da>
+            <uk><![CDATA[â”œÃ‰Ã”Ã‡Ã–â”œÃ¦Ã”Ã‡Ã´â”œÃ‰â”¬â”¤â”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â©â”œÃ‰â”¬â•£â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã† (~) â”œÃ¦Ã”Ã‡Ã´ â”œÃ‰â”¬â–“â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ¦Ã”Ã‡Ã´â”œÃ¦Ã”Ã‡Ãœâ”œÃ¦â”¼Ã† 'income'. â”œÃ‰â”¼Ã­â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Â¥â”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡Ã´: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></uk>
+            <ru><![CDATA[â”œÃ‰â”¼Â¥â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬â•‘â”œÃ¦Ã”Ã©Â¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•£â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã â”œÃ‰â”¬â•‘â”œÃ‰â”¬Â¥â”œÃ‰â”¬Â¢â”œÃ¦â”¬Ã¼â”œÃ‰â”¬Â¥â”œÃ‰â”¬â•—â”œÃ¦â”¼Ã† (~) â”œÃ‰â”¬Â© â”œÃ‰â”¬â–“â”œÃ‰â”¬â–“â”œÃ‰â”¬Ãâ”œÃ‰â”¬â”¤â”œÃ‰â”¬Â©â”œÃ¦Ã”Ã‡Ãœâ”œÃ‰â”¬Ã 'income'. â”œÃ‰â”¼Ã­â”œÃ‰â”¬â•—â”œÃ¦â”¼Â¢â”œÃ¦Ã”Ã‡Ã­â”œÃ‰â”¬Ãâ”œÃ‰â”¬â–“â”œÃ¦Ã”Ã‡â•£â”œÃ‰â”¬Ã: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></ru>
+            <da><![CDATA[â”œÃ¢Ã”Ã‡Âªbn udviklerkonsollen (~) og skriv 'income' for den fulde liste. Nâ”œÃ¢â”¬Â©glekommandoer: IncomeShowSettings, IncomeHistory, IncomeNext, IncomeTestPayment, IncomeSetDifficulty 1|2|3, IncomeResetSettings.]]></da>
         </text>
     
 
@@ -2088,12 +2088,12 @@
     </l10n>
 
     <!--
-        Help pages accessible in-game via: Pause Menu ├óÔÇáÔÇÖ Help.
+        Help pages accessible in-game via: Pause Menu â”œÃ³Ã”Ã‡Ã¡Ã”Ã‡Ã– Help.
         Four categories: Overview, Settings, Tips & Tricks, About.
     -->
     <helpLines>
 
-        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Category 1: Overview ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
+        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Category 1: Overview â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
         <category title="$l10n_im_help_cat_overview">
 
             <page title="$l10n_im_help_p1_title" iconSliceId="icon_info">
@@ -2120,7 +2120,7 @@
 
         </category>
 
-        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Category 2: Settings ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
+        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Category 2: Settings â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
         <category title="$l10n_im_help_cat_settings">
 
             <page title="$l10n_im_help_s1_title" iconSliceId="icon_info">
@@ -2170,7 +2170,7 @@
 
         </category>
 
-        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Category 3: Tips & Tricks ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
+        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Category 3: Tips & Tricks â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
         <category title="$l10n_im_help_cat_tips">
 
             <page title="$l10n_im_help_t1_title" iconSliceId="icon_info">
@@ -2197,7 +2197,7 @@
 
         </category>
 
-        <!-- ├óÔÇØÔé¼├óÔÇØÔé¼ Category 4: About ├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼├óÔÇØÔé¼ -->
+        <!-- â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ Category 4: About â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼â”œÃ³Ã”Ã‡Ã˜Ã”Ã©Â¼ -->
         <category title="$l10n_im_help_cat_info">
 
             <page title="$l10n_im_help_i1_title" iconSliceId="icon_info">

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -209,18 +209,30 @@
 
                         <!-- Card 2 of 3 (BUILD 12:59): Selected + Next now live INSIDE the
                              PRODUCTS card, so the card owns the whole middle column. -->
-                        <GuiElement profile="RF_EscCardFrame" id="treatProductsShell" position="220px -22px">
-                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -6px" size="540px 20px"
+                        <!-- GO 21:06 (BUILD 21:01): PRODUCTS was inheriting 560 from
+                             RF_EscCardFrame, so its right edge sat at 220 + 560 = 780 against
+                             ROTATION at 850: a dark 70px canyon down the middle of a three-card
+                             family. The inline 620 lands the right edge on 840, leaving 10px of
+                             air, and TREATMENT already ends at 210 against PRODUCTS at 220, so
+                             both gutters read as the same gap. Family rhythm, not a kiss.
+                             Bodies follow 540 -> 600 in step so the 10px left inset is kept and
+                             nothing is re-centred; RATE and TOTAL keep their left-anchored
+                             recipe and simply gain trailing air.
+                             This edit is in ALL NINE door copies on purpose. The Esc page is
+                             built by whichever mod loads first, from its own copy, so a change
+                             in Soil alone would be overwritten by whoever won the race. -->
+                        <GuiElement profile="RF_EscCardFrame" id="treatProductsShell" position="220px -22px" size="620px 248px">
+                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -6px" size="600px 20px"
                                   textAlignment="left"/>
-                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -26px" size="540px 36px"
+                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -26px" size="600px 36px"
                                   textAlignment="left" textMaxNumLines="2" textVerticalAlignment="top"/>
                             <!-- Zone split (BUILD 16:19): Selected + Next stay on top, then ~16px of
                                  air with one 1px hairline centred in it, then the PRODUCTS table.
                                  One outer outline only; the rule is a Bitmap, not a second frame.
                                  Bodies inset X 0 -> 10 and widths 560 -> 540 so nothing kisses the
                                  white stroke on either side. -->
-                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -70px" size="540px 1px"/>
-                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -80px" size="540px 18px"
+                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -70px" size="600px 1px"/>
+                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -80px" size="600px 18px"
                                   text="$l10n_rf_pda_treat_products"/>
                             <Text profile="RF_ProductColHeaderDense" position="10px -100px" size="40px 16px" text="NUT"/>
                             <Text profile="RF_ProductColHeaderDense" position="54px -100px" size="270px 16px" text="PRODUCT"/>
@@ -228,54 +240,54 @@
                                   textAlignment="right" text="RATE"/>
                             <Text profile="RF_ProductColHeaderDense" position="440px -100px" size="110px 16px"
                                   textAlignment="right" text="TOTAL"/>
-                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -120px" size="540px 22px"
+                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -120px" size="600px 22px"
                                   visible="false"/>
                             <!-- Clip sized to exactly the eight densified rows (8 x 15 = 120), so the
                                  card bottom keeps 8px of air instead of cutting row 8 mid-glyph. -->
-                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -120px" size="540px 120px">
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow1" position="0px 0px" size="540px 15px" visible="false">
+                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -120px" size="600px 120px">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow1" position="0px 0px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd1Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd1Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd1Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd1Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow2" position="0px -15px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow2" position="0px -15px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd2Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd2Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd2Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd2Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow3" position="0px -30px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow3" position="0px -30px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd3Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd3Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd3Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd3Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow4" position="0px -45px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow4" position="0px -45px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd4Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd4Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd4Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd4Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow5" position="0px -60px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow5" position="0px -60px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd5Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd5Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd5Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd5Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow6" position="0px -75px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow6" position="0px -75px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd6Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd6Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd6Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd6Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow7" position="0px -90px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow7" position="0px -90px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd7Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd7Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd7Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd7Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow8" position="0px -105px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow8" position="0px -105px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd8Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd8Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd8Rate" position="320px 0px" size="100px 15px"/>
@@ -341,58 +353,80 @@
                     <!-- Worker Costs page bodies only (page chrome = left sibling band). -->
                     <GuiElement profile="RF_WcPageShell" id="wcPageShell" visible="false">
                         <!-- Dashboard -->
-                        <GuiElement profile="RF_WcPage" id="wcPageDashboard" visible="true">
-                            <Text profile="RF_TreatTargetLine" id="wcDashStatus" position="0px 0px" size="1140px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashMode" position="0px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashWage" position="580px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashRate" position="0px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashWorkers" position="580px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashEstimate" position="0px -144px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashCountdown" position="580px -144px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="wcDashWorkerNames" position="0px -200px" size="1140px 280px"
+                        <!-- Dashboard is the only WC page that gets the white card (Ash 15:35 #2):
+                             Wages/Workers/About carry MTOs and their own chrome. Framed on
+                             wcPageDashboard itself, not a new inner shell, so nothing double-frames.
+                             Body cells inset 10px L/R and 8px down; worker names still 280 tall and
+                             end at -488 of 500, so 12px of bottom air and no clip. -->
+                        <GuiElement profile="RF_EscCardFrameWide" id="wcPageDashboard" visible="true">
+                            <Text profile="RF_TreatTargetLine" id="wcDashStatus" position="10px -8px" size="1120px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashMode" position="10px -56px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashWage" position="580px -56px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashRate" position="10px -104px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashWorkers" position="580px -104px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashEstimate" position="10px -152px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashCountdown" position="580px -152px" size="550px 22px" text=""/>
+                            <Text profile="RF_HintText" id="wcDashWorkerNames" position="10px -208px" size="1120px 280px"
                                   textMaxNumLines="12" textVerticalAlignment="top" text=""/>
                         </GuiElement>
 
                         <!-- Wages: tight label+option rows; summary/help/Reset UNDER stack (no 760 side column). -->
+                        <!-- Two cards, not one: settings stack up, summary/help/Reset below, 16px of
+                             clear air between the strokes. The page itself stays unframed - a frame on
+                             RF_WcPage would be the mega-shell over the MTOs George vetoed. Wrappers carry
+                             handleFocus=false so nothing between the player and an option can take a click,
+                             and the MTOs are still found by getDescendantById, which does not care how deep
+                             they sit. Card B trims one internal gap by 8px, which is exactly what the two
+                             strokes plus their air cost, so wcBtnWageReset lands back on -536 and the page
+                             stays 580 tall. Nothing grew to make room. -->
                         <GuiElement profile="RF_WcPage" id="wcPageWages" size="1140px 580px" visible="false">
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblEnabled" position="0px 8px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptEnabled" position="220px 0px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblMode" position="0px -44px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptCostMode" position="220px -52px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblLevel" position="0px -96px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptWageLevel" position="220px -104px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblNotify" position="0px -148px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptNotifications" position="220px -156px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblDebug" position="0px -200px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptDebugMode" position="220px -208px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblSalary" position="0px -252px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptMonthlySalary" position="220px -260px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <!-- Summary band under last option (~-260); full width; not overlapping options. -->
-                            <Text profile="RF_SectionTitle" id="wcWageBigRate" position="0px -340px" size="1140px 36px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageRateLabel" position="0px -384px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcWagePayInterval" position="580px -384px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="wcWageHelpBody" position="0px -420px" size="1140px 100px"
-                                  textMaxNumLines="4" textVerticalAlignment="top" text=""/>
-                            <Button profile="buttonActivate" id="wcBtnWageReset" position="0px -536px" size="200px 36px"
-                                    text="Reset" onClick="onClickWcWageReset"/>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWagesCardA" position="0px 0px" size="1140px 326px" handleFocus="false">
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblEnabled" position="10px -10px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptEnabled" position="230px -18px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblMode" position="10px -62px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptCostMode" position="230px -70px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblLevel" position="10px -114px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptWageLevel" position="230px -122px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblNotify" position="10px -166px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptNotifications" position="230px -174px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblDebug" position="10px -218px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptDebugMode" position="230px -226px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblSalary" position="10px -270px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptMonthlySalary" position="230px -278px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                            </GuiElement>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWagesCardB" position="0px -342px" size="1140px 238px" handleFocus="false">
+                                <Text profile="RF_SectionTitle" id="wcWageBigRate" position="10px -6px" size="1120px 36px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageRateLabel" position="10px -50px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcWagePayInterval" position="580px -50px" size="550px 22px" text=""/>
+                                <Text profile="RF_HintText" id="wcWageHelpBody" position="10px -86px" size="1120px 100px"
+                                      textMaxNumLines="4" textVerticalAlignment="top" text=""/>
+                                <Button profile="buttonActivate" id="wcBtnWageReset" position="10px -194px" size="200px 36px"
+                                        text="Reset" onClick="onClickWcWageReset"/>
+                            </GuiElement>
                         </GuiElement>
 
                         <!-- Workers -->
+                        <!-- Same family as Wages: stats card, 16px of air, then the worker list card.
+                             wcStatsWorkerList stays fixed Text rows, no SmoothList. -->
                         <GuiElement profile="RF_WcPage" id="wcPageWorkers" visible="false">
-                            <Text profile="RF_TreatTargetLine" id="wcStatsMode" position="0px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsWage" position="580px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsInterval" position="0px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsCount" position="580px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsCostPer" position="0px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsTotal" position="580px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="wcStatsWorkerList" position="0px -160px" size="1140px 320px"
-                                  textMaxNumLines="14" textVerticalAlignment="top" text=""/>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWorkersCardA" position="0px 0px" size="1140px 136px" handleFocus="false">
+                                <Text profile="RF_TreatTargetLine" id="wcStatsMode" position="10px -10px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsWage" position="580px -10px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsInterval" position="10px -58px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsCount" position="580px -58px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsCostPer" position="10px -106px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsTotal" position="580px -106px" size="550px 22px" text=""/>
+                            </GuiElement>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWorkersCardB" position="0px -152px" size="1140px 338px" handleFocus="false">
+                                <Text profile="RF_HintText" id="wcStatsWorkerList" position="10px -10px" size="1120px 320px"
+                                      textMaxNumLines="14" textVerticalAlignment="top" text=""/>
+                            </GuiElement>
                         </GuiElement>
 
                         <!-- About page retired 2026-08-02: copy lives in wcSideInfoShell. Keep shell for nil-safe ids. -->
@@ -417,61 +451,84 @@
                          Text-only; no onClick. Visible only for framework module ids.
                          George 2026-08-05: shell 0/-20 (X flush + B1 blurb-48 clearance); titles hidden; rows +36. -->
                     <GuiElement profile="RF_WcPageShell" id="rfFrameworkGlanceShell" visible="false" position="0px 0px">
-                        <GuiElement id="rfFwStatusBlock" visible="true" position="0px 0px" size="1140px 580px">
-                            <Text profile="RF_SectionTitle" id="rfFwStatusTitle" position="0px 0px" size="1140px 24px" text="" visible="false"/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine1" position="0px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine2" position="0px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine3" position="0px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine4" position="0px -144px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine5" position="580px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine6" position="580px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine7" position="580px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine8" position="580px -144px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="rfFwHint" position="0px -200px" size="1140px 120px"
+                        <!-- Income / Tax / Depot status glance. 580 was taller than the shell (520);
+                             the card is sized to its content instead: hint ends at -328, so 340
+                             leaves 12px of bottom air inside the stroke. -->
+                        <GuiElement profile="RF_EscCardFrameWide" id="rfFwStatusBlock" visible="true" position="0px 0px" size="1140px 340px">
+                            <Text profile="RF_SectionTitle" id="rfFwStatusTitle" position="10px -8px" size="1120px 24px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine1" position="10px -8px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine2" position="10px -56px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine3" position="10px -104px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine4" position="10px -152px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine5" position="580px -8px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine6" position="580px -56px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine7" position="580px -104px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine8" position="580px -152px" size="550px 22px" text=""/>
+                            <Text profile="RF_HintText" id="rfFwHint" position="10px -208px" size="1120px 120px"
                                   textMaxNumLines="4" textVerticalAlignment="top" text=""/>
                         </GuiElement>
-                        <GuiElement id="rfFwTableBlock" visible="false" position="0px 0px" size="1140px 580px">
-                            <Text profile="RF_SectionTitle" id="rfFwTableTitle" position="0px 0px" size="1140px 24px" text="" visible="false"/>
-                            <Text profile="RF_ColHeader" id="rfFwColA" position="0px -32px" size="280px 22px" text=""/>
-                            <Text profile="RF_ColHeader" id="rfFwColB" position="300px -32px" size="280px 22px" text=""/>
-                            <Text profile="RF_ColHeader" id="rfFwColC" position="600px -32px" size="220px 22px" text=""/>
-                            <Text profile="RF_ColHeader" id="rfFwColD" position="840px -32px" size="280px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1A" position="0px -60px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1B" position="300px -60px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1C" position="600px -60px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1D" position="840px -60px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2A" position="0px -88px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2B" position="300px -88px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2C" position="600px -88px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2D" position="840px -88px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3A" position="0px -116px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3B" position="300px -116px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3C" position="600px -116px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3D" position="840px -116px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4A" position="0px -144px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4B" position="300px -144px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4C" position="600px -144px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4D" position="840px -144px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5A" position="0px -172px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5B" position="300px -172px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5C" position="600px -172px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5D" position="840px -172px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6A" position="0px -200px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6B" position="300px -200px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6C" position="600px -200px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6D" position="840px -200px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7A" position="0px -228px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7B" position="300px -228px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7C" position="600px -228px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7D" position="840px -228px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8A" position="0px -256px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8B" position="300px -256px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="600px -256px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="840px -256px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwMore" position="0px -292px" size="1140px 20px" text=""/>
-                            <Text profile="RF_HintText" id="rfFwEmptyHint" position="0px -60px" size="1140px 44px"
+                        <!-- Dairy / NPC Favor table glance. Content runs to -416 (hint under the rows),
+                             so 428 gives the same 12px of bottom air. Only one of the two blocks is
+                             ever visible (setVis is an either/or), so no card is ever naked beside
+                             another - Ash 15:35 #1 sibling framing has nothing to bite on here. -->
+                        <GuiElement profile="RF_EscCardFrameWide" id="rfFwTableBlock" visible="false" position="0px 0px" size="1140px 428px">
+                            <Text profile="RF_SectionTitle" id="rfFwTableTitle" position="10px -8px" size="1120px 24px" text="" visible="false"/>
+                            <!-- Excel sheet: the outer border is rfFwTableBlock's own hasFrame; these 11 hairlines
+                                 are the inner grid. RF_EscCardRule is already blank.png + soft grey 0.55, so they
+                                 take it with an inline size rather than one profile per orientation. Declared
+                                 before the cells so text paints over them. Per-cell hasFrame would have been 144
+                                 frame rects for the same picture. -->
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleHead" position="10px -64px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow1" position="10px -92px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow2" position="10px -120px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow3" position="10px -148px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow4" position="10px -176px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow5" position="10px -204px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow6" position="10px -232px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow7" position="10px -260px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol1" position="300px -36px" size="1px 250px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol2" position="600px -36px" size="1px 250px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol3" position="840px -36px" size="1px 250px"/>
+                            <Text profile="RF_FwColHeader" id="rfFwColA" position="10px -40px" size="280px 22px" text=""/>
+                            <Text profile="RF_FwColHeader" id="rfFwColB" position="310px -40px" size="280px 22px" text=""/>
+                            <Text profile="RF_FwColHeader" id="rfFwColC" position="610px -40px" size="220px 22px" text=""/>
+                            <Text profile="RF_FwColHeader" id="rfFwColD" position="850px -40px" size="280px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1A" position="10px -68px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1B" position="310px -68px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1C" position="610px -68px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1D" position="850px -68px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2A" position="10px -96px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2B" position="310px -96px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2C" position="610px -96px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2D" position="850px -96px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3A" position="10px -124px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3B" position="310px -124px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3C" position="610px -124px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3D" position="850px -124px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4A" position="10px -152px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4B" position="310px -152px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4C" position="610px -152px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4D" position="850px -152px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5A" position="10px -180px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5B" position="310px -180px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5C" position="610px -180px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5D" position="850px -180px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6A" position="10px -208px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6B" position="310px -208px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6C" position="610px -208px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6D" position="850px -208px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7A" position="10px -236px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7B" position="310px -236px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7C" position="610px -236px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7D" position="850px -236px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8A" position="10px -264px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8B" position="310px -264px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="610px -264px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="850px -264px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwMore" position="10px -300px" size="1120px 20px" text=""/>
+                            <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
-                            <Text profile="RF_HintText" id="rfFwHintTable" position="0px -328px" size="1140px 80px"
+                            <Text profile="RF_HintText" id="rfFwHintTable" position="10px -336px" size="1120px 80px"
                                   textMaxNumLines="3" textVerticalAlignment="top" text=""/>
                         </GuiElement>
                     </GuiElement>
@@ -710,23 +767,23 @@
                         <Bitmap profile="RF_TreatmentBoxBg"/>
 
                         <!-- Page A — Prices -->
-                        <GuiElement id="mdPricesBand" visible="true" position="0px 0px" size="100% 100%">
+                        <GuiElement profile="RF_EscCardFrameWide" id="mdPricesBand" visible="true" position="10px -10px" size="1130px 344px">
                             <Text profile="RF_SectionTitle" id="mdGraphTitle" position="10px -6px" size="700px 22px" text=""/>
-                            <GuiElement profile="RF_MdGraphArea" id="mdGraphArea"/>
-            <Text profile="RF_EmptyHint" id="mdGraphEmptyHint" position="40px -96px" size="720px 40px"
+                            <GuiElement profile="RF_MdGraphArea" id="mdGraphArea" position="30px -28px"/>
+            <Text profile="RF_EmptyHint" id="mdGraphEmptyHint" position="30px -86px" size="720px 40px"
                   visible="false" text=""/>
-            <Text profile="RF_TreatSelected" id="mdDetailCommodity" position="770px -32px" size="380px 22px"
+            <Text profile="RF_TreatSelected" id="mdDetailCommodity" position="770px -32px" size="350px 22px"
                   textAlignment="left" text=""/>
-            <Text profile="RF_TreatTargetLine" id="mdDetailPrice" position="770px -64px" size="380px 20px" text=""/>
-            <Text profile="RF_TreatTargetLine" id="mdDetailPressure" position="770px -92px" size="380px 20px" text=""/>
-            <Text profile="RF_HintText" id="mdDetailEmpty" position="770px -64px" size="380px 44px"
+            <Text profile="RF_TreatTargetLine" id="mdDetailPrice" position="770px -64px" size="350px 20px" text=""/>
+            <Text profile="RF_TreatTargetLine" id="mdDetailPressure" position="770px -92px" size="350px 20px" text=""/>
+            <Text profile="RF_HintText" id="mdDetailEmpty" position="770px -64px" size="350px 44px"
                   textMaxNumLines="2" visible="false" text=""/>
-            <Button profile="buttonActivate" id="mdOpenMarketBtn" position="770px -280px" size="360px 36px"
+            <Button profile="buttonActivate" id="mdOpenMarketBtn" position="770px -280px" size="350px 36px"
                     onClick="onClickMdOpenMarket"/>
                         </GuiElement>
 
                         <!-- Page B — Events (fixed Text rows; no SmoothList thrash). -->
-                        <GuiElement id="mdEventsBand" visible="false" position="0px 0px" size="100% 100%">
+                        <GuiElement profile="RF_EscCardFrameWide" id="mdEventsBand" visible="false" position="10px -10px" size="1130px 344px">
                             <Text profile="RF_SectionTitle" id="mdEventsTitle" position="10px -6px" size="700px 22px" text=""/>
                             <Text profile="RF_ColHeader" id="mdEvColName" position="10px -36px" size="420px 20px" text=""/>
                             <Text profile="RF_ColHeader" id="mdEvColIntensity" position="450px -36px" size="220px 20px" text=""/>
@@ -752,12 +809,12 @@
                             <Text profile="RF_TreatTargetLine" id="mdEvMore" position="10px -240px" size="1100px 20px" text=""/>
                             <Text profile="RF_HintText" id="mdEventsEmpty" position="10px -64px" size="1100px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
-            <Button profile="buttonActivate" id="mdOpenMarketBtnEvents" position="770px -280px" size="360px 36px"
+            <Button profile="buttonActivate" id="mdOpenMarketBtnEvents" position="770px -280px" size="350px 36px"
                     onClick="onClickMdOpenMarket"/>
                         </GuiElement>
 
                         <!-- Page C — Contracts (read-only fixed rows). -->
-                        <GuiElement id="mdContractsBand" visible="false" position="0px 0px" size="100% 100%">
+                        <GuiElement profile="RF_EscCardFrameWide" id="mdContractsBand" visible="false" position="10px -10px" size="1130px 344px">
                             <Text profile="RF_SectionTitle" id="mdContractsTitle" position="10px -6px" size="900px 22px" text=""/>
                             <Text profile="RF_ColHeader" id="mdCtColCrop" position="10px -36px" size="280px 20px" text=""/>
                             <Text profile="RF_ColHeader" id="mdCtColQty" position="300px -36px" size="220px 20px" text=""/>
@@ -786,7 +843,7 @@
                             <Text profile="RF_TreatTargetLine" id="mdCtMore" position="10px -212px" size="1100px 20px" text=""/>
                             <Text profile="RF_HintText" id="mdContractsEmpty" position="10px -64px" size="1100px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
-            <Button profile="buttonActivate" id="mdOpenMarketBtnContracts" position="770px -280px" size="360px 36px"
+            <Button profile="buttonActivate" id="mdOpenMarketBtnContracts" position="770px -280px" size="350px 36px"
                     onClick="onClickMdOpenMarket"/>
                         </GuiElement>
                     </GuiElement>


### PR DESCRIPTION
## Summary
- Esc-only shared-door freeze: widen Soil PRODUCTS card to 620x248 so PRODUCTS–ROTATION gutters match the 10px family (TREATMENT/ROTATION footprints unchanged).
- Tax only: Status densify FAILFIX (literal GuiUtils reassert every onShow; densify gone).
- Branched clean from live `development`. No `.local/share-staging`, no zip, no gameplay ride-alongs.

## Test plan
- [ ] Esc → RF → Soil: even gaps between the three bottom cards
- [ ] Esc → RF → Tax: Status lines inside the white frame
- [ ] Other RF Esc pages unchanged in behaviour
- [ ] No UTF-8 BOM / UTF-16 on touched files

Replaces the earlier oversized Esc WIP PRs (Sasha CHANGES_REQUESTED on Soil/SCS for deleted shipped APIs / undisclosed pump activatable).