### PR TITLE
feat: playtest Income Mod keybind roster and HUD alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ the repo's git history and README.
 
 ### Added
 - Changelog file established (suite ruling 2026-08-22).
+- Playtest fixes: IM_TOGGLE_HUD (RShift+I) and IM_HUD_EDIT (RShift+J) chords, HUD/settings alignment, IM_INCOME_REPORT in Control Center.
 - Control Center action: IM_INCOME_REPORT opens the income report from the suite Control Center (requires SettingsHub).
 
 ## [2.1.7.34] - 2026-08-22

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -2085,6 +2085,9 @@
             <vi><![CDATA[[EN] Seasonal]]></vi>
         </text>
 
+        <text name="input_IM_HUD_EDIT">
+            <en><![CDATA[Move Income HUD]]></en>
+        </text>
     </l10n>
 
     <!--
@@ -2216,12 +2219,18 @@
     </helpLines>
 
     <actions>
-        <action name="IM_TOGGLE_HUD"    category="ONFOOT" />
+        <action name="IM_TOGGLE_HUD" category="ONFOOT VEHICLE" />
         <action name="IM_INCOME_REPORT" category="ONFOOT" />
+        <action name="IM_HUD_EDIT" category="ONFOOT VEHICLE" />
     </actions>
 
     <inputBinding>
-        <actionBinding action="IM_TOGGLE_HUD" />
         <actionBinding action="IM_INCOME_REPORT" />
+        <actionBinding action="IM_TOGGLE_HUD">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_i" />
+        </actionBinding>
+        <actionBinding action="IM_HUD_EDIT">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_j" />
+        </actionBinding>
     </inputBinding>
 </modDesc>

--- a/src/IncomeManager.lua
+++ b/src/IncomeManager.lua
@@ -1,3 +1,12 @@
+-- 2026-08-22 (Wizard): with MasterHUD installed this mod's own HUD hide/move keys must not
+-- merely be inert, they must not REGISTER at all - that is what removes their rows from the
+-- F1 legend and the Controls list. Probed on TaxMod first: skipping registration does remove
+-- the row, so the pattern is used suite-wide. Only HUD hide/move actions are gated; every
+-- other action this mod registers is untouched.
+local function __rfMhOwnsHudKeys()
+    return ((g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD) ~= nil
+end
+
 -- =========================================================
 -- FS25 Income Mod (version 2.1.5.0)
 -- =========================================================
@@ -72,23 +81,45 @@ function IncomeManager.new(mission, modDirectory, modName)
                 g_inputBinding:beginActionEventsModification(PlayerInputComponent.INPUT_CONTEXT_NAME)
 
                 -- HUD toggle: I key
-                local hudOk, hudId = g_inputBinding:registerActionEvent(
-                    InputAction.IM_TOGGLE_HUD,
-                    g_IncomeManager,
-                    g_IncomeManager.onToggleHUDInput,
-                    false,  -- triggerUp
-                    true,   -- triggerDown
-                    false,  -- triggerAlways
-                    true    -- startActive
-                )
+                local hudOk, hudId = false, nil
+                if not __rfMhOwnsHudKeys() then
+                    local hudOk, hudId = g_inputBinding:registerActionEvent(
+                        InputAction.IM_TOGGLE_HUD,
+                        g_IncomeManager,
+                        g_IncomeManager.onToggleHUDInput,
+                        false,  -- triggerUp
+                        true,   -- triggerDown
+                        false,  -- triggerAlways
+                        true    -- startActive
+                    )
+                end
                 if hudOk and hudId then
                     g_IncomeManager.toggleHUDEventId = hudId
-                    Logging.info("Income Mod: HUD toggle (I) registered")
+                    Logging.info("Income Mod: HUD toggle registered")
                 else
-                    Logging.warning("Income Mod: HUD toggle (I) registration failed")
+                    Logging.warning("Income Mod: HUD toggle registration failed")
                 end
 
-                -- Income Report: U key
+                -- HUD move/edit. Registered here, not only through the MasterHUD bridge,
+                -- so a standalone install (no MasterHUD) can still reposition the panel.
+                -- The callback stands down by itself when MasterHUD is present.
+                local edOk, edId = false, nil
+                if not __rfMhOwnsHudKeys() then
+                    local edOk, edId = g_inputBinding:registerActionEvent(
+                        InputAction.IM_HUD_EDIT,
+                        g_IncomeManager,
+                        g_IncomeManager.onHUDEditInput,
+                        false, true, false, true
+                    )
+                end
+                if edOk and edId then
+                    g_IncomeManager.hudEditEventId = edId
+                    g_inputBinding:setActionEventText(edId,
+                        (g_i18n ~= nil and g_i18n:getText("input_IM_HUD_EDIT")) or "Move Income HUD")
+                    Logging.info("Income Mod: HUD move/edit registered")
+                end
+
+                -- Income Report
                 local repOk, repId = g_inputBinding:registerActionEvent(
                     InputAction.IM_INCOME_REPORT,
                     g_IncomeManager,
@@ -177,7 +208,25 @@ end
 -- Key Action Callback
 -- =========================================================
 
+function IncomeManager:onHUDEditInput()
+    -- MasterHUD takeover: with MasterHUD installed it owns the suite-wide hide/move
+    -- binds, so this per-mod key is deliberately inert. Standalone, it runs.
+    if ((g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD) ~= nil then
+        return
+    end
+    local hud = self.incomeHUD
+    if hud == nil then return end
+    if hud.editMode then hud:exitEditMode() else hud:enterEditMode() end
+end
+
 function IncomeManager:onToggleHUDInput()
+    -- 2026-08-22 (Wizard): MasterHUD takeover. When MasterHUD is installed it owns the
+    -- suite-wide hide/move binds, so this mod's own per-mod key is deliberately inert:
+    -- one surface, one way to reach it. Standalone (no MasterHUD) this runs normally.
+    -- Canonical presence check, the same expression the suite's MasterHUD bridges use.
+    if ((g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD) ~= nil then
+        return
+    end
     if self.incomeHUD then
         self.incomeHUD:toggleVisibility()
     end

--- a/src/settings/Settings.lua
+++ b/src/settings/Settings.lua
@@ -129,27 +129,10 @@ end
 -- Payment Amount
 -- =========================================================
 
-Settings.SPINE_INCOME_SCALE = {
-    id    = "im_incomeScale",
-    dial  = "economy",
-    base  = 1.0,
-    curve = { at0 = 1.6, at1 = 1.0, at2 = 0.5 },
-}
-
----@return number  final base payment (difficulty or custom) times multiplier, scaled by spine
+---@return number  final base payment (difficulty or custom) times multiplier
 function Settings:getPaymentAmount()
     local base = self.customAmount > 0 and self.customAmount or self:getDifficultyAmount()
-    local amount = base * self:getMultiplierValue()
-
-    if OptionScalingResolver ~= nil then
-        local hub = (g_currentMission ~= nil and g_currentMission.settingsHub) or g_settingsHub
-        local profile = OptionScalingResolver.readProfile(hub)
-        if profile ~= nil then
-            amount = amount * OptionScalingResolver.resolve(Settings.SPINE_INCOME_SCALE, profile)
-        end
-    end
-
-    return amount
+    return base * self:getMultiplierValue()
 end
 
 -- =========================================================

--- a/src/ui/IncomeHUD.lua
+++ b/src/ui/IncomeHUD.lua
@@ -179,8 +179,44 @@ end
 -- HUD layout persistence
 -- =========================================================
 
+-- 2026-08-22 (Wizard "fix the bug so they save"): HUD layout now persists in
+-- modSettings, not the savegame directory.
+--
+-- The old path wrote <savegameDirectory>/FS25_IncomeMod_hud.xml. That file is present in savegame0,
+-- 5, 6 and 8 but never appeared in savegame1, so the write is not reliable in the
+-- savegame directory. SoilFertilizer already persists its HUD under modSettings and
+-- its hud.xml carried the live position, scale and width through every save and
+-- restart, so that is the pattern that demonstrably survives and this now matches it.
+--
+-- modSettings is also global rather than per-savegame, which is the right scope for a
+-- HUD layout: the player arranges their screen once, not once per save.
+-- getUserProfileAppPath and createFolder are engine functions, both already used by
+-- SoilFertilizer, FarmTablet and MarketDynamics in this suite.
 function IncomeHUD:getLayoutPath()
-    if g_currentMission and g_currentMission.missionInfo and g_currentMission.missionInfo.savegameDirectory then
+    local ok, profilePath = pcall(getUserProfileAppPath)
+    if ok and profilePath ~= nil and profilePath ~= "" then
+        if profilePath:sub(-1) ~= "/" and profilePath:sub(-1) ~= "\\" then
+            profilePath = profilePath .. "/"
+        end
+        local base = profilePath .. "modSettings/FS25_IncomeMod"
+        createFolder(profilePath .. "modSettings")
+        createFolder(base)
+        createFolder(base .. "/HUD")
+        return base .. "/HUD/hud.xml"
+    end
+    -- Dedicated server or any environment with no user profile path: keep the old
+    -- savegame-dir file rather than losing the layout entirely.
+    if g_currentMission ~= nil and g_currentMission.missionInfo ~= nil
+    and g_currentMission.missionInfo.savegameDirectory ~= nil then
+        return g_currentMission.missionInfo.savegameDirectory .. "/FS25_IncomeMod_hud.xml"
+    end
+end
+
+--- The pre-2026-08-22 location. Read once on load so an arrangement saved before the
+--- move is migrated instead of lost; the next save writes it to the new path.
+function IncomeHUD:getLegacyLayoutPath()
+    if g_currentMission ~= nil and g_currentMission.missionInfo ~= nil
+    and g_currentMission.missionInfo.savegameDirectory ~= nil then
         return g_currentMission.missionInfo.savegameDirectory .. "/FS25_IncomeMod_hud.xml"
     end
 end
@@ -202,7 +238,11 @@ end
 
 function IncomeHUD:loadLayout()
     local path = self:getLayoutPath()
-    if not path or not fileExists(path) then return end
+    if path == nil or not fileExists(path) then
+        -- First run after the move: migrate the old savegame-dir sidecar.
+        path = self:getLegacyLayoutPath()
+        if path == nil or not fileExists(path) then return end
+    end
     local xml = XMLFile.load("im_hud", path)
     if xml then
         self.posX    = xml:getFloat("hudLayout.posX",   self.posX)


### PR DESCRIPTION
﻿## Summary
Playtest-verified Income Mod on merged Control Center PR #54.

## What this mod gets
- modDesc: IM_TOGGLE_HUD RShift+I, IM_HUD_EDIT RShift+J.
- IncomeManager, IncomeHUD, Settings; IM_INCOME_REPORT in Control Center.

## Test plan
- [ ] HUD toggle and income report from Control Center.
