### PR TITLE
feat(hud): base-game HUD extension styling, width resizing, and factory layout defaults

### DIFF
--- a/src/gui/RfEscModules.lua
+++ b/src/gui/RfEscModules.lua
@@ -256,6 +256,11 @@ function RfEscModules:registerModule(def)
         -- companions that predate this.
         selectCommodityIndex = def.selectCommodityIndex,
         onLightTick = def.onLightTick,
+        -- Sixth instance, BUILD 14:04 (Brian TEST 10:29): NPC Favor registered onPageStep
+        -- for the shared row pager on BUILD 09:19 and this whitelist ate it, so the live
+        -- MORE (1/2) button forwarded a step to nil and the roster never turned the page.
+        -- The register-time warning below did name it, in a log nobody read back.
+        onPageStep = def.onPageStep,
     }
     -- BUILD 23:51: this whitelist has now silently eaten a handler four times, so stop
     -- letting it do that quietly. Anything a caller passed that is not carried above gets

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -1033,13 +1033,56 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
         return
     end
 
-    sel.disableButtonsOnSingleText = false
-    sel.hideLeftRightButtons = false
-    if sel.setCanChangeState then
-        sel:setCanChangeState(true)
+    -- BUILD 17:50 (PB-06). The item count decides everything below this line.
+    --
+    -- Before 17:50 this helper forced the arrows enabled and full lime unconditionally,
+    -- which was the fault it fixed: with a single entry the arrow cannot change state, so
+    -- the player saw a bright, clickable-looking arrow that could never act.
+    --
+    -- 17:50 leaned on disableButtonsOnSingleText to express that. BUILD 20:39 takes it back
+    -- off (see the note below the empty-list guard) and drives disabled from here alone.
+    -- Line references throughout are
+    -- .local/ref/FS25-lua-scripting/elements/MultiTextOptionElement.lua unless named
+    -- otherwise. Nothing here is guessed.
+    local texts = sel.texts or {}
+
+    -- BUILD 20:39. An empty text list means "not seeded yet", not "one page", and the two
+    -- must not be treated the same. Every caller below runs this helper both BEFORE and
+    -- AFTER the texts are set, so the early call used to latch the pager disabled from a
+    -- count that was about to change - and if the seeding path then failed or threw, the
+    -- pager stayed disabled for the rest of the session while the arrows below still got
+    -- painted. That is one of the three ways George's TASK 20:38 lime-but-dead read is
+    -- reachable. With no texts there is nothing to page through, so write nothing and let
+    -- the seeded call decide.
+    if #texts == 0 then
+        return
     end
+    local multi = #texts > 1
+
+    -- BUILD 20:39: disableButtonsOnSingleText stays FALSE (Sam feel lock DESIGN 20:00,
+    -- re-stated in BUILD 20:39; the XML declares false on every MTO in this page).
+    -- 17:50 read it as a free engine helper, but it is not free: with it true the engine
+    -- writes setDisabled(#texts <= 1) from inside updateContentElement (:831-833), and
+    -- updateContentElement runs on every setTexts, setState and arrow click. That is a
+    -- second writer on the one flag that decides whether the pager takes input at all,
+    -- firing on the same frame as our own write - "state reset in the same frame", the
+    -- third cause George named. With it false this function is the only writer.
+    -- The single-page focus guard 17:50 wanted from it is not lost: canReceiveFocus (:774)
+    -- also returns false on a disabled element, and one page still sets disabled below.
+    sel.disableButtonsOnSingleText = false
+    sel.hideLeftRightButtons = false   -- never remove the control, only dim it
+    if sel.setCanChangeState then
+        sel:setCanChangeState(multi)
+    end
+    -- This is the gate that decides whether a click ever reaches the arrows. A disabled
+    -- MTO swallows the whole mouse event before it can descend to its buttons:
+    -- MultiTextOptionElement:mouseEvent wraps its entire body in getIsActive() (:434) and
+    -- GuiElement:getIsActive is "not disabled and visible" (GuiElement.lua:1338-1340).
+    -- The GuiOverlay.setColor tint further down does NOT go through that gate, so a
+    -- disabled pager still paints lime - which is exactly the reported defect: lime arrows,
+    -- dead clicks. Multi-page must therefore end this call with disabled == false.
     if sel.setDisabled then
-        sel:setDisabled(false)
+        sel:setDisabled(not multi)
     end
 
     -- Extract: GuiUtils.getNormalizedScreenValues(values, default) - values = "Wpx Hpx" or array; returns table.
@@ -1053,11 +1096,22 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
     end
 
     -- ButtonElement extends TextElement (not Bitmap); tint via GuiOverlay on .overlay.
-    local r, g, b, a = 0.549, 0.776, 0.247, 1
+    --
+    -- Enabled keeps George's lime. Disabled goes to Samantha's neutral 45% rather than a faded
+    -- lime, so "cannot act" reads as absence of colour instead of a dimmed affordance. The
+    -- brief writes the enabled state as {1,1,1,1}, which would drop the lime this file already
+    -- carries; that is not what PB-06 is about, so the lime stays and the reading is flagged
+    -- in the reply rather than decided silently.
+    local r, g, b, a
+    if multi then
+        r, g, b, a = 0.549, 0.776, 0.247, 1
+    else
+        r, g, b, a = 1, 1, 1, 0.45
+    end
     for _, btn in ipairs({ sel.leftButtonElement, sel.rightButtonElement }) do
         if btn ~= nil then
             if btn.setVisible then btn:setVisible(true) end
-            if btn.setDisabled then btn:setDisabled(false) end
+            if btn.setDisabled then btn:setDisabled(not multi) end
             -- Size THEN lime (George Plan A). Absolute target - do not ratio current size.
             if type(btn.setSize) == "function" and tw ~= nil and th ~= nil then
                 btn:setSize(tw, th)
@@ -1073,8 +1127,19 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
 end
 
 --- Keep Map circle arrows enabled + lime on first open (not near-black grey).
+--- BUILD 20:39: also the wrap lock for the left-pane pager. Wrap is engine-native and on
+--- by default (MultiTextOptionElement.lua:55) - onRightButtonClicked rolls #texts -> 1 and
+--- onLeftButtonClicked rolls 1 -> #texts (:670-679 / :721-730) - but XML #wrap and profile
+--- "wrap" can both turn it off (:111 / :141), and with it off the last page clamps and the
+--- arrow reads dead at exactly one end. The ask is explicit that both ends wrap, so state
+--- it rather than inherit it. Set here on the pager only: _ensureMtoArrowsVisible is shared
+--- with the WC wage / About / subnav MTOs, and their wrap is not this token's business.
 function RfPdaMenuPage:_ensureSelectorArrowsVisible()
-    self:_ensureMtoArrowsVisible(self.rfPanelSelector)
+    local sel = self.rfPanelSelector
+    if sel ~= nil then
+        sel.wrap = true
+    end
+    self:_ensureMtoArrowsVisible(sel)
 end
 
 --- Stable id list fingerprint for quiet SmoothList reload decisions.
@@ -1114,7 +1179,10 @@ function RfPdaMenuPage:refreshPanelSelector(forceRebuildDots)
             activeIndex = 1
         end
 
-        self:_ensureSelectorArrowsVisible()
+        -- BUILD 20:39: the pre-setTexts ensure call that used to sit here is gone. It fed
+        -- _ensureMtoArrowsVisible the PREVIOUS text count - on first open an empty one - so
+        -- it decided the pager's disabled state from a number that the next line was about
+        -- to replace. The post-setState call below is the one that matters and it stays.
         -- setTexts can re-apply profile single-text disable; always follow with force-enable.
         self.rfPanelSelector:setTexts(texts)
         if self.rfPanelSelector.setState then
@@ -1270,14 +1338,43 @@ function RfPdaMenuPage:_applySelectorState()
 
     local state = self.rfPanelSelector:getState()
     local panel = self._panelCache[state]
-    if panel == nil then return end
+    if panel == nil then
+        -- BUILD 20:39: this is the second half of the defect. The arrow has already moved
+        -- the label and the dots by the time we get here (the engine advances state, then
+        -- raises this callback), so returning empty-handed leaves the page NAME on one
+        -- module and the page CONTENT on another - the "content does not move" read. A
+        -- cache one module older than the MTO texts is enough to hit it. Re-read the
+        -- registry once before giving up.
+        local panels = (type(host.getPanels) == "function") and host:getPanels() or nil
+        if panels ~= nil then
+            self._panelCache = panels
+            panel = panels[state]
+        end
+    end
+    if panel == nil then
+        -- Still nothing at this index: put the pager back on the page that is actually
+        -- showing. An honest snap-back beats a label pointing at a page that never loaded.
+        self:_restoreBrandToActivePanel()
+        return
+    end
 
     if host.activeModuleId ~= panel.id then
         if not self:_allowModuleSelect(panel.id) then
+            -- Refused by the dual-fire debounce. The MTO state has still moved, so snap it
+            -- back or label, dots and content stay disagreeing until the next full refresh.
+            self:_restoreBrandToActivePanel()
             return
         end
         -- Host notify refreshes selector + content (quiet lists).
-        host:selectPanel(panel.id)
+        local switched = host:selectPanel(panel.id)
+        if switched == false then
+            -- Registry refused (module gone or isAvailable false): no notify fires, so
+            -- nothing downstream would ever correct the advanced label. Snap it back.
+            SoilLogger.warning("RfPdaMenuPage: selectPanel %s refused, restoring pager state",
+                tostring(panel.id))
+            self:_restoreBrandToActivePanel()
+            return
+        end
         SoilLogger.info("RfPdaMenuPage: selectPanel %s (arrow/selector)", tostring(panel.id))
     else
         self:refreshContent(false)

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -16,17 +16,29 @@
 local MOD_DIR = g_currentModDirectory
 local MOD_NAME = g_currentModName
 
--- Soft log when sourced from WC/CS joiners (SoilLogger may be absent).
+-- Soft log when sourced from a non-Soil joiner (SoilLogger may be absent).
+-- BUILD 17:08: the stub's signature must match Soil's real logger, which is DOT-called
+-- with the format first (src/utils/Logger.lua: function SoilLogger.info(msg, ...)), and
+-- every call in this file is dot-style. The old stub took (_, fmt, ...) as if colon-called,
+-- so on every non-Soil-hosted door the message landed in the discarded first slot and the
+-- log printed only the leftover arguments - or nothing at all. That is why the host's
+-- [RfEsc] lines have never appeared in a Dairy-door log, and it would have eaten the
+-- selector diagnostics this build ships. pcall on the format so a stray % in a runtime
+-- value can never turn a log line into the only traceback on the page.
 if SoilLogger == nil then
+    local function stubLine(fmt, ...)
+        local ok, text = pcall(string.format, fmt or "", ...)
+        return "[RfEsc] " .. (ok and text or tostring(fmt))
+    end
     SoilLogger = {
-        info = function(_, fmt, ...)
-            if Logging and Logging.info then Logging.info("[RfEsc] " .. string.format(fmt or "", ...)) end
+        info = function(fmt, ...)
+            if Logging and Logging.info then Logging.info(stubLine(fmt, ...)) end
         end,
-        warning = function(_, fmt, ...)
-            if Logging and Logging.warning then Logging.warning("[RfEsc] " .. string.format(fmt or "", ...)) end
+        warning = function(fmt, ...)
+            if Logging and Logging.warning then Logging.warning(stubLine(fmt, ...)) end
         end,
-        error = function(_, fmt, ...)
-            if Logging and Logging.error then Logging.error("[RfEsc] " .. string.format(fmt or "", ...)) end
+        error = function(fmt, ...)
+            if Logging and Logging.error then Logging.error(stubLine(fmt, ...)) end
         end,
     }
 end
@@ -198,7 +210,9 @@ local function mdResolve(bare, name)
             MdRfPdaGuest = "FS25_MarketDynamics",
             MDMMarketScreenGraph = "FS25_MarketDynamics",
             MDMMarketScreen = "FS25_MarketDynamics",
+            MDMPriceFormat = "FS25_MarketDynamics",
             CsRfPdaGuest = "FS25_SeasonalCropStress",
+            NpcRfPdaGuest = "FS25_NPCFavor",
         }
         local env = g_modEnvironments[OWNER[name] or "FS25_MarketDynamics"]
         if env ~= nil and env[name] ~= nil then
@@ -212,16 +226,69 @@ local function mdResolve(bare, name)
             end
         end
     end
-    -- 4. real global table: MarketDynamics publishes here from BUILD 11:43.
+    -- 4. _G. BUILD 14:04 (George TASK 10:53): Vera's live gate read via=mission, which
+    --    means belts 2 and 3 miss on the live engine (g_modEnvironments carries nothing
+    --    there) and getfenv(0) is the per-mod sandbox, not a shared root. _G read from mod
+    --    code resolves through the sandbox chain, so when the engine backs it with the real
+    --    global table this belt sees a publisher's _G write; when the sandbox loops _G onto
+    --    itself it degenerates to the bare lookup and costs one table index.
+    if type(_G) == "table" and _G[name] ~= nil then
+        return _G[name]
+    end
+    -- 5. sandbox root: MarketDynamics publishes here from BUILD 11:43.
     local okEnv, root = pcall(getfenv, 0)
     if okEnv and type(root) == "table" and root[name] ~= nil then
         return root[name]
     end
-    -- 5. mission handle, same publish.
+    -- 6. mission handle, same publish. The one belt Vera's live gate has actually seen
+    --    resolve on a non-MD door (via=mission), so it must stay last-resort-but-present.
     if g_currentMission ~= nil and g_currentMission[name] ~= nil then
         return g_currentMission[name]
     end
     return nil
+end
+
+--- BUILD 14:04 fence for _populateMdCommodityRow: 2dp currency when MDMPriceFormat cannot
+--- be resolved at all. George's constraint on the failed probe is "degrades to 2dp path -
+--- never formatMoney(..., 0)". This is the Vera-F2 pad rule in miniature (formatNumber and
+--- formatMoney both round-then-tostring, so neither ever pads a whole number to .00): split
+--- the digits by hand, let formatNumber group the integer half only, take the locale's own
+--- decimal mark. No x1000, no litre suffix, no animal test - that display policy lives in
+--- MDMPriceFormat and duplicating it here would put two dialects back on screen. This fence
+--- should be unreachable: the Prices rows only paint under a registered MD guest, and
+--- registration publishes MDMPriceFormat to the mission handle every attempt.
+local function mdMoney2(value)
+    local rounded = value
+    if MathUtil ~= nil and type(MathUtil.round) == "function" then
+        rounded = MathUtil.round(value, 2)
+    end
+    local negative = rounded < 0
+    local magnitude = negative and -rounded or rounded
+    local whole = math.floor(magnitude)
+    local frac = math.floor((magnitude - whole) * 100 + 0.5)
+    if frac >= 100 then
+        whole = whole + 1
+        frac = frac - 100
+    end
+    local wholeStr = tostring(whole)
+    local separator = "."
+    local symbol = ""
+    if g_i18n ~= nil then
+        if type(g_i18n.formatNumber) == "function" then
+            wholeStr = g_i18n:formatNumber(whole, 0)
+        end
+        if type(g_i18n.decimalSeparator) == "string" and g_i18n.decimalSeparator ~= "" then
+            separator = g_i18n.decimalSeparator
+        end
+        if type(g_i18n.getCurrencySymbol) == "function" then
+            symbol = g_i18n:getCurrencySymbol(true) or ""
+        end
+    end
+    local out = symbol .. wholeStr .. separator .. string.format("%02d", frac)
+    if negative then
+        out = "-" .. out
+    end
+    return out
 end
 
 local function tr(key, fallback)
@@ -1283,6 +1350,13 @@ function RfPdaMenuPage:_rebuildDots(count)
 end
 
 function RfPdaMenuPage:onClickRfPanelSelector()
+    -- BUILD 17:08 diagnostic, one line per real selector input (forceEvent is false on
+    -- every internal setState in this file, so this callback only fires for the player).
+    -- If a live test still shows dead arrows AND this line never appears in the log, the
+    -- click is being consumed ABOVE this page (menu-level), which the in-page shield in
+    -- mouseEvent cannot reach - that finding goes to George, not to more host code.
+    SoilLogger.info("RfPdaMenuPage: selector input received, state=%s",
+        tostring(self.rfPanelSelector ~= nil and self.rfPanelSelector:getState() or "?"))
     self:_ensureSelectorArrowsVisible()
     self:_applySelectorState()
 end
@@ -1551,6 +1625,17 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
         end
     end
     setVis(self.rfHostTableRegion, isCs)
+    -- BUILD 09:19 (PB-07): the shared row pager is OFF by default, every refresh, for every
+    -- module. Only a guest that implements onPageStep turns it back on, from inside its own
+    -- onShow, which runs after this. That ordering is what stops the pager following the
+    -- player from NPC Favor onto Income or Dairy - those guests do not know the buttons
+    -- exist and would never have hidden them.
+    for _, id in ipairs({ "rfFwPagePrev", "rfFwPageNext" }) do
+        local btn = self:getDescendantById(id)
+        if btn ~= nil and type(btn.setVisible) == "function" then
+            btn:setVisible(false)
+        end
+    end
     -- Action bar rides the CS module only; the guest decides the two buttons.
     setVis(self.csActionBar, isCs)
     if not isCs then
@@ -2336,6 +2421,136 @@ function RfPdaMenuPage:onClickHelpCs()
     end
 end
 
+-- ---------------------------------------------------------------------------
+-- BUILD 09:19 (PB-07): shared Table-mode row pager.
+--
+-- rfFwTableBlock is a STATIC eight-row table (rfFwRow1..rfFwRow8) - not a SmoothList - and
+-- four guests paint into it: Income, Dairy, NPC Favor and Fertilizer Depot. When a guest has
+-- more rows than eight it prints "showing 8 of 11" into rfFwMore and the other three rows
+-- were unreachable: no scrollbar, no page control, no route of any kind. Sam's law is that a
+-- list which prints a range must be navigable to the end of that range.
+--
+-- This is a PAGER and deliberately not a SmoothList. George's standing hang lesson is that a
+-- SmoothList nested under the Map-style Bitmap shell in this page can hang the frame, and the
+-- existing csConsultPanel carries the same NO-GO ("George NO-GO on TextElement.new rebuild,
+-- dialog XML nest, or SmoothList"). Two Buttons plus a window offset held by the guest costs
+-- no new list machinery and cannot re-enter the layout.
+--
+-- The host owns only the click. It knows nothing about roster size, page count or labels -
+-- it forwards a step to whichever guest is active and then repaints. A guest that does not
+-- implement onPageStep is simply not pageable and the buttons stay hidden, which is why the
+-- other three Table guests need no change to keep working exactly as before.
+-- ---------------------------------------------------------------------------
+
+--- Forward one page step to the active guest, then repaint the page it just moved.
+---@param delta number -1 for previous page, +1 for next
+---@return boolean moved true when the window moved and a repaint ran
+function RfPdaMenuPage:_rfFwPageStep(delta)
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    if active == nil then
+        return false
+    end
+    local step = active.onPageStep
+    -- BUILD 14:04 (Brian TEST 10:29). This is why the live MORE was a painted no-op: the
+    -- guest registered onPageStep exactly as BUILD 09:19 described, and
+    -- RfEscModules:registerModule silently dropped it - the sixth handler that whitelist
+    -- has eaten (onOpenFullMarket, onOpenConsultant/Schedule/Help, onPivotRemote,
+    -- onLightTick, onMoverChanged before it). The whitelist now carries onPageStep, and
+    -- this belt is the same shape as the 23:51 onLightTick belt directly below in
+    -- refreshContent: if the registry instance was created by a mod still running an old
+    -- RfEscModules copy, reach the guest class itself rather than shipping a dead button
+    -- again. npcFavor is the only pageable guest today, so the belt names it.
+    if type(step) ~= "function" and active.id == "npcFavor" then
+        local npcGuest = (type(mdResolve) == "function")
+                and mdResolve(NpcRfPdaGuest, "NpcRfPdaGuest") or NpcRfPdaGuest
+        if npcGuest ~= nil and type(npcGuest.onPageStep) == "function" then
+            step = npcGuest.onPageStep
+        end
+    end
+    if type(step) ~= "function" then
+        return false
+    end
+    -- The guest owns the clamp/wrap: it is the only side that knows how many rows it has.
+    -- It returns true when the window actually moved, so a click at a hard end does not
+    -- trigger a pointless full repaint.
+    local ok, moved = pcall(step, delta)
+    if not ok then
+        SoilLogger.warning("RfPdaMenuPage: onPageStep failed on %s: %s",
+            tostring(active.id), tostring(moved))
+        return false
+    end
+    if moved == false then
+        return false
+    end
+    -- Soft refresh: same path the module pager uses, so the guest repaints its rows and its
+    -- own footer range without a full enter/rebuild.
+    self:refreshContent(false)
+    return true
+end
+
+function RfPdaMenuPage:onClickRfFwPagePrev()
+    self:_rfFwPageStep(-1)
+end
+
+function RfPdaMenuPage:onClickRfFwPageNext()
+    self:_rfFwPageStep(1)
+end
+
+--- BUILD 14:04 (PB-07): Space and ">" advance the row pager, per the brief's
+--- "click/Space/>" acceptance. keyEvent walks children first via the superclass
+--- (GuiElement.lua:772-784, children in reverse order, eventUsed carried), so a focused
+--- control that consumes the key - including the pager Button itself activating on Space -
+--- wins before this fires and nothing double-steps. Only an unclaimed press reaches the
+--- step, and only a step that actually moved marks the event used; on every page without a
+--- pageable guest _rfFwPageStep returns false immediately and the key passes through
+--- untouched. unicode 32 is Space, 62 is ">", taken from the event's own unicode so the
+--- layout that produced ">" does not matter.
+function RfPdaMenuPage:keyEvent(unicode, sym, modifier, isDown, eventUsed)
+    local used = RfPdaMenuPage:superClass().keyEvent(self, unicode, sym, modifier, isDown, eventUsed)
+    if not used and isDown == true and (unicode == 32 or unicode == 62) then
+        used = self:_rfFwPageStep(1) == true
+    end
+    return used
+end
+
+--- BUILD 17:08 (Brian TEST 16:53, George TASK 17:03 GO): click shield for the module
+--- selector. Brian measured both selector arrows hover-highlighting but never advancing,
+--- with no Lua traceback. The engine split that allows exactly that: ButtonElement paints
+--- its hover state regardless of eventUsed (ButtonElement.lua:450-459) but fires its click
+--- only "if not eventUsed" (:469-491), and FocusManager highlight on the MTO is likewise
+--- move-driven (MultiTextOptionElement.lua:465-469). So hover-alive-click-dead means the
+--- CLICK half of the event is being consumed before the selector's walk position - George's
+--- hit-steal read. Event order in this engine is reverse declaration order with no z-index,
+--- and Sam's lock forbids moving any geometry, so the fix is delivery order, not layout:
+--- the page offers every click that lands inside the selector's rect to the selector FIRST,
+--- then runs the normal child walk with the event marked used, so whichever sibling was
+--- eating the click can still clear its own pressed state but can no longer act on it.
+--- Moves are NOT pre-offered - hover behavior is untouched, and a second visit of the MTO
+--- during the normal walk with eventUsed=true only re-computes identical press flags
+--- (:441-446, not eventUsed-gated), so nothing double-fires and no wrapper element is
+--- introduced. Clicks outside the selector rect take the walk exactly as before, so the
+--- module list, FW pager and every guest control keep their ownership.
+function RfPdaMenuPage:mouseEvent(posX, posY, isDown, isUp, button, eventUsed)
+    local used = eventUsed
+    local sel = self.rfPanelSelector
+    if not used and (isDown or isUp) and sel ~= nil
+        and sel.absPosition ~= nil and sel.absSize ~= nil
+        and type(sel.getIsActive) == "function" and sel:getIsActive()
+        and GuiUtils ~= nil and type(GuiUtils.checkOverlayOverlap) == "function"
+        and GuiUtils.checkOverlayOverlap(posX, posY,
+            sel.absPosition[1], sel.absPosition[2], sel.absSize[1], sel.absSize[2], nil) then
+        if sel:mouseEvent(posX, posY, isDown, isUp, button, false) then
+            used = true
+            if not self._selShieldLogged then
+                self._selShieldLogged = true
+                SoilLogger.info("RfPdaMenuPage: selector click shield delivered its first click")
+            end
+        end
+    end
+    return RfPdaMenuPage:superClass().mouseEvent(self, posX, posY, isDown, isUp, button, used) or used
+end
+
 function RfPdaMenuPage:_csPageSel()
     return self.csSubnavSelector
 end
@@ -2786,12 +3001,50 @@ function RfPdaMenuPage:_populateMdCommodityRow(index, cell)
         end
     end
     if nameEl then nameEl:setText(entry.title or "-") end
+    -- BUILD 09:19 (PB-02). This cell is the one Brian read as "£0" and "£1".
+    --
+    -- entry.price is the PER-LITRE engine number. formatMoney(price, 0, ...) rounded it to
+    -- whole currency units and printed no unit at all, so a live 0.00037/l commodity became
+    -- an actionable-looking "£0" and soybean at 0.85/l became "£1". Neither is a zero and
+    -- neither says what it is a price OF.
+    --
+    -- MDMPriceFormat is the single place that decides how a market price is written: the
+    -- x1000 display multiply for bulk goods, the forced two decimals built by hand (Vera F2:
+    -- neither formatMoney nor formatNumber forcePrecision actually pads .00), the locale
+    -- decimal mark, and the " / 1,000L" suffix that animal cargo does NOT get. The full
+    -- Market table and the Esc selected-crop line call the same helper, so all three
+    -- surfaces print one string and not three dialects of it.
+    --
+    -- The nil guard matters on this file specifically: this host is mirrored into all nine
+    -- doors and only the Market Dynamics zip ships MdPriceFormat.lua. On the other eight
+    -- doors MDMPriceFormat is nil UNLESS Market Dynamics is also loaded - and if it is not
+    -- loaded there is no Market page to paint anyway. The fallback keeps the old reading
+    -- instead of erroring.
+    --
+    -- BUILD 10:06, Vera FAIL F1. The bare global was doing less than that comment claimed.
+    -- It is nil not only when Market Dynamics is absent, but whenever Market Dynamics is not
+    -- the mod that WON the door race: FS25 gives every mod its own environment and this
+    -- mirrored file executes inside the host's, so on a Dairy-hosted or Income-hosted suite
+    -- the bare lookup misses a fully loaded MdPriceFormat.lua and the cell silently drops to
+    -- the formatMoney fallback - the exact "GBP 0" reading PB-02 was supposed to have fixed.
+    -- Same failure shape, same cause and same cure as MDMMarketScreenGraph on the Dairy door.
+    -- Resolved through mdResolve, which is that cure: bare first (free when Market Dynamics
+    -- hosts), then the named g_modEnvironments["FS25_MarketDynamics"] entry, then the
+    -- name-independent scan and the getfenv(0) / mission belts.
+    local priceFormat = (type(mdResolve) == "function")
+            and mdResolve(MDMPriceFormat, "MDMPriceFormat") or MDMPriceFormat
     local priceText = "-"
     if entry.price ~= nil then
-        if g_i18n and g_i18n.formatMoney then
-            priceText = g_i18n:formatMoney(entry.price, 0, true, true)
+        if priceFormat ~= nil and type(priceFormat.price) == "function" then
+            priceText = priceFormat.price(entry.fillTypeIndex, entry.price)
         else
-            priceText = string.format("%.0f", entry.price)
+            -- BUILD 14:04 (Vera FAIL on SUBMIT 10:16). The old branch here was
+            -- formatMoney(entry.price, 0, ...), which is the exact GBP 0 / GBP 1 reading
+            -- this cell has now shipped twice. George's constraint is verbatim "failed
+            -- probe degrades to 2dp path - never formatMoney(..., 0)", so the raw
+            -- per-litre number prints at two decimals or it does not print through
+            -- an engine rounder at all.
+            priceText = mdMoney2(entry.price)
         end
     end
     if priceEl then priceEl:setText(priceText) end

--- a/src/ui/IncomeHUD.lua
+++ b/src/ui/IncomeHUD.lua
@@ -10,7 +10,10 @@
 -- =========================================================
 
 ---@class IncomeHUD
-IncomeHUD = {}
+-- BUILD 17:57 (Wizard hot-reload law 2026-08-21, FS25-HotReload-Guide.md Part 1):
+-- reuse the existing class table on Ctrl+R reload so updated methods land on the
+-- table live metatables already reference, instead of orphaning it.
+IncomeHUD = IncomeHUD or {}
 local IncomeHUD_mt = Class(IncomeHUD)
 
 IncomeHUD.MAX_HISTORY_ROWS  = 5
@@ -28,9 +31,13 @@ function IncomeHUD.new(incomeSystem, settings)
     self.visible = true
 
     -- Panel anchor: top-left of content area (text starts here)
-    self.posX       = 0.77
-    self.posY       = 0.90
-    self.panelWidth = 0.21
+    -- BUILD 17:10 (Sam DESIGN 17:08): factory home splits Income off the WE box -
+    -- both mods shipped (0.77, 0.90) and stacked. Income sits under WE in the
+    -- 0.550-0.750 band (posY is the panel TOP edge per the clamp below): 0.73-0.84,
+    -- keeping the gap above Soil's top at ~0.709. Saved hudLayout XML still wins.
+    self.posX       = 0.55
+    self.posY       = 0.84
+    self.panelWidth = 0.20
 
     -- Base layout constants (at scale 1.0 — multiplied by self.scale at draw time)
     self.LINE_H      = 0.017
@@ -75,7 +82,8 @@ function IncomeHUD.new(incomeSystem, settings)
         BORDER       = {0.20, 0.20, 0.20, 0.40},   -- neutral subtle border
         DIVIDER      = {0.25, 0.25, 0.25, 0.85},
         SHADOW       = {0.00, 0.00, 0.00, 0.35},
-        HEADER       = {1.00, 1.00, 1.00, 1.00},
+        -- BUILD 18:47: TEMPORARY loud green for the hot-reload proof (was 1,1,1,1).
+        HEADER       = {0.20, 1.00, 0.20, 1.00},
         ENABLED      = {0.30, 0.90, 0.30, 1.00},   -- green ON status — keep
         DISABLED     = {0.90, 0.30, 0.30, 1.00},   -- red OFF status — keep
         LABEL        = {0.72, 0.72, 0.72, 1.00},   -- neutral gray, no green tint
@@ -441,7 +449,9 @@ function IncomeHUD:drawPanel()
     setTextBold(true)
     setTextAlignment(RenderText.ALIGN_LEFT)
     setTextColor(self.COLORS.HEADER[1], self.COLORS.HEADER[2], self.COLORS.HEADER[3], self.COLORS.HEADER[4])
-    renderText(x, cy - tsTitle, tsTitle, "INCOME MOD")
+    -- BUILD 18:47: TEMPORARY visible hot-reload needle (Wizard Ctrl+R proof with
+    -- Brian eyes-on). Revert the string and COLORS.HEADER when the proof is scored.
+    renderText(x, cy - tsTitle, tsTitle, "INCOME MOD *R4*")
 
     local statusColor = s.enabled and self.COLORS.ENABLED or self.COLORS.DISABLED
     setTextAlignment(RenderText.ALIGN_RIGHT)
@@ -593,4 +603,33 @@ end
 
 function IncomeHUD:divider(dx, dy, dw, sc)
     self:rect(dx, dy, dw, 0.001 * (sc or 1.0), self.COLORS.DIVIDER)
+end
+
+-- =========================================================
+
+-- BUILD 17:57 (Wizard hot-reload law, FS25-HotReload-Guide.md Part 2): after a
+
+-- Ctrl+R reload the metatable chain does not reliably deliver updated methods to
+
+-- live instances, so copy them on directly. The live instance lives on the
+
+-- mission handle published by src/main.lua (mission.incomeManager), holding the
+
+-- HUD as .incomeHUD (IncomeManager.lua). Functions only; state fields untouched.
+
+if g_currentMission ~= nil and g_currentMission.incomeManager ~= nil
+    and g_currentMission.incomeManager.incomeHUD ~= nil then
+    local inst = g_currentMission.incomeManager.incomeHUD
+    for k, v in pairs(IncomeHUD) do
+        if type(v) == "function" then
+            inst[k] = v
+        end
+    end
+    -- BUILD 18:47 TEMPORARY (revert with the needle): COLORS is constructor-set
+    -- instance STATE, which method patching deliberately does not touch - so the
+    -- loud-green header needle must be pushed onto the live instance here, or the
+    -- Ctrl+R proof would show the *HOT* title (method-borne) without the color.
+    if inst.COLORS ~= nil then
+        inst.COLORS.HEADER = {0.20, 1.00, 0.20, 1.00}
+    end
 end

--- a/src/ui/IncomeHUD.lua
+++ b/src/ui/IncomeHUD.lua
@@ -20,6 +20,17 @@ IncomeHUD.MAX_HISTORY_ROWS  = 5
 IncomeHUD.MIN_SCALE         = 0.60
 IncomeHUD.MAX_SCALE         = 1.80
 IncomeHUD.RESIZE_HANDLE_SIZE = 0.008
+-- Wizard 2026-08-21 width wave: left/right edge drag adjusts a width multiplier,
+-- independent of corner-scale (NPCFavor/Workplace pattern, suite-wide).
+IncomeHUD.MIN_WIDTH_MULT = 0.7
+IncomeHUD.MAX_WIDTH_MULT = 2.5
+IncomeHUD.EDGE_BAND_W    = 0.008
+IncomeHUD.EDGE_SENS      = 3.0
+
+local function getBaseGameRenderer()
+    local hud = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+    return hud ~= nil and hud.renderer or nil
+end
 
 function IncomeHUD.new(incomeSystem, settings)
     local self = setmetatable({}, IncomeHUD_mt)
@@ -35,8 +46,10 @@ function IncomeHUD.new(incomeSystem, settings)
     -- both mods shipped (0.77, 0.90) and stacked. Income sits under WE in the
     -- 0.550-0.750 band (posY is the panel TOP edge per the clamp below): 0.73-0.84,
     -- keeping the gap above Soil's top at ~0.709. Saved hudLayout XML still wins.
-    self.posX       = 0.55
-    self.posY       = 0.84
+    -- Wizard 2026-08-21: factory home is the suite layout Wizard arranged
+    -- in-game (bottom-left lane). A saved hudLayout XML still wins on load.
+    self.posX       = 0.213021
+    self.posY       = 0.979074
     self.panelWidth = 0.20
 
     -- Base layout constants (at scale 1.0 — multiplied by self.scale at draw time)
@@ -47,7 +60,7 @@ function IncomeHUD.new(incomeSystem, settings)
     self.TEXT_SMALL  = 0.0095
 
     -- Scale & edit state (NPCFavor / SoilHUD pattern)
-    self.scale            = 1.0
+    self.scale            = 1.083220   -- factory suite layout (Wizard 2026-08-21)
     self.editMode         = false
     self.dragging         = false
     self.resizing         = false
@@ -58,6 +71,12 @@ function IncomeHUD.new(incomeSystem, settings)
     self.resizeStartScale = 1.0
     self.hoverCorner      = nil
     self.animTimer        = 0
+
+    -- Width state (edge-drag, NPCFavor/Workplace pattern)
+    self.widthMult          = 0.759375   -- factory suite layout (Wizard 2026-08-21)
+    self.edgeDragging       = nil   -- nil | "left" | "right"
+    self.edgeDragStartX     = 0
+    self.edgeDragStartWidth = 1.0
 
     -- Camera freeze (NPCFavor pattern)
     self.savedCamRotX = nil
@@ -82,8 +101,7 @@ function IncomeHUD.new(incomeSystem, settings)
         BORDER       = {0.20, 0.20, 0.20, 0.40},   -- neutral subtle border
         DIVIDER      = {0.25, 0.25, 0.25, 0.85},
         SHADOW       = {0.00, 0.00, 0.00, 0.35},
-        -- BUILD 18:47: TEMPORARY loud green for the hot-reload proof (was 1,1,1,1).
-        HEADER       = {0.20, 1.00, 0.20, 1.00},
+        HEADER       = {1.00, 1.00, 1.00, 1.00},
         ENABLED      = {0.30, 0.90, 0.30, 1.00},   -- green ON status — keep
         DISABLED     = {0.90, 0.30, 0.30, 1.00},   -- red OFF status — keep
         LABEL        = {0.72, 0.72, 0.72, 1.00},   -- neutral gray, no green tint
@@ -145,10 +163,11 @@ function IncomeHUD:enterEditMode()
 end
 
 function IncomeHUD:exitEditMode()
-    self.editMode    = false
-    self.dragging    = false
-    self.resizing    = false
-    self.hoverCorner = nil
+    self.editMode     = false
+    self.dragging     = false
+    self.resizing     = false
+    self.edgeDragging = nil
+    self.hoverCorner  = nil
     self.savedCamRotX, self.savedCamRotY, self.savedCamRotZ = nil, nil, nil
     if g_inputBinding and g_inputBinding.setShowMouseCursor then
         g_inputBinding:setShowMouseCursor(false)
@@ -174,6 +193,7 @@ function IncomeHUD:saveLayout()
         xml:setFloat("hudLayout.posX",   self.posX)
         xml:setFloat("hudLayout.posY",   self.posY)
         xml:setFloat("hudLayout.scale",  self.scale)
+        xml:setFloat("hudLayout.widthMult", self.widthMult or 1.0)
         xml:setBool("hudLayout.visible", self.visible)
         xml:save()
         xml:delete()
@@ -188,6 +208,8 @@ function IncomeHUD:loadLayout()
         self.posX    = xml:getFloat("hudLayout.posX",   self.posX)
         self.posY    = xml:getFloat("hudLayout.posY",   self.posY)
         self.scale   = xml:getFloat("hudLayout.scale",  self.scale)
+        self.widthMult = math.max(IncomeHUD.MIN_WIDTH_MULT, math.min(IncomeHUD.MAX_WIDTH_MULT,
+            xml:getFloat("hudLayout.widthMult", self.widthMult or 1.0)))
         self.visible = xml:getBool("hudLayout.visible", self.visible)
         xml:delete()
     end
@@ -219,6 +241,16 @@ function IncomeHUD:hitTestCorner(posX, posY)
         and posY >= r.y and posY <= r.y + r.h then
             return key
         end
+    end
+    return nil
+end
+
+function IncomeHUD:hitTestEdge(posX, posY)
+    local band = IncomeHUD.EDGE_BAND_W
+    local bx, by, bw, bh = self.lastBgX, self.lastBgY, self.lastBgW, self.lastBgH
+    if posY >= by and posY <= by + bh then
+        if posX >= bx - band / 2 and posX <= bx + band / 2 then return "left" end
+        if posX >= bx + bw - band / 2 and posX <= bx + bw + band / 2 then return "right" end
     end
     return nil
 end
@@ -255,20 +287,31 @@ function IncomeHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
 
     if not self.editMode then return false end
 
-    -- LMB down: corner resize or body drag
+    -- LMB down: corner resize, edge width, or body drag
     if isDown and button == Input.MOUSE_BUTTON_LEFT then
         local corner = self:hitTestCorner(posX, posY)
         if corner then
             self.resizing         = true
             self.dragging         = false
+            self.edgeDragging     = nil
             self.resizeStartX     = posX
             self.resizeStartY     = posY
             self.resizeStartScale = self.scale
             return true
         end
+        local edge = self:hitTestEdge(posX, posY)
+        if edge then
+            self.edgeDragging       = edge
+            self.dragging           = false
+            self.resizing           = false
+            self.edgeDragStartX     = posX
+            self.edgeDragStartWidth = self.widthMult or 1.0
+            return true
+        end
         if self:isPointerOverHUD(posX, posY) then
             self.dragging    = true
             self.resizing    = false
+            self.edgeDragging = nil
             -- offset from panel text anchor
             self.dragOffsetX = posX - self.posX
             self.dragOffsetY = posY - self.posY
@@ -277,11 +320,12 @@ function IncomeHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
         return false
     end
 
-    -- LMB up: end drag/resize
+    -- LMB up: end drag/resize/edge
     if isUp and button == Input.MOUSE_BUTTON_LEFT then
-        if self.dragging or self.resizing then
-            self.dragging = false
-            self.resizing = false
+        if self.dragging or self.resizing or self.edgeDragging then
+            self.dragging     = false
+            self.resizing     = false
+            self.edgeDragging = nil
             self:clampPosition()
             return true
         end
@@ -310,8 +354,19 @@ function IncomeHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
         handled = true
     end
 
+    -- Edge width drag: dx scaled by EDGE_SENS, left edge inverted so pulling
+    -- outward always widens (NPCFavor/Workplace pattern).
+    if self.edgeDragging then
+        local dx = posX - self.edgeDragStartX
+        if self.edgeDragging == "left" then dx = -dx end
+        self.widthMult = math.max(IncomeHUD.MIN_WIDTH_MULT,
+            math.min(IncomeHUD.MAX_WIDTH_MULT, self.edgeDragStartWidth + dx * IncomeHUD.EDGE_SENS))
+        self:clampPosition()
+        handled = true
+    end
+
     -- Hover detection for corner handles
-    if not self.dragging and not self.resizing then
+    if not self.dragging and not self.resizing and not self.edgeDragging then
         self.hoverCorner = self:hitTestCorner(posX, posY)
         if self.hoverCorner then
             handled = true
@@ -382,9 +437,9 @@ function IncomeHUD:drawPanel()
     local s   = self.settings
     local sys = self.incomeSystem
 
-    -- Scaled layout values
+    -- Scaled layout values (width also carries the edge-drag multiplier)
     local x   = self.posX
-    local w   = self.panelWidth * sc
+    local w   = self.panelWidth * (self.widthMult or 1.0) * sc
     local pad = self.PAD * sc
     local lh  = self.LINE_H * sc
 
@@ -409,18 +464,18 @@ function IncomeHUD:drawPanel()
     self.lastBgW = bgW
     self.lastBgH = bgH
 
-    -- Drop shadow
-    self:rect(bgX + 0.002, bgY - 0.002, bgW, bgH, self.COLORS.SHADOW)
-
-    -- Background
-    self:rect(bgX, bgY, bgW, bgH, self.COLORS.BG)
-
-    -- Permanent border
-    local bw = 0.0012
-    self:rect(bgX,           bgY + bgH - bw, bgW, bw, self.COLORS.BORDER)
-    self:rect(bgX,           bgY,            bgW, bw, self.COLORS.BORDER)
-    self:rect(bgX,           bgY,            bw, bgH, self.COLORS.BORDER)
-    self:rect(bgX + bgW - bw, bgY,           bw, bgH, self.COLORS.BORDER)
+    local renderer = getBaseGameRenderer()
+    local usedNativePanel = renderer ~= nil and renderer.renderPanel ~= nil
+        and renderer:renderPanel(bgX, bgY, bgW, bgH, self.COLORS.BG[4])
+    if not usedNativePanel then
+        self:rect(bgX + 0.002, bgY - 0.002, bgW, bgH, self.COLORS.SHADOW)
+        self:rect(bgX, bgY, bgW, bgH, self.COLORS.BG)
+        local bw = 0.0012
+        self:rect(bgX,           bgY + bgH - bw, bgW, bw, self.COLORS.BORDER)
+        self:rect(bgX,           bgY,            bgW, bw, self.COLORS.BORDER)
+        self:rect(bgX,           bgY,            bw, bgH, self.COLORS.BORDER)
+        self:rect(bgX + bgW - bw, bgY,           bw, bgH, self.COLORS.BORDER)
+    end
 
     -- Edit mode chrome
     if self.editMode then
@@ -436,6 +491,14 @@ function IncomeHUD:drawPanel()
             local isHover = (self.hoverCorner == key)
             self:rectA(r.x, r.y, r.w, r.h, self.COLORS.EDIT_HANDLE, isHover and 1.0 or 0.65)
         end
+
+        -- Left/right edge width handles (suite width vocabulary)
+        local ehW   = 0.004
+        local inset = bgH * 0.15
+        self:rectA(bgX - ehW / 2,       bgY + inset, ehW, bgH - inset * 2,
+            self.COLORS.EDIT_HANDLE, self.edgeDragging == "left" and 1.0 or 0.65)
+        self:rectA(bgX + bgW - ehW / 2, bgY + inset, ehW, bgH - inset * 2,
+            self.COLORS.EDIT_HANDLE, self.edgeDragging == "right" and 1.0 or 0.65)
     end
 
     -- ── Content rows ──────────────────────────────────────
@@ -449,9 +512,7 @@ function IncomeHUD:drawPanel()
     setTextBold(true)
     setTextAlignment(RenderText.ALIGN_LEFT)
     setTextColor(self.COLORS.HEADER[1], self.COLORS.HEADER[2], self.COLORS.HEADER[3], self.COLORS.HEADER[4])
-    -- BUILD 18:47: TEMPORARY visible hot-reload needle (Wizard Ctrl+R proof with
-    -- Brian eyes-on). Revert the string and COLORS.HEADER when the proof is scored.
-    renderText(x, cy - tsTitle, tsTitle, "INCOME MOD *R4*")
+    renderText(x, cy - tsTitle, tsTitle, "INCOME MOD")
 
     local statusColor = s.enabled and self.COLORS.ENABLED or self.COLORS.DISABLED
     setTextAlignment(RenderText.ALIGN_RIGHT)
@@ -461,7 +522,7 @@ function IncomeHUD:drawPanel()
     cy = cy - lh
 
     -- Divider
-    self:divider(bgX, cy + lh * 0.35, bgW, sc)
+    self:divider(bgX, cy, bgW, sc)
     cy = cy - 0.004 * sc
 
     -- Mode | Difficulty | Amount
@@ -511,7 +572,7 @@ function IncomeHUD:drawPanel()
     cy = cy - lh
 
     -- Divider
-    self:divider(bgX, cy + lh * 0.35, bgW, sc)
+    self:divider(bgX, cy, bgW, sc)
     cy = cy - 0.004 * sc
 
     -- History header
@@ -549,7 +610,7 @@ function IncomeHUD:drawPanel()
     end
 
     -- Divider
-    self:divider(bgX, cy + lh * 0.35, bgW, sc)
+    self:divider(bgX, cy, bgW, sc)
     cy = cy - 0.004 * sc
 
     -- Hint row
@@ -601,8 +662,11 @@ function IncomeHUD:rectA(rx, ry, rw, rh, color, alpha)
     renderOverlay(self.bgOverlay, rx, ry, rw, rh)
 end
 
-function IncomeHUD:divider(dx, dy, dw, sc)
-    self:rect(dx, dy, dw, 0.001 * (sc or 1.0), self.COLORS.DIVIDER)
+function IncomeHUD:divider(dx, bandTopY, dw, sc)
+    local dividerH = g_pixelSizeY or (1 / 1080)
+    local bandH = 0.004 * (sc or 1.0)
+    self:rect(dx, bandTopY - (bandH + dividerH) * 0.5,
+        dw, dividerH, self.COLORS.DIVIDER)
 end
 
 -- =========================================================
@@ -625,11 +689,14 @@ if g_currentMission ~= nil and g_currentMission.incomeManager ~= nil
             inst[k] = v
         end
     end
-    -- BUILD 18:47 TEMPORARY (revert with the needle): COLORS is constructor-set
-    -- instance STATE, which method patching deliberately does not touch - so the
-    -- loud-green header needle must be pushed onto the live instance here, or the
-    -- Ctrl+R proof would show the *HOT* title (method-borne) without the color.
+    -- Constructor-owned state is not replaced by method patching. Reset the old
+    -- live-refresh proof colour so an already-running panel gets the finished
+    -- base-game white heading as well.
     if inst.COLORS ~= nil then
-        inst.COLORS.HEADER = {0.20, 1.00, 0.20, 1.00}
+        inst.COLORS.HEADER = {1.00, 1.00, 1.00, 1.00}
     end
+    -- Fields new in the width wave that a pre-wave live instance lacks.
+    if inst.widthMult == nil then inst.widthMult = 1.0 end
+    -- Delivery proof in log.txt (Wizard 2026-08-21).
+    print("[IncomeMod] IncomeHUD hot-patched onto live instance")
 end

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -22,9 +22,13 @@
             </ThreePartBitmap>
 
             <Bitmap profile="fs25_subCategoryContainer" id="rfFilterBox">
-                <MultiTextOption profile="fs25_subCategorySelector" id="rfPanelSelector"
-                                 disableButtonsOnSingleText="false"
-                                 onClick="onClickRfPanelSelector" focusInit="onOpen"/>
+                <!-- BUILD 18:16: rfPanelSelector moved to LAST child of rfFilterBox (see below).
+                     George TASK 18:12 asked for z-order ~10-20 on the selector; this engine has no
+                     z attribute of any kind (GuiElement loads none, and no rfHeaderBg element exists
+                     in this page) - draw AND input priority are declaration order, walked in reverse
+                     for events. Declaring the selector last IS the engine's z-raise: it now receives
+                     events before every sibling in this box and draws above them. Positions are
+                     profile-absolute, so nothing moves a pixel. -->
                 <BoxLayout profile="fs25_subCategorySelectorBox" id="rfPanelDotBox">
                     <RoundCorner profile="fs25_subCategorySelectorDot" id="rfPanelDotTemplate"/>
                 </BoxLayout>
@@ -60,6 +64,16 @@
                         <Slider profile="fs25_listSlider" dataElementId="moduleList" hideParentWhenEmpty="true"/>
                     </ThreePartBitmap>
                 </GuiElement>
+
+                <!-- BUILD 18:16 (George TASK 18:12): the module selector is deliberately the LAST
+                     child of rfFilterBox. Events walk children in reverse declaration order, so
+                     last-declared = first offered = this engine's only "z-order raise". Its band
+                     rect (profile-positioned, unchanged) does not overlap any sibling's visible
+                     paint, so drawing on top changes no pixel. The BUILD 17:08 page-level click
+                     shield stays as the guarantee against anything OUTSIDE this box. -->
+                <MultiTextOption profile="fs25_subCategorySelector" id="rfPanelSelector"
+                                 disableButtonsOnSingleText="false"
+                                 onClick="onClickRfPanelSelector" focusInit="onOpen"/>
             </Bitmap>
 
             <!-- WC page chrome: sibling under Modules (NOT inside rfFilterBox — hit hygiene).
@@ -222,29 +236,43 @@
                              built by whichever mod loads first, from its own copy, so a change
                              in Soil alone would be overwritten by whoever won the race. -->
                         <GuiElement profile="RF_EscCardFrame" id="treatProductsShell" position="220px -22px" size="620px 248px">
-                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -6px" size="600px 20px"
+                            <!-- BUILD 09:19 (PB-05). Brian read "Wait: amending now can burn t..." on
+                                 this strip: the sentence that says an apply will scorch the crop was
+                                 cut before its own verb.
+                                 The wrap was not broken. TextElement defaults to LAYOUT_MODE.TRUNCATE
+                                 (TextElement.lua:141) and with textMaxNumLines > 1 that takes the
+                                 limitVerticalLines path (:667-676), wrapping at absSize[1] and then
+                                 chopping characters until the text fits the line budget before adding
+                                 "..." (:679-699). So it wrapped to its two lines exactly as asked and
+                                 the string is simply longer than two lines of 18px across 600px.
+                                 Two allowed 18px lines become three. The 18px comes out of this zone
+                                 rather than out of the table: Selected moves up 2, the hairline and
+                                 the PRODUCTS heading close up, and the eight-row clip drops 4. Row 8
+                                 still ends 4px clear of the card frame (124 + 120 = 244 against 248),
+                                 so nothing is cut mid-glyph and the card does not grow. -->
+                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -4px" size="600px 20px"
                                   textAlignment="left"/>
-                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -26px" size="600px 36px"
-                                  textAlignment="left" textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <!-- Zone split (BUILD 16:19): Selected + Next stay on top, then ~16px of
-                                 air with one 1px hairline centred in it, then the PRODUCTS table.
+                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -24px" size="600px 54px"
+                                  textAlignment="left" textMaxNumLines="3" textVerticalAlignment="top"/>
+                            <!-- Zone split (BUILD 16:19): Selected + Next stay on top, then air with
+                                 one 1px hairline in it, then the PRODUCTS table.
                                  One outer outline only; the rule is a Bitmap, not a second frame.
                                  Bodies inset X 0 -> 10 and widths 560 -> 540 so nothing kisses the
                                  white stroke on either side. -->
-                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -70px" size="600px 1px"/>
-                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -80px" size="600px 18px"
+                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -82px" size="600px 1px"/>
+                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -86px" size="600px 18px"
                                   text="$l10n_rf_pda_treat_products"/>
-                            <Text profile="RF_ProductColHeaderDense" position="10px -100px" size="40px 16px" text="NUT"/>
-                            <Text profile="RF_ProductColHeaderDense" position="54px -100px" size="270px 16px" text="PRODUCT"/>
-                            <Text profile="RF_ProductColHeaderDense" position="330px -100px" size="100px 16px"
+                            <Text profile="RF_ProductColHeaderDense" position="10px -106px" size="40px 16px" text="NUT"/>
+                            <Text profile="RF_ProductColHeaderDense" position="54px -106px" size="270px 16px" text="PRODUCT"/>
+                            <Text profile="RF_ProductColHeaderDense" position="330px -106px" size="100px 16px"
                                   textAlignment="right" text="RATE"/>
-                            <Text profile="RF_ProductColHeaderDense" position="440px -100px" size="110px 16px"
+                            <Text profile="RF_ProductColHeaderDense" position="440px -106px" size="110px 16px"
                                   textAlignment="right" text="TOTAL"/>
-                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -120px" size="600px 22px"
+                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -124px" size="600px 22px"
                                   visible="false"/>
                             <!-- Clip sized to exactly the eight densified rows (8 x 15 = 120), so the
-                                 card bottom keeps 8px of air instead of cutting row 8 mid-glyph. -->
-                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -120px" size="600px 120px">
+                                 card bottom keeps air instead of cutting row 8 mid-glyph. -->
+                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -124px" size="600px 120px">
                                 <GuiElement profile="RF_ProductRow" id="treatProdRow1" position="0px 0px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd1Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd1Name" position="44px 0px" size="270px 15px"/>
@@ -312,20 +340,43 @@
                             <Text profile="RF_ProductCell" id="soilRotationStatus" position="10px -56px" size="270px 20px"/>
                             <Text profile="RF_ProductCell" id="soilRotationTip" position="10px -76px" size="270px 32px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Bitmap profile="RF_EscCardRule" id="soilRotationRule" position="10px -116px" size="270px 1px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationWhatIfHeader" position="10px -124px" size="270px 16px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationIfColCrop" position="10px -144px" size="92px 14px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationIfColStatus" position="106px -144px" size="60px 14px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationIfColEffect" position="170px -144px" size="110px 14px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf1Crop" position="10px -162px" size="92px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf1Status" position="106px -162px" size="60px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf1Effect" position="170px -162px" size="110px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf2Crop" position="10px -184px" size="92px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf2Status" position="106px -184px" size="60px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf2Effect" position="170px -184px" size="110px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf3Crop" position="10px -206px" size="92px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf3Status" position="106px -206px" size="60px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf3Effect" position="170px -206px" size="110px 18px"/>
+                            <!-- BUILD 09:19 (PB-05). The WHAT IF effect column lost whole consequences.
+                                 RotationPlannerData.effectText joins at most three items with ", " and
+                                 the set is closed: fatigue "x1.15 depletion", nitrogen "+N", and one of
+                                 "less disease" / "more disease". The worst real string is therefore
+                                 "x1.15 depletion, +N, less disease" at 33 characters, and the painter
+                                 capped the cell at 18 - so even the two-item "x1.15 depletion, +N" (19)
+                                 dropped an item and the player was told about the fatigue but not about
+                                 the disease.
+                                 18 was not arbitrary against the OLD cell: this card's own calibration
+                                 is ~6px per glyph at 17px (crop 92px/16, status 60px/10, effect 110px/18),
+                                 so 110px really does hold about 18. One 17px line cannot hold 33 and the
+                                 card cannot grow - George holds the footprint at 290x248 and it must
+                                 never take width back from PRODUCTS. So the effect cell gains a SECOND
+                                 line at 14px instead, which is the size the PRODUCTS table already uses
+                                 for its own cells (RF_ProductCellDense), and about 22 glyphs a line at
+                                 that size gives ~44 against a bounded worst case of 33.
+                                 Row pitch 22 -> 30 to hold the taller cell; the hairline and the two
+                                 header lines close up by 4-8px to pay for it. Row 3 ends at 240 against
+                                 the 248 frame, so the card keeps its 8px of bottom air. Crop and Status
+                                 stay one 17px line and are unchanged. -->
+                            <Bitmap profile="RF_EscCardRule" id="soilRotationRule" position="10px -112px" size="270px 1px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationWhatIfHeader" position="10px -118px" size="270px 16px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColCrop" position="10px -136px" size="92px 14px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColStatus" position="106px -136px" size="60px 14px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColEffect" position="170px -136px" size="110px 14px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf1Crop" position="10px -152px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf1Status" position="106px -152px" size="60px 18px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilRotationIf1Effect" position="170px -152px" size="110px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf2Crop" position="10px -182px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf2Status" position="106px -182px" size="60px 18px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilRotationIf2Effect" position="170px -182px" size="110px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf3Crop" position="10px -212px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf3Status" position="106px -212px" size="60px 18px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilRotationIf3Effect" position="170px -212px" size="110px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
                         </GuiElement>
 
                         <!-- Col 3: sampling — shifted right so widened PRODUCTS does not overlap -->
@@ -526,6 +577,19 @@
                             <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="610px -264px" size="220px 20px" text=""/>
                             <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="850px -264px" size="280px 20px" text=""/>
                             <Text profile="RF_TreatTargetLine" id="rfFwMore" position="10px -300px" size="1120px 20px" text=""/>
+                            <!-- BUILD 09:19 (PB-07): row pager for this static eight-row table.
+                                 Hidden by default and shown ONLY by a guest that implements
+                                 onPageStep, so Income / Dairy / Depot keep exactly the page they
+                                 have today. Two Buttons, not a SmoothList: George's standing NO-GO
+                                 on nesting a SmoothList in this page (see csConsultPanel below)
+                                 applies here too, and a window offset held by the guest cannot
+                                 re-enter the layout the way a list rebuild can.
+                                 Parked on the rfFwTableTitle band, which every Table-mode guest
+                                 already hides, so the pager collides with nothing that paints. -->
+                            <Button profile="buttonActivate" id="rfFwPagePrev" position="880px -8px" size="120px 24px"
+                                    visible="false" text="" onClick="onClickRfFwPagePrev"/>
+                            <Button profile="buttonActivate" id="rfFwPageNext" position="1010px -8px" size="120px 24px"
+                                    visible="false" text="" onClick="onClickRfFwPageNext"/>
                             <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
                             <Text profile="RF_HintText" id="rfFwHintTable" position="10px -336px" size="1120px 80px"

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <GUIProfiles>
     <!-- ============================================================ -->
     <!-- Realistic Farming PDA profiles — MOCKUP-ESC-RF-PDA swatches  -->
@@ -260,6 +260,16 @@
     </Profile>
     <Profile name="RF_ProductCellRight" extends="RF_ProductCell">
         <textAlignment value="right"/>
+    </Profile>
+    <!-- BUILD 09:19 (PB-05): WHAT IF effect cell only. Two lines at the same 14px the
+         PRODUCTS table already uses for its own cells, so a comma-joined consequence is
+         printed whole instead of losing its last item to a one-line 110px column. Top
+         aligned because a two-line cell that centres would not line up with the one-line
+         Crop and Status cells beside it. -->
+    <Profile name="RF_ProductCellEffect" extends="RF_ProductCell">
+        <textSize value="14px"/>
+        <textMaxNumLines value="2"/>
+        <textVerticalAlignment value="top"/>
     </Profile>
     <Profile name="RF_ProductOk" extends="fs25_textDefault" with="anchorTopLeft">
         <textSize value="18px"/>


### PR DESCRIPTION
## Summary
- Upgrades Income HUD to native base-game extension styling.
- Integrates full corner scale and left/right edge width resizing.
- Sets factory layout default to (0.213, 0.979, scale 1.083, widthMult 0.759).
- Supports MasterHUD global toggle and edit mode.

## Test plan
- Verified in-game: Clean rendering without palette leaks, dragging and resizing functional, persistence intact.